### PR TITLE
Declare inbuffer const

### DIFF
--- a/jdatasrc.c
+++ b/jdatasrc.c
@@ -254,7 +254,7 @@ jpeg_stdio_src (j_decompress_ptr cinfo, FILE * infile)
 
 GLOBAL(void)
 jpeg_mem_src (j_decompress_ptr cinfo,
-              unsigned char * inbuffer, unsigned long insize)
+              const unsigned char * inbuffer, unsigned long insize)
 {
   struct jpeg_source_mgr * src;
 
@@ -278,6 +278,6 @@ jpeg_mem_src (j_decompress_ptr cinfo,
   src->resync_to_restart = jpeg_resync_to_restart; /* use default method */
   src->term_source = term_source;
   src->bytes_in_buffer = (size_t) insize;
-  src->next_input_byte = (JOCTET *) inbuffer;
+  src->next_input_byte = (const JOCTET *) inbuffer;
 }
 #endif

--- a/jpeglib.h
+++ b/jpeglib.h
@@ -919,7 +919,8 @@ EXTERN(void) jpeg_stdio_src (j_decompress_ptr cinfo, FILE * infile);
 /* Data source and destination managers: memory buffers. */
 EXTERN(void) jpeg_mem_dest (j_compress_ptr cinfo, unsigned char ** outbuffer,
                             unsigned long * outsize);
-EXTERN(void) jpeg_mem_src (j_decompress_ptr cinfo, unsigned char * inbuffer,
+EXTERN(void) jpeg_mem_src (j_decompress_ptr cinfo,
+                           const unsigned char * inbuffer,
                            unsigned long insize);
 #endif
 


### PR DESCRIPTION
`inbuffer` is never modified. `const` in function declaration allows callers to also use read-only buffers (this helps when libjpeg-turbo is used from the Rust language which is very strict about immutability).

It's backwards compatible, since C allows passing non-const types to const arguments.