### PR TITLE
Check image size when reading targa file

### DIFF
--- a/rdtarga.c
+++ b/rdtarga.c
@@ -364,7 +364,8 @@ start_input_tga (j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
   if (cmaptype > 1 ||           /* cmaptype must be 0 or 1 */
       source->pixel_size < 1 || source->pixel_size > 4 ||
       (UCH(targaheader[16]) & 7) != 0 || /* bits/pixel must be multiple of 8 */
-      interlace_type != 0)      /* currently don't allow interlaced image */
+      interlace_type != 0 ||      /* currently don't allow interlaced image */
+      width == 0 || height == 0)  /* image width/height must be nonzero */
     ERREXIT(cinfo, JERR_TGA_BADPARMS);
 
   if (subtype > 8) {


### PR DESCRIPTION
Throw an error when image width or height is 0 when reading a targa file

Picked from https://github.com/mozilla/mozjpeg/issues/140