### PR TITLE
Convert the BUILD stamp to AC_ARG_WITH argument

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,6 @@
 
 AC_PREREQ([2.56])
 AC_INIT([libjpeg-turbo], [1.4.80])
-BUILD=`date +%Y%m%d`
 
 AM_INIT_AUTOMAKE([-Wall foreign dist-bzip2])
 AC_PREFIX_DEFAULT(/opt/libjpeg-turbo)
@@ -21,6 +20,10 @@ AM_PROG_CC_C_O
 AC_PROG_INSTALL
 AC_PROG_LIBTOOL
 AC_PROG_LN_S
+
+AC_ARG_WITH([build-date], [Use custom build string to enable reproducible builds (default: YYMMDD)],
+  [BUILD="$with_build_date"],
+  [BUILD=`date +%Y%m%d`])
 
 # When the prefix is /opt/libjpeg-turbo, we assume that an "official" binary is
 # being created, and thus we install things into specific locations.


### PR DESCRIPTION
Debian is working on reproducible builds and embedding current date doesn't work really well. Instead of patching the code only in Debian, I propose following patch that will make the BUILD stamp as an --with argument, so it can be changed by calling the configure --with-build-date=<string>. The default is %Y%m%d as before.