### PR TITLE
Give correct state in empty output buffer callback.

### DIFF
--- a/jchuff.c
+++ b/jchuff.c
@@ -317,6 +317,9 @@ dump_buffer (working_state * state)
 {
   struct jpeg_destination_mgr * dest = state->cinfo->dest;
 
+  /* Need to make sure state is propagated back */
+  dest->next_output_byte = state->next_output_byte;
+  dest->free_in_buffer = state->free_in_buffer;
   if (! (*dest->empty_output_buffer) (state->cinfo))
     return FALSE;
   /* After a successful buffer dump, must reset buffer pointers */


### PR DESCRIPTION
Previously the caller would get an incorrect state when empty_output_buffer() is called, resulting in dropped data. TigerVNC/tigervnc#218 is the result of this bug.