### PR TITLE
Make sure BMP height and width don't exceed positive signed 32-bit

### DIFF
--- a/rdbmp.c
+++ b/rdbmp.c
@@ -381,7 +381,7 @@ start_input_bmp (j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
     return;
   }
 
-  if (biWidth <= 0 || biHeight <= 0)
+  if (biWidth <= 0 || biHeight <= 0 || biWidth > 0x7fffffffL || biHeight > 0x7fffffffL)
     ERREXIT(cinfo, JERR_BMP_EMPTY);
   if (biPlanes != 1)
     ERREXIT(cinfo, JERR_BMP_BADPLANES);


### PR DESCRIPTION
Make sure BMP height and width don't exceed positive signed 32-bit range even when 64-bit variables are being used.

https://github.com/mozilla/mozjpeg/issues/153