### PR TITLE
Enabling with hand turned AVX2 SIMD extensions 

### DIFF
--- a/jdcoefct.h
+++ b/jdcoefct.h
@@ -5,6 +5,7 @@
  * Copyright (C) 1994-1997, Thomas G. Lane.
  * libjpeg-turbo Modifications:
  * Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+ * Copyright 2015, Intel Corporation
  * For conditions of distribution and use, see the accompanying README file.
  */
 
@@ -38,7 +39,7 @@ typedef struct {
    * In multi-pass modes, this array points to the current MCU's blocks
    * within the virtual arrays; it is used only by the input side.
    */
-  JBLOCKROW MCU_buffer[D_MAX_BLOCKS_IN_MCU];
+  JBLOCKROW MCU_buffer[2*D_MAX_BLOCKS_IN_MCU];
 
   /* Temporary workspace for one MCU */
   JCOEF * workspace;
@@ -53,6 +54,9 @@ typedef struct {
   int * coef_bits_latch;
 #define SAVED_COEFS  6          /* we save coef_bits[0..5] */
 #endif
+
+	JBLOCKROW SIMD256_comp_buffer[MAX_COMPS_IN_SCAN][2][2]; /* [Col0-1][height0-1] */
+	JBLOCKROW SIMD256_buffer[2][D_MAX_BLOCKS_IN_MCU];
 } my_coef_controller;
 
 typedef my_coef_controller * my_coef_ptr;

--- a/jdmaster.c
+++ b/jdmaster.c
@@ -7,6 +7,7 @@
  * libjpeg-turbo Modifications:
  * Copyright (C) 2009-2011, D. R. Commander.
  * Copyright (C) 2013, Linaro Limited.
+ * Copyright (C) 2015, Intel Corporation.
  * For conditions of distribution and use, see the accompanying README file.
  *
  * This file contains master control logic for the JPEG decompressor.
@@ -86,6 +87,7 @@ use_merged_upsample (j_decompress_ptr cinfo)
       cinfo->comp_info[2]._DCT_scaled_size != cinfo->_min_DCT_scaled_size)
     return FALSE;
   /* ??? also need to test for upsample-time rescaling, when & if supported */
+  printf("using merged upsampling\n");
   return TRUE;                  /* by golly, it'll work... */
 #else
   return FALSE;

--- a/jdmaster.c
+++ b/jdmaster.c
@@ -7,7 +7,6 @@
  * libjpeg-turbo Modifications:
  * Copyright (C) 2009-2011, D. R. Commander.
  * Copyright (C) 2013, Linaro Limited.
- * Copyright (C) 2015, Intel Corporation.
  * For conditions of distribution and use, see the accompanying README file.
  *
  * This file contains master control logic for the JPEG decompressor.
@@ -87,7 +86,6 @@ use_merged_upsample (j_decompress_ptr cinfo)
       cinfo->comp_info[2]._DCT_scaled_size != cinfo->_min_DCT_scaled_size)
     return FALSE;
   /* ??? also need to test for upsample-time rescaling, when & if supported */
-  printf("using merged upsampling\n");
   return TRUE;                  /* by golly, it'll work... */
 #else
   return FALSE;

--- a/jmemmgr.c
+++ b/jmemmgr.c
@@ -85,7 +85,7 @@ round_up_pow2 (size_t a, size_t b)
 #ifndef WITH_SIMD
 #define ALIGN_SIZE  sizeof(double)
 #else
-#define ALIGN_SIZE  32 /* Most SIMD implementations require this */
+#define ALIGN_SIZE  32 /* AVX2 requires alignment of 256bit (32 bytes) */
 #endif
 #endif
 

--- a/jmemmgr.c
+++ b/jmemmgr.c
@@ -3,6 +3,7 @@
  *
  * This file was part of the Independent JPEG Group's software:
  * Copyright (C) 1991-1997, Thomas G. Lane.
+ * Copyright (C) 2015, Intel Corporation.
  * It was modified by The libjpeg-turbo Project to include only code and
  * information relevant to libjpeg-turbo.
  * For conditions of distribution and use, see the accompanying README file.
@@ -84,7 +85,7 @@ round_up_pow2 (size_t a, size_t b)
 #ifndef WITH_SIMD
 #define ALIGN_SIZE  sizeof(double)
 #else
-#define ALIGN_SIZE  16 /* Most SIMD implementations require this */
+#define ALIGN_SIZE  32 /* Most SIMD implementations require this */
 #endif
 #endif
 

--- a/jpeglib.h
+++ b/jpeglib.h
@@ -7,6 +7,7 @@
  * libjpeg-turbo Modifications:
  * Copyright (C) 2009-2011, 2013-2014, D. R. Commander.
  * Copyright (C) 2015, Google, Inc.
+ * Copyright (C) 2015, Intel Corporation.
  * For conditions of distribution and use, see the accompanying README file.
  *
  * This file defines the application interface for the JPEG library.
@@ -1108,6 +1109,16 @@ struct jpeg_color_quantizer { long dummy; };
 #include "jpegint.h"            /* fetch private declarations */
 #include "jerror.h"             /* fetch error codes too */
 #endif
+
+/*
+ * Defined for AVX2,AVX3,AVX3.1 SIMD 
+ */
+typedef enum {
+  JSIMD_LEN_LESS_256,        /* SIMD register length less then 256  */
+  JSIMD_LEN_256,             /* 256 bit SIMD regiter length, fg AVX/AVX2    */
+  JSIMD_LEN_512,             /* 512 bit SIMD regiter length, fg AVX3      */
+  JSIMD_LEN_1024,            /* 1024 bit SIMD regiter length, fg AVX3.1   */
+} JSIMD_REGISTER_LEN;
 
 #ifdef __cplusplus
 #ifndef DONT_USE_EXTERN_C

--- a/jsimddct.h
+++ b/jsimddct.h
@@ -5,6 +5,7 @@
  *
  * Based on the x86 SIMD extension for IJG JPEG library,
  * Copyright (C) 1999-2006, MIYASAKA Masaru.
+ * Copyright (C) 2015, Intel Corporation.
  * For conditions of distribution and use, see copyright notice in jsimdext.inc
  *
  */
@@ -25,6 +26,19 @@ EXTERN(int) jsimd_can_fdct_float (void);
 EXTERN(void) jsimd_fdct_islow (DCTELEM * data);
 EXTERN(void) jsimd_fdct_ifast (DCTELEM * data);
 EXTERN(void) jsimd_fdct_float (FAST_FLOAT * data);
+
+EXTERN(void) jsimd_fdct_merged_islow (JSAMPARRAY data,  
+                                      JDIMENSION start_col,
+                                      JCOEFPTR coef_block,
+                                      DCTELEM * divisors);
+EXTERN(void) jsimd_fdct_merged_ifast (JSAMPARRAY data,  
+                                     JDIMENSION start_col,
+                                     JCOEFPTR coef_block,
+                                     DCTELEM * divisors);
+EXTERN(void) jsimd_fdct_merged_float (JSAMPARRAY sample_data,
+                                      JDIMENSION start_col,
+                                      JCOEFPTR coef_block, 
+                                      FAST_FLOAT * divisors);
 
 EXTERN(int) jsimd_can_quantize (void);
 EXTERN(int) jsimd_can_quantize_float (void);
@@ -69,6 +83,15 @@ EXTERN(void) jsimd_idct_ifast (j_decompress_ptr cinfo,
                                JCOEFPTR coef_block, JSAMPARRAY output_buf,
                                JDIMENSION output_col);
 EXTERN(void) jsimd_idct_float (j_decompress_ptr cinfo,
+                               jpeg_component_info * compptr,
+                               JCOEFPTR coef_block, JSAMPARRAY output_buf,
+                               JDIMENSION output_col);
+
+EXTERN(void) jsimd_simd256_idct_islow (j_decompress_ptr cinfo,
+                               jpeg_component_info * compptr,
+                               JCOEFPTR coef_block, JSAMPARRAY output_buf,
+                               JDIMENSION c1);
+EXTERN(void) jsimd_simd256_idct_ifast (j_decompress_ptr cinfo,
                                jpeg_component_info * compptr,
                                JCOEFPTR coef_block, JSAMPARRAY output_buf,
                                JDIMENSION output_col);

--- a/simd/Makefile.am
+++ b/simd/Makefile.am
@@ -12,18 +12,27 @@ EXTRA_DIST = nasm_lt.sh CMakeLists.txt \
 if SIMD_X86_64
 
 libsimd_la_SOURCES = jsimd_x86_64.c jsimd.h jsimdcfg.inc.h jsimdext.inc \
-	jcolsamp.inc jdct.inc jfdctflt-sse-64.asm \
+	jcolsamp.inc jdct.inc jfdctflt-sse-64.asm jsimdcpu.asm \
 	jccolor-sse2-64.asm   jcgray-sse2-64.asm    jcsample-sse2-64.asm \
 	jdcolor-sse2-64.asm   jdmerge-sse2-64.asm   jdsample-sse2-64.asm \
 	jfdctfst-sse2-64.asm  jfdctint-sse2-64.asm  jidctflt-sse2-64.asm \
-	jidctfst-sse2-64.asm  jidctint-sse2-64.asm  jidctred-sse2-64.asm  \
-	jquantf-sse2-64.asm   jquanti-sse2-64.asm
+	jidctfst-sse2-64.asm  jidctint-sse2-64.asm  jidctred-sse2-64.asm \
+	jquantf-sse2-64.asm   jquanti-sse2-64.asm \
+	jdmerge-avx2-64.asm   jdsample-avx2-64.asm  jcsample-avx2-64.asm \
+	jfdctmflt-avx2-64.asm	jfdctmfst-avx2-64.asm jfdctmint-avx2-64.asm \
+	jidctflt-avx2-64.asm	jidctint-avx2-64.asm 	jidctfst-avx2-64.asm \
+	jccolor-avx2-64.asm		jdcolor-avx2-64.asm		jcgray-avx2-64.asm	 \
+	jquantf-avx2-64.asm 	jfdctflt-avx2-64.asm
 
 jccolor-sse2-64.lo:  jccolext-sse2-64.asm
 jcgray-sse2-64.lo:   jcgryext-sse2-64.asm
 jdcolor-sse2-64.lo:  jdcolext-sse2-64.asm
 jdmerge-sse2-64.lo:  jdmrgext-sse2-64.asm
 
+jccolor-avx2-64.lo:  jccolext-avx2-64.asm
+jcgray-avx2-64.lo:   jcgryext-avx2-64.asm
+jdcolor-avx2-64.lo:  jdcolext-avx2-64.asm
+jdmerge-avx2-64.lo:  jdmrgext-avx2-64.asm
 endif
 
 if SIMD_I386

--- a/simd/jccolext-avx2-64.asm
+++ b/simd/jccolext-avx2-64.asm
@@ -382,7 +382,7 @@ EXTN(jsimd_rgb_ycc_convert_avx2):
 
         vpsllw     ymm7,ymm7,BYTE_BIT
         vpor       ymm5,ymm5,ymm7             ; ymm5=Cb
-        vmovdqa    YMMWORD [rbx], ymm5   ; Save Cb
+        vmovdqu    YMMWORD [rbx], ymm5   ; Save Cb
 
         vmovdqa    ymm0, YMMWORD [wk(3)] ; ymm0=BO
         vmovdqa    ymm6, YMMWORD [wk(2)] ; ymm6=BE
@@ -449,7 +449,7 @@ EXTN(jsimd_rgb_ycc_convert_avx2):
 
         vpsllw     ymm0,ymm0,BYTE_BIT
         vpor       ymm6,ymm6,ymm0             ; ymm6=Y
-        vmovdqa    YMMWORD [rdi], ymm6   ; Save Y
+        vmovdqu    YMMWORD [rdi], ymm6   ; Save Y
 
         vpxor      ymm2,ymm2,ymm2
         vpxor      ymm4,ymm4,ymm4
@@ -470,7 +470,7 @@ EXTN(jsimd_rgb_ycc_convert_avx2):
 
         vpsllw     ymm7,ymm7,BYTE_BIT
         vpor       ymm1,ymm1,ymm7             ; ymm1=Cr
-        vmovdqa    YMMWORD [rdx], ymm1   ; Save Cr
+        vmovdqu    YMMWORD [rdx], ymm1   ; Save Cr
 
 .done:
         sub     rcx, byte SIZEOF_YMMWORD

--- a/simd/jccolext-avx2-64.asm
+++ b/simd/jccolext-avx2-64.asm
@@ -1,0 +1,509 @@
+;
+; jccolext.asm - colorspace conversion (64-bit AVX2)
+;
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; Copyright (C) 2009, D. R. Commander.
+; Copyright (C) 2015, Intel Corporation.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; [TAB8]
+
+
+%include "jcolsamp.inc"
+
+; --------------------------------------------------------------------------
+;
+; Convert some rows of samples to the output colorspace.
+;
+; GLOBAL(void)
+; jsimd_rgb_ycc_convert_avx2 (JDIMENSION img_width,
+;                             JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+;                             JDIMENSION output_row, int num_rows);
+;
+
+; r10 = JDIMENSION img_width
+; r11 = JSAMPARRAY input_buf
+; r12 = JSAMPIMAGE output_buf
+; r13 = JDIMENSION output_row
+; r14 = int num_rows
+
+;%define wk(i)           rbp-(WK_NUM-(i))*SIZEOF_XMMWORD ; xmmword wk[WK_NUM]
+; i = 0 -> rbp - 8*32
+; i = 1 -> rbp - 7*32
+
+%define wk(i)           rbp-(WK_NUM-(i))*SIZEOF_YMMWORD ; ymmword wk[WK_NUM]
+%define WK_NUM          8
+        align   32
+
+        global  EXTN(jsimd_rgb_ycc_convert_avx2)
+
+EXTN(jsimd_rgb_ycc_convert_avx2):
+        push    rbp
+        mov     rax,rsp                         ; rax = original rbp
+        sub     rsp, byte 4
+        and     rsp, byte (-SIZEOF_YMMWORD)     ; align to 256 bits
+        mov     [rsp],rax
+        mov     rbp,rsp                         ; rbp = aligned rbp
+        lea     rsp, [wk(0)]
+        collect_args
+        push    rbx
+
+        mov     rcx, r10
+        test    rcx,rcx
+        jz      near .return
+
+        push    rcx
+
+        mov rsi, r12
+        mov rcx, r13
+        mov     rdi, JSAMPARRAY [rsi+0*SIZEOF_JSAMPARRAY]
+        mov     rbx, JSAMPARRAY [rsi+1*SIZEOF_JSAMPARRAY]
+        mov     rdx, JSAMPARRAY [rsi+2*SIZEOF_JSAMPARRAY]
+        lea     rdi, [rdi+rcx*SIZEOF_JSAMPROW]
+        lea     rbx, [rbx+rcx*SIZEOF_JSAMPROW]
+        lea     rdx, [rdx+rcx*SIZEOF_JSAMPROW]
+
+        pop     rcx
+
+        mov rsi, r11
+        mov     eax, r14d ;num_rows
+        test    rax,rax
+        jle     near .return
+.rowloop:
+        push    rdx
+        push    rbx
+        push    rdi
+        push    rsi
+        push    rcx                     ; col
+
+        mov     rsi, JSAMPROW [rsi]     ; inptr
+        mov     rdi, JSAMPROW [rdi]     ; outptr0
+        mov     rbx, JSAMPROW [rbx]     ; outptr1
+        mov     rdx, JSAMPROW [rdx]     ; outptr2
+
+        cmp     rcx, byte SIZEOF_YMMWORD
+        jae     near .columnloop
+
+%if RGB_PIXELSIZE == 3 ; ---------------
+.column_ld1:
+        push    rax
+        push    rdx
+        lea     rcx,[rcx+rcx*2]         ; imul ecx,RGB_PIXELSIZE
+        test    cl, SIZEOF_BYTE
+        jz      short .column_ld2
+        sub     rcx, byte SIZEOF_BYTE
+        movzx   rax, BYTE [rsi+rcx]
+.column_ld2:
+        test    cl, SIZEOF_WORD
+        jz      short .column_ld4
+        sub     rcx, byte SIZEOF_WORD
+        movzx   rdx, WORD [rsi+rcx]
+        shl     rax, WORD_BIT
+        or      rax,rdx
+.column_ld4:
+        vmovd    xmmA,eax
+        pop     rdx
+        pop     rax
+        test    cl, SIZEOF_DWORD
+        jz      short .column_ld8
+        sub     rcx, byte SIZEOF_DWORD
+        vmovd    xmmF, XMM_DWORD [rsi+rcx]
+        vpslldq  xmmA,xmmA, SIZEOF_DWORD
+        vpor     xmmA,xmmA,xmmF
+.column_ld8:
+        test    cl, SIZEOF_MMWORD
+        jz      short .column_ld16
+        sub     rcx, byte SIZEOF_MMWORD
+        vmovq    xmmB, XMM_MMWORD [rsi+rcx]
+        vpslldq  xmmA,xmmA, SIZEOF_MMWORD
+        vpor     xmmA,xmmA,xmmB
+.column_ld16:
+        test    cl, SIZEOF_XMMWORD
+        jz      short .column_ld32
+        sub     rcx, byte SIZEOF_XMMWORD
+        vmovdqu    xmmB, XMM_MMWORD [rsi+rcx]
+    vperm2i128 ymmA,ymmA,ymmA,1
+        vpor     ymmA,ymmB
+.column_ld32:
+        test    cl, SIZEOF_YMMWORD
+        jz      short .column_ld64
+        sub     rcx, byte SIZEOF_YMMWORD
+        vmovdqa  ymmF,ymmA
+        vmovdqu  ymmA, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+.column_ld64:
+        test    cl, 2*SIZEOF_YMMWORD
+        mov     rcx, SIZEOF_YMMWORD
+        jz      short .rgb_ycc_cnv
+        vmovdqa  ymmB,ymmA
+        vmovdqu  ymmA, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymmF, YMMWORD [rsi+1*SIZEOF_YMMWORD]
+        jmp     short .rgb_ycc_cnv
+
+.columnloop:
+        vmovdqu  ymmA, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymmF, YMMWORD [rsi+1*SIZEOF_YMMWORD]
+        vmovdqu  ymmB, YMMWORD [rsi+2*SIZEOF_YMMWORD]
+
+.rgb_ycc_cnv:
+
+        vmovdqu ymmC, ymmA
+        vinserti128 ymmA, ymmF, xmmA, 0
+        vinserti128 ymmC, ymmC, xmmB, 0
+        vinserti128 ymmB, ymmB, xmmF, 0
+        vperm2i128 ymmF,ymmC,ymmC,1
+
+        vmovdqa ymmG,ymmA
+        vpslldq ymmA,ymmA,8
+        vpsrldq ymmG,ymmG,8
+
+        vpunpckhbw ymmA,ymmA,ymmF
+        vpslldq ymmF,ymmF,8
+        vpunpcklbw ymmG,ymmG,ymmB
+        vpunpckhbw ymmF, ymmF, ymmB
+        vmovdqa ymmD,ymmA
+        vpslldq ymmA,ymmA,8
+        vpsrldq ymmD,ymmD,8
+
+        vpunpckhbw ymmA,ymmA,ymmG
+        vpslldq ymmG,ymmG,8
+        vpunpcklbw ymmD,ymmD,ymmF
+        vpunpckhbw ymmG,ymmG,ymmF
+        vmovdqa ymmE, ymmA
+        vpslldq ymmA,ymmA,8
+        vpsrldq ymmE, ymmE, 8
+        vpunpckhbw ymmA,ymmA,ymmD
+        vpslldq ymmD,ymmD,8
+        vpunpcklbw ymmE,ymmE,ymmG
+        vpunpckhbw ymmD,ymmD,ymmG
+        vpxor ymmH,ymmH,ymmH
+        vmovdqa ymmC,ymmA
+        vpunpcklbw ymmA,ymmA,ymmH
+        vpunpckhbw ymmC,ymmC,ymmH
+        vmovdqa ymmB,ymmE
+        vpunpcklbw ymmE,ymmE,ymmH
+        vpunpckhbw ymmB,ymmB,ymmH
+
+        vmovdqa ymmF,ymmD
+        vpunpcklbw ymmD,ymmD,ymmH
+        vpunpckhbw ymmF,ymmF,ymmH
+
+%else ; RGB_PIXELSIZE == 4 ; -----------
+
+.column_ld1:
+        test    cl, SIZEOF_XMMWORD/16
+        jz      short .column_ld2
+        sub     rcx, byte SIZEOF_XMMWORD/16
+        vmovd    xmmA, XMM_DWORD [rsi+rcx*RGB_PIXELSIZE]
+.column_ld2:
+        test    cl, SIZEOF_XMMWORD/8
+        jz      short .column_ld4
+        sub     rcx, byte SIZEOF_XMMWORD/8
+        vmovq     xmmE, XMM_MMWORD [rsi+rcx*RGB_PIXELSIZE]
+        vpslldq   xmmA,xmmA, SIZEOF_MMWORD
+        vpor     xmmA,xmmA,xmmE
+.column_ld4:
+        test    cl, SIZEOF_XMMWORD/4
+        jz      short .column_ld8
+        sub     rcx, byte SIZEOF_XMMWORD/4
+        vmovdqa  xmmE,xmmA
+        vperm2i128 ymmE,ymmE,ymmE,1
+        vmovdqu  xmmA, XMMWORD [rsi+rcx*RGB_PIXELSIZE]
+        vpor     ymmA,ymmA,ymmE
+.column_ld8:
+        test    cl, SIZEOF_XMMWORD/2
+        jz      short .column_ld16
+        sub     rcx, byte SIZEOF_XMMWORD/2
+        vmovdqa  ymmE,ymmA
+        vmovdqu  ymmA, YMMWORD [rsi+rcx*RGB_PIXELSIZE]
+.column_ld16:
+        test    cl, SIZEOF_XMMWORD
+        mov     rcx, SIZEOF_YMMWORD
+        jz      short .rgb_ycc_cnv
+        vmovdqa  ymmF,ymmA
+        vmovdqa  ymmH,ymmE
+        vmovdqu  ymmA, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymmE, YMMWORD [rsi+1*SIZEOF_YMMWORD]
+        jmp     short .rgb_ycc_cnv
+
+.columnloop:
+        vmovdqu  ymmA, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymmE, YMMWORD [rsi+1*SIZEOF_YMMWORD]
+        vmovdqu  ymmF, YMMWORD [rsi+2*SIZEOF_YMMWORD]
+        vmovdqu  ymmH, YMMWORD [rsi+3*SIZEOF_YMMWORD]
+
+.rgb_ycc_cnv:
+        
+        vmovdqa ymmB,ymmA
+        vinserti128 ymmA,ymmA,xmmF,1
+        vperm2i128 ymmF,ymmB,ymmF,0x31
+
+        vmovdqa ymmB,ymmE
+        vinserti128 ymmE,ymmE,xmmH,1
+        vperm2i128 ymmH,ymmB,ymmH,0x31
+
+        vmovdqa ymmB, ymmE
+        vmovdqa ymmE, ymmF
+        vmovdqa ymmF, ymmB
+
+        vmovdqa    ymmD,ymmA 
+        vpunpcklbw ymmA,ymmA,ymmE 
+        vpunpckhbw ymmD,ymmD,ymmE 
+
+        vmovdqa    ymmC,ymmF 
+        vpunpcklbw ymmF,ymmF,ymmH
+        vpunpckhbw ymmC,ymmC,ymmH
+
+        vmovdqa    ymmB,ymmA 
+        vpunpcklwd ymmA,ymmA,ymmF
+        vpunpckhwd ymmB,ymmB,ymmF
+
+        vmovdqa    ymmG,ymmD 
+        vpunpcklwd ymmD,ymmD,ymmC
+        vpunpckhwd ymmG,ymmG,ymmC
+
+        vmovdqa    ymmE,ymmA 
+        vpunpcklbw ymmA,ymmA,ymmD
+        vpunpckhbw ymmE,ymmE,ymmD
+
+        vmovdqa    ymmH,ymmB 
+        vpunpcklbw ymmB,ymmB,ymmG
+        vpunpckhbw ymmH,ymmH,ymmG
+
+        vpxor      ymmF,ymmF,ymmF 
+
+        vmovdqa    ymmC,ymmA 
+        vpunpcklbw ymmA,ymmA,ymmF
+        vpunpckhbw ymmC,ymmC,ymmF
+
+        vmovdqa    ymmD,ymmB 
+        vpunpcklbw ymmB,ymmB,ymmF
+        vpunpckhbw ymmD,ymmD,ymmF
+
+        vmovdqa    ymmG,ymmE 
+        vpunpcklbw ymmE,ymmE,ymmF
+        vpunpckhbw ymmG,ymmG,ymmF
+
+        vpunpcklbw ymmF,ymmF,ymmH 
+        vpunpckhbw ymmH,ymmH,ymmH 
+        vpsrlw     ymmF,ymmF,8 
+        vpsrlw     ymmH,ymmH,8 
+
+%endif ; RGB_PIXELSIZE ; ---------------
+
+        ; ymm0=R(02468ACE)=RE, ymm2=G(02468ACE)=GE, ymm4=B(02468ACE)=BE
+        ; ymm1=R(13579BDF)=RO, ymm3=G(13579BDF)=GO, ymm5=B(13579BDF)=BO
+
+        ; (Original)
+        ; Y  =  0.29900 * R + 0.58700 * G + 0.11400 * B
+        ; Cb = -0.16874 * R - 0.33126 * G + 0.50000 * B + CENTERJSAMPLE
+        ; Cr =  0.50000 * R - 0.41869 * G - 0.08131 * B + CENTERJSAMPLE
+        ;
+        ; (This implementation)
+        ; Y  =  0.29900 * R + 0.33700 * G + 0.11400 * B + 0.25000 * G
+        ; Cb = -0.16874 * R - 0.33126 * G + 0.50000 * B + CENTERJSAMPLE
+        ; Cr =  0.50000 * R - 0.41869 * G - 0.08131 * B + CENTERJSAMPLE
+
+        vmovdqa    YMMWORD [wk(0)], ymm0 ; wk(0)=RE
+        vmovdqa    YMMWORD [wk(1)], ymm1 ; wk(1)=RO
+        vmovdqa    YMMWORD [wk(2)], ymm4 ; wk(2)=BE
+        vmovdqa    YMMWORD [wk(3)], ymm5 ; wk(3)=BO
+
+        vmovdqa    ymm6,ymm1  ; least 
+        vpunpcklwd ymm1,ymm1,ymm3 ;R1-G1-R3-G3-R5-G5-R7-G7  = ROL GOL interleave
+        vpunpckhwd ymm6,ymm6,ymm3 ;R9-G9-RA-GA-RD-GD-RF-GF  = ROH GOH interleave
+        vmovdqa    ymm7,ymm1
+        vmovdqa    ymm4,ymm6
+        vpmaddwd   ymm1,ymm1,[rel PW_F0299_F0337] ; ymm1=ROL*FIX(0.299)+GOL*FIX(0.337)
+        vpmaddwd   ymm6,ymm6,[rel PW_F0299_F0337] ; ymm6=ROH*FIX(0.299)+GOH*FIX(0.337)
+        vpmaddwd   ymm7,ymm7,[rel PW_MF016_MF033] ; ymm7=ROL*-FIX(0.168)+GOL*-FIX(0.331)
+
+        vpmaddwd   ymm4,ymm4,[rel PW_MF016_MF033] ; ymm4=ROH*-FIX(0.168)+GOH*-FIX(0.331)
+
+        vmovdqa    YMMWORD [wk(4)], ymm1 ; wk(4)=ROL*FIX(0.299)+GOL*FIX(0.337)
+        vmovdqa    YMMWORD [wk(5)], ymm6 ; wk(5)=ROH*FIX(0.299)+GOH*FIX(0.337)
+
+        vpxor      ymm1,ymm1,ymm1
+        vpxor      ymm6,ymm6,ymm6
+        vpunpcklwd ymm1,ymm1,ymm5             ; ymm1=BOL
+        vpunpckhwd ymm6,ymm6,ymm5             ; ymm6=BOH
+        vpsrld     ymm1,ymm1,1                ; ymm1=BOL*FIX(0.500)
+        vpsrld     ymm6,ymm6,1                ; ymm6=BOH*FIX(0.500)
+
+        vmovdqa    ymm5,[rel PD_ONEHALFM1_CJ] ; ymm5=[PD_ONEHALFM1_CJ]
+
+        vpaddd     ymm7,ymm7,ymm1 ;{ROL*-FIX(0.168)+GOL*-FIX(0.331)} + {BOL*FIX(0.500)}
+        vpaddd     ymm4,ymm4,ymm6
+        vpaddd     ymm7,ymm7,ymm5;{ROL*-FIX(0.168)+GOL*-FIX(0.331)} + {BOL*FIX(0.500)}+{[PD_ONEHALFM1_CJ]}
+        vpaddd     ymm4,ymm4,ymm5
+        vpsrld     ymm7,ymm7,SCALEBITS        ; ymm7=CbOL
+        vpsrld     ymm4,ymm4,SCALEBITS        ; ymm4=CbOH
+        vpackssdw  ymm7,ymm7,ymm4             ; ymm7=CbO
+
+
+        vmovdqa    ymm1, YMMWORD [wk(2)] ; ymm1=BE
+
+        vmovdqa    ymm6,ymm0
+        vpunpcklwd ymm0,ymm0,ymm2
+        vpunpckhwd ymm6,ymm6,ymm2
+        vmovdqa    ymm5,ymm0
+        vmovdqa    ymm4,ymm6
+        vpmaddwd   ymm0,ymm0,[rel PW_F0299_F0337] ; ymm0=REL*FIX(0.299)+GEL*FIX(0.337)
+        vpmaddwd   ymm6,ymm6,[rel PW_F0299_F0337] ; ymm6=REH*FIX(0.299)+GEH*FIX(0.337)
+        vpmaddwd   ymm5,ymm5,[rel PW_MF016_MF033] ; ymm5=REL*-FIX(0.168)+GEL*-FIX(0.331)
+        vpmaddwd   ymm4,ymm4,[rel PW_MF016_MF033] ; ymm4=REH*-FIX(0.168)+GEH*-FIX(0.331)
+
+        vmovdqa    YMMWORD [wk(6)], ymm0 ; wk(6)=REL*FIX(0.299)+GEL*FIX(0.337)
+        vmovdqa    YMMWORD [wk(7)], ymm6 ; wk(7)=REH*FIX(0.299)+GEH*FIX(0.337)
+
+        vpxor      ymm0,ymm0,ymm0
+        vpxor      ymm6,ymm6,ymm6
+        vpunpcklwd ymm0,ymm0,ymm1             ; ymm0=BEL
+        vpunpckhwd ymm6,ymm6,ymm1             ; ymm6=BEH
+        vpsrld     ymm0,ymm0,1                ; ymm0=BEL*FIX(0.500)
+        vpsrld     ymm6,ymm6,1                ; ymm6=BEH*FIX(0.500)
+
+
+        vmovdqa    ymm1,[rel PD_ONEHALFM1_CJ] ; ymm1=[PD_ONEHALFM1_CJ]
+
+        vpaddd     ymm5,ymm5,ymm0
+        vpaddd     ymm4,ymm4,ymm6
+        vpaddd     ymm5,ymm5,ymm1
+        vpaddd     ymm4,ymm4,ymm1
+        vpsrld     ymm5,ymm5,SCALEBITS        ; ymm5=CbEL
+        vpsrld     ymm4,ymm4,SCALEBITS        ; ymm4=CbEH
+        vpackssdw  ymm5,ymm5,ymm4             ; ymm5=CbE
+
+        vpsllw     ymm7,ymm7,BYTE_BIT
+        vpor       ymm5,ymm5,ymm7             ; ymm5=Cb
+        vmovdqa    YMMWORD [rbx], ymm5   ; Save Cb
+
+        vmovdqa    ymm0, YMMWORD [wk(3)] ; ymm0=BO
+        vmovdqa    ymm6, YMMWORD [wk(2)] ; ymm6=BE
+        vmovdqa    ymm1, YMMWORD [wk(1)] ; ymm1=RO
+
+        vmovdqa    ymm4,ymm0
+        vpunpcklwd ymm0,ymm0,ymm3
+        vpunpckhwd ymm4,ymm4,ymm3
+        vmovdqa    ymm7,ymm0
+        vmovdqa    ymm5,ymm4
+        vpmaddwd   ymm0,ymm0,[rel PW_F0114_F0250] ; ymm0=BOL*FIX(0.114)+GOL*FIX(0.250)
+        vpmaddwd   ymm4,ymm4,[rel PW_F0114_F0250] ; ymm4=BOH*FIX(0.114)+GOH*FIX(0.250)
+        vpmaddwd   ymm7,ymm7,[rel PW_MF008_MF041] ; ymm7=BOL*-FIX(0.081)+GOL*-FIX(0.418)
+        vpmaddwd   ymm5,ymm5,[rel PW_MF008_MF041] ; ymm5=BOH*-FIX(0.081)+GOH*-FIX(0.418)
+
+        vmovdqa    ymm3,[rel PD_ONEHALF] ; ymm3=[PD_ONEHALF]
+
+        vpaddd     ymm0,ymm0, YMMWORD [wk(4)]
+        vpaddd     ymm4,ymm4, YMMWORD [wk(5)]
+        vpaddd     ymm0,ymm0,ymm3
+        vpaddd     ymm4,ymm4,ymm3
+        vpsrld     ymm0,ymm0,SCALEBITS        ; ymm0=YOL
+        vpsrld     ymm4,ymm4,SCALEBITS        ; ymm4=YOH
+        vpackssdw  ymm0,ymm0,ymm4             ; ymm0=YO
+
+        vpxor      ymm3,ymm3,ymm3
+        vpxor      ymm4,ymm4,ymm4
+        vpunpcklwd ymm3,ymm3,ymm1             ; ymm3=ROL
+        vpunpckhwd ymm4,ymm4,ymm1             ; ymm4=ROH
+        vpsrld     ymm3,ymm3,1                ; ymm3=ROL*FIX(0.500)
+        vpsrld     ymm4,ymm4,1                ; ymm4=ROH*FIX(0.500)
+
+        vmovdqa    ymm1,[rel PD_ONEHALFM1_CJ] ; ymm1=[PD_ONEHALFM1_CJ]
+
+        vpaddd     ymm7,ymm7,ymm3
+        vpaddd     ymm5,ymm5,ymm4
+        vpaddd     ymm7,ymm7,ymm1
+        vpaddd     ymm5,ymm5,ymm1
+        vpsrld     ymm7,ymm7,SCALEBITS        ; ymm7=CrOL
+        vpsrld     ymm5,ymm5,SCALEBITS        ; ymm5=CrOH
+        vpackssdw  ymm7,ymm7,ymm5             ; ymm7=CrO
+
+        vmovdqa    ymm3, YMMWORD [wk(0)] ; ymm3=RE
+
+        vmovdqa    ymm4,ymm6
+        vpunpcklwd ymm6,ymm6,ymm2
+        vpunpckhwd ymm4,ymm4,ymm2
+        vmovdqa    ymm1,ymm6
+        vmovdqa    ymm5,ymm4
+        vpmaddwd   ymm6,ymm6,[rel PW_F0114_F0250] ; ymm6=BEL*FIX(0.114)+GEL*FIX(0.250)
+        vpmaddwd   ymm4,ymm4,[rel PW_F0114_F0250] ; ymm4=BEH*FIX(0.114)+GEH*FIX(0.250)
+        vpmaddwd   ymm1,ymm1,[rel PW_MF008_MF041] ; ymm1=BEL*-FIX(0.081)+GEL*-FIX(0.418)
+        vpmaddwd   ymm5,ymm5,[rel PW_MF008_MF041] ; ymm5=BEH*-FIX(0.081)+GEH*-FIX(0.418)
+
+        vmovdqa    ymm2,[rel PD_ONEHALF] ; ymm2=[PD_ONEHALF]
+
+        vpaddd     ymm6,ymm6, YMMWORD [wk(6)]
+        vpaddd     ymm4,ymm4, YMMWORD [wk(7)]
+        vpaddd     ymm6,ymm6,ymm2
+        vpaddd     ymm4,ymm4,ymm2
+        vpsrld     ymm6,ymm6,SCALEBITS        ; ymm6=YEL
+        vpsrld     ymm4,ymm4,SCALEBITS        ; ymm4=YEH
+        vpackssdw  ymm6,ymm6,ymm4             ; ymm6=YE
+
+        vpsllw     ymm0,ymm0,BYTE_BIT
+        vpor       ymm6,ymm6,ymm0             ; ymm6=Y
+        vmovdqa    YMMWORD [rdi], ymm6   ; Save Y
+
+        vpxor      ymm2,ymm2,ymm2
+        vpxor      ymm4,ymm4,ymm4
+        vpunpcklwd ymm2,ymm2,ymm3             ; ymm2=REL
+        vpunpckhwd ymm4,ymm4,ymm3             ; ymm4=REH
+        vpsrld     ymm2,ymm2,1                ; ymm2=REL*FIX(0.500)
+        vpsrld     ymm4,ymm4,1                ; ymm4=REH*FIX(0.500)
+
+        vmovdqa    ymm0,[rel PD_ONEHALFM1_CJ] ; ymm0=[PD_ONEHALFM1_CJ]
+
+        vpaddd     ymm1,ymm1,ymm2
+        vpaddd     ymm5,ymm5,ymm4
+        vpaddd     ymm1,ymm1,ymm0
+        vpaddd     ymm5,ymm5,ymm0
+        vpsrld     ymm1,ymm1,SCALEBITS        ; ymm1=CrEL
+        vpsrld     ymm5,ymm5,SCALEBITS        ; ymm5=CrEH
+        vpackssdw  ymm1,ymm1,ymm5             ; ymm1=CrE
+
+        vpsllw     ymm7,ymm7,BYTE_BIT
+        vpor       ymm1,ymm1,ymm7             ; ymm1=Cr
+        vmovdqa    YMMWORD [rdx], ymm1   ; Save Cr
+
+.done:
+        sub     rcx, byte SIZEOF_YMMWORD
+        add     rsi, RGB_PIXELSIZE*SIZEOF_YMMWORD  ; inptr
+        add     rdi, byte SIZEOF_YMMWORD                ; outptr0
+        add     rbx, byte SIZEOF_YMMWORD                ; outptr1
+        add     rdx, byte SIZEOF_YMMWORD                ; outptr2
+        cmp     rcx, byte SIZEOF_YMMWORD
+        jae     near .columnloop
+        test    rcx,rcx
+        jnz     near .column_ld1
+
+        pop     rcx                     ; col
+        pop     rsi
+        pop     rdi
+        pop     rbx
+        pop     rdx
+
+        add     rsi, byte SIZEOF_JSAMPROW       ; input_buf
+        add     rdi, byte SIZEOF_JSAMPROW
+        add     rbx, byte SIZEOF_JSAMPROW
+        add     rdx, byte SIZEOF_JSAMPROW
+        dec     rax                             ; num_rows
+        jg      near .rowloop
+
+.return:
+        pop     rbx
+        uncollect_args
+        mov     rsp,rbp         ; rsp <- aligned rbp
+        pop     rsp             ; rsp <- original rbp
+        pop     rbp
+        ret
+
+; For some reason, the OS X linker does not honor the request to align the
+; segment unless we do this.
+        align   32

--- a/simd/jccolor-avx2-64.asm
+++ b/simd/jccolor-avx2-64.asm
@@ -1,0 +1,121 @@
+;
+; jccolor.asm - colorspace conversion (64-bit AVX2)
+;
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; Copyright (C) 2009, D. R. Commander.
+; Copyright (C) 2015, Intel Corporation.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; [TAB8]
+
+%include "jsimdext.inc"
+
+; --------------------------------------------------------------------------
+
+%define SCALEBITS       16
+
+F_0_081 equ      5329                   ; FIX(0.08131)
+F_0_114 equ      7471                   ; FIX(0.11400)
+F_0_168 equ     11059                   ; FIX(0.16874)
+F_0_250 equ     16384                   ; FIX(0.25000)
+F_0_299 equ     19595                   ; FIX(0.29900)
+F_0_331 equ     21709                   ; FIX(0.33126)
+F_0_418 equ     27439                   ; FIX(0.41869)
+F_0_587 equ     38470                   ; FIX(0.58700)
+F_0_337 equ     (F_0_587 - F_0_250)     ; FIX(0.58700) - FIX(0.25000)
+
+; --------------------------------------------------------------------------
+        SECTION SEG_CONST
+
+        alignz  32
+        global  EXTN(jconst_rgb_ycc_convert_avx2)
+
+EXTN(jconst_rgb_ycc_convert_avx2):
+
+PW_F0299_F0337  times 8 dw  F_0_299, F_0_337
+PW_F0114_F0250  times 8 dw  F_0_114, F_0_250
+PW_MF016_MF033  times 8 dw -F_0_168,-F_0_331
+PW_MF008_MF041  times 8 dw -F_0_081,-F_0_418
+PD_ONEHALFM1_CJ times 8 dd  (1 << (SCALEBITS-1)) - 1 + (CENTERJSAMPLE << SCALEBITS)
+PD_ONEHALF      times 8 dd  (1 << (SCALEBITS-1))
+
+        alignz  32
+
+; --------------------------------------------------------------------------
+        SECTION SEG_TEXT
+        BITS    64
+
+%include "jccolext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_RGB_RED
+%define RGB_GREEN EXT_RGB_GREEN
+%define RGB_BLUE EXT_RGB_BLUE
+%define RGB_PIXELSIZE EXT_RGB_PIXELSIZE
+%define jsimd_rgb_ycc_convert_avx2 jsimd_extrgb_ycc_convert_avx2
+%include "jccolext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_RGBX_RED
+%define RGB_GREEN EXT_RGBX_GREEN
+%define RGB_BLUE EXT_RGBX_BLUE
+%define RGB_PIXELSIZE EXT_RGBX_PIXELSIZE
+%define jsimd_rgb_ycc_convert_avx2 jsimd_extrgbx_ycc_convert_avx2
+%include "jccolext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_BGR_RED
+%define RGB_GREEN EXT_BGR_GREEN
+%define RGB_BLUE EXT_BGR_BLUE
+%define RGB_PIXELSIZE EXT_BGR_PIXELSIZE
+%define jsimd_rgb_ycc_convert_avx2 jsimd_extbgr_ycc_convert_avx2
+%include "jccolext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_BGRX_RED
+%define RGB_GREEN EXT_BGRX_GREEN
+%define RGB_BLUE EXT_BGRX_BLUE
+%define RGB_PIXELSIZE EXT_BGRX_PIXELSIZE
+%define jsimd_rgb_ycc_convert_avx2 jsimd_extbgrx_ycc_convert_avx2
+%include "jccolext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_XBGR_RED
+%define RGB_GREEN EXT_XBGR_GREEN
+%define RGB_BLUE EXT_XBGR_BLUE
+%define RGB_PIXELSIZE EXT_XBGR_PIXELSIZE
+%define jsimd_rgb_ycc_convert_avx2 jsimd_extxbgr_ycc_convert_avx2
+%include "jccolext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_XRGB_RED
+%define RGB_GREEN EXT_XRGB_GREEN
+%define RGB_BLUE EXT_XRGB_BLUE
+%define RGB_PIXELSIZE EXT_XRGB_PIXELSIZE
+%define jsimd_rgb_ycc_convert_avx2 jsimd_extxrgb_ycc_convert_avx2
+%include "jccolext-avx2-64.asm"

--- a/simd/jcgray-avx2-64.asm
+++ b/simd/jcgray-avx2-64.asm
@@ -1,0 +1,114 @@
+;
+; jcgray.asm - grayscale colorspace conversion (64-bit AVX2)
+;
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; Copyright (C) 2011, D. R. Commander.
+; Copyright (C) 2015, Intel Corporation.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; [TAB8]
+
+%include "jsimdext.inc"
+
+; --------------------------------------------------------------------------
+
+%define SCALEBITS       16
+
+F_0_114 equ      7471                   ; FIX(0.11400)
+F_0_250 equ     16384                   ; FIX(0.25000)
+F_0_299 equ     19595                   ; FIX(0.29900)
+F_0_587 equ     38470                   ; FIX(0.58700)
+F_0_337 equ     (F_0_587 - F_0_250)     ; FIX(0.58700) - FIX(0.25000)
+
+; --------------------------------------------------------------------------
+        SECTION SEG_CONST
+
+        alignz  32
+        global  EXTN(jconst_rgb_gray_convert_avx2)
+
+EXTN(jconst_rgb_gray_convert_avx2):
+
+PW_F0299_F0337  times 8 dw  F_0_299, F_0_337
+PW_F0114_F0250  times 8 dw  F_0_114, F_0_250
+PD_ONEHALF      times 8 dd  (1 << (SCALEBITS-1))
+
+        alignz  32
+
+; --------------------------------------------------------------------------
+        SECTION SEG_TEXT
+        BITS    64
+
+%include "jcgryext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_RGB_RED
+%define RGB_GREEN EXT_RGB_GREEN
+%define RGB_BLUE EXT_RGB_BLUE
+%define RGB_PIXELSIZE EXT_RGB_PIXELSIZE
+%define jsimd_rgb_gray_convert_avx2 jsimd_extrgb_gray_convert_avx2
+%include "jcgryext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_RGBX_RED
+%define RGB_GREEN EXT_RGBX_GREEN
+%define RGB_BLUE EXT_RGBX_BLUE
+%define RGB_PIXELSIZE EXT_RGBX_PIXELSIZE
+%define jsimd_rgb_gray_convert_avx2 jsimd_extrgbx_gray_convert_avx2
+%include "jcgryext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_BGR_RED
+%define RGB_GREEN EXT_BGR_GREEN
+%define RGB_BLUE EXT_BGR_BLUE
+%define RGB_PIXELSIZE EXT_BGR_PIXELSIZE
+%define jsimd_rgb_gray_convert_avx2 jsimd_extbgr_gray_convert_avx2
+%include "jcgryext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_BGRX_RED
+%define RGB_GREEN EXT_BGRX_GREEN
+%define RGB_BLUE EXT_BGRX_BLUE
+%define RGB_PIXELSIZE EXT_BGRX_PIXELSIZE
+%define jsimd_rgb_gray_convert_avx2 jsimd_extbgrx_gray_convert_avx2
+%include "jcgryext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_XBGR_RED
+%define RGB_GREEN EXT_XBGR_GREEN
+%define RGB_BLUE EXT_XBGR_BLUE
+%define RGB_PIXELSIZE EXT_XBGR_PIXELSIZE
+%define jsimd_rgb_gray_convert_avx2 jsimd_extxbgr_gray_convert_avx2
+%include "jcgryext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_XRGB_RED
+%define RGB_GREEN EXT_XRGB_GREEN
+%define RGB_BLUE EXT_XRGB_BLUE
+%define RGB_PIXELSIZE EXT_XRGB_PIXELSIZE
+%define jsimd_rgb_gray_convert_avx2 jsimd_extxrgb_gray_convert_avx2
+%include "jcgryext-avx2-64.asm"

--- a/simd/jcgryext-avx2-64.asm
+++ b/simd/jcgryext-avx2-64.asm
@@ -1,0 +1,377 @@
+;
+; jcgryext.asm - grayscale colorspace conversion (64-bit AVX2)
+;
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; Copyright (C) 2011, D. R. Commander.
+; Copyright (C) 2015, Intel Corporation.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; [TAB8]
+
+%include "jcolsamp.inc"
+
+; --------------------------------------------------------------------------
+;
+; Convert some rows of samples to the output colorspace.
+;
+; GLOBAL(void)
+; jsimd_rgb_gray_convert_avx2 (JDIMENSION img_width,
+;                              JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+;                              JDIMENSION output_row, int num_rows);
+;
+
+; r10 = JDIMENSION img_width
+; r11 = JSAMPARRAY input_buf
+; r12 = JSAMPIMAGE output_buf
+; r13 = JDIMENSION output_row
+; r14 = int num_rows
+
+%define wk(i)           rbp-(WK_NUM-(i))*SIZEOF_YMMWORD ; ymmword wk[WK_NUM]
+%define WK_NUM          2
+
+        align   32
+
+        global  EXTN(jsimd_rgb_gray_convert_avx2)
+
+EXTN(jsimd_rgb_gray_convert_avx2):
+        push    rbp
+        mov     rax,rsp                         ; rax = original rbp
+        sub     rsp, byte 4
+        and     rsp, byte (-SIZEOF_YMMWORD)     ; align to 128 bits
+        mov     [rsp],rax
+        mov     rbp,rsp                         ; rbp = aligned rbp
+        lea     rsp, [wk(0)]
+        collect_args
+        push    rbx
+
+        mov     rcx, r10
+        test    rcx,rcx
+        jz      near .return
+
+        push    rcx
+
+        mov rsi, r12
+        mov rcx, r13
+        mov     rdi, JSAMPARRAY [rsi+0*SIZEOF_JSAMPARRAY]
+        lea     rdi, [rdi+rcx*SIZEOF_JSAMPROW]
+
+        pop     rcx
+
+        mov rsi, r11
+        mov     eax, r14d
+        test    rax,rax
+        jle     near .return
+.rowloop:
+        push    rdi
+        push    rsi
+        push    rcx                     ; col
+
+        mov     rsi, JSAMPROW [rsi]     ; inptr
+        mov     rdi, JSAMPROW [rdi]     ; outptr0
+
+        cmp     rcx, byte SIZEOF_YMMWORD
+        jae     near .columnloop
+
+%if RGB_PIXELSIZE == 3 
+.column_ld1:
+        push    rax
+        push    rdx
+        lea     rcx,[rcx+rcx*2]         ; imul ecx,RGB_PIXELSIZE
+        test    cl, SIZEOF_BYTE
+        jz      short .column_ld2
+        sub     rcx, byte SIZEOF_BYTE
+        movzx   rax, BYTE [rsi+rcx]
+.column_ld2:
+        test    cl, SIZEOF_WORD
+        jz      short .column_ld4
+        sub     rcx, byte SIZEOF_WORD
+        movzx   rdx, WORD [rsi+rcx]
+        shl     rax, WORD_BIT
+        or      rax,rdx
+.column_ld4:
+        vmovd    xmmA,eax
+        pop     rdx
+        pop     rax
+        test    cl, SIZEOF_DWORD
+        jz      short .column_ld8
+        sub     rcx, byte SIZEOF_DWORD
+        vmovd    xmmF, XMM_DWORD [rsi+rcx]
+        vpslldq  xmmA,xmmA, SIZEOF_DWORD
+        vpor     xmmA,xmmA,xmmF
+.column_ld8:
+        test    cl, SIZEOF_MMWORD
+        jz      short .column_ld16
+        sub     rcx, byte SIZEOF_MMWORD
+        vmovq    xmmB, XMM_MMWORD [rsi+rcx]
+        vpslldq  xmmA,xmmA, SIZEOF_MMWORD
+        vpor     xmmA,xmmA,xmmB
+.column_ld16:
+        test    cl, SIZEOF_XMMWORD
+        jz      short .column_ld32
+        sub     rcx, byte SIZEOF_XMMWORD
+        vmovdqu    xmmB, XMM_MMWORD [rsi+rcx]
+        vperm2i128 ymmA,ymmA,ymmA,1
+        vpor     ymmA,ymmB
+.column_ld32:
+        test    cl, SIZEOF_YMMWORD
+        jz      short .column_ld64
+        sub     rcx, byte SIZEOF_YMMWORD
+        vmovdqa  ymmF,ymmA
+        vmovdqu  ymmA, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+.column_ld64:
+        test    cl, 2*SIZEOF_YMMWORD
+        mov     rcx, SIZEOF_YMMWORD
+        jz      short .rgb_gray_cnv
+        vmovdqa  ymmB,ymmA
+        vmovdqu  ymmA, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymmF, YMMWORD [rsi+1*SIZEOF_YMMWORD]
+        jmp     short .rgb_gray_cnv
+
+.columnloop:
+        vmovdqu  ymmA, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymmF, YMMWORD [rsi+1*SIZEOF_YMMWORD]
+        vmovdqu  ymmB, YMMWORD [rsi+2*SIZEOF_YMMWORD]
+
+.rgb_gray_cnv:
+
+        vmovdqu ymmC, ymmA
+        vinserti128 ymmA, ymmF, xmmA, 0
+        vinserti128 ymmC, ymmC, xmmB, 0
+        vinserti128 ymmB, ymmB, xmmF, 0
+        vperm2i128 ymmF,ymmC,ymmC,1
+
+        vmovdqa ymmG,ymmA
+        vpslldq ymmA,ymmA,8
+        vpsrldq ymmG,ymmG,8
+
+        vpunpckhbw ymmA,ymmA,ymmF
+        vpslldq ymmF,ymmF,8
+        vpunpcklbw ymmG,ymmG,ymmB
+        vpunpckhbw ymmF, ymmF, ymmB
+        vmovdqa ymmD,ymmA
+        vpslldq ymmA,ymmA,8
+        vpsrldq ymmD,ymmD,8
+
+        vpunpckhbw ymmA,ymmA,ymmG
+        vpslldq ymmG,ymmG,8
+        vpunpcklbw ymmD,ymmD,ymmF
+        vpunpckhbw ymmG,ymmG,ymmF
+        vmovdqa ymmE, ymmA
+        vpslldq ymmA,ymmA,8
+        vpsrldq ymmE, ymmE, 8
+        vpunpckhbw ymmA,ymmA,ymmD
+        vpslldq ymmD,ymmD,8
+        vpunpcklbw ymmE,ymmE,ymmG
+        vpunpckhbw ymmD,ymmD,ymmG
+        vpxor ymmH,ymmH,ymmH
+        vmovdqa ymmC,ymmA
+        vpunpcklbw ymmA,ymmA,ymmH
+        vpunpckhbw ymmC,ymmC,ymmH
+        vmovdqa ymmB,ymmE
+        vpunpcklbw ymmE,ymmE,ymmH
+        vpunpckhbw ymmB,ymmB,ymmH
+
+        vmovdqa ymmF,ymmD
+        vpunpcklbw ymmD,ymmD,ymmH
+        vpunpckhbw ymmF,ymmF,ymmH
+
+%else ; RGB_PIXELSIZE == 4 
+
+.column_ld1:
+        test    cl, SIZEOF_XMMWORD/16
+        jz      short .column_ld2
+        sub     rcx, byte SIZEOF_XMMWORD/16
+        vmovd    xmmA, XMM_DWORD [rsi+rcx*RGB_PIXELSIZE]
+.column_ld2:
+        test    cl, SIZEOF_XMMWORD/8
+        jz      short .column_ld4
+        sub     rcx, byte SIZEOF_XMMWORD/8
+        vmovq       xmmE, XMM_MMWORD [rsi+rcx*RGB_PIXELSIZE]
+        vpslldq     xmmA,xmmA, SIZEOF_MMWORD
+        vpor     xmmA,xmmA,xmmE
+.column_ld4:
+        test    cl, SIZEOF_XMMWORD/4
+        jz      short .column_ld8
+        sub     rcx, byte SIZEOF_XMMWORD/4
+        vmovdqa  xmmE,xmmA
+        vperm2i128 ymmE,ymmE,ymmE,1
+        vmovdqu  xmmA, XMMWORD [rsi+rcx*RGB_PIXELSIZE]
+        vpor     ymmA,ymmA,ymmE
+.column_ld8:
+        test    cl, SIZEOF_XMMWORD/2
+        jz      short .column_ld16
+        sub     rcx, byte SIZEOF_XMMWORD/2
+        vmovdqa  ymmE,ymmA
+        vmovdqu  ymmA, YMMWORD [rsi+rcx*RGB_PIXELSIZE]
+.column_ld16:
+        test    cl, SIZEOF_XMMWORD
+        mov     rcx, SIZEOF_YMMWORD
+        jz      short .rgb_gray_cnv
+        vmovdqa  ymmF,ymmA
+        vmovdqa  ymmH,ymmE
+        vmovdqu  ymmA, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymmE, YMMWORD [rsi+1*SIZEOF_YMMWORD]
+        jmp     short .rgb_gray_cnv
+
+.columnloop:
+        vmovdqu  ymmA, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymmE, YMMWORD [rsi+1*SIZEOF_YMMWORD]
+        vmovdqu  ymmF, YMMWORD [rsi+2*SIZEOF_YMMWORD]
+        vmovdqu  ymmH, YMMWORD [rsi+3*SIZEOF_YMMWORD]
+
+.rgb_gray_cnv:
+        
+        vmovdqa ymmB,ymmA
+        vinserti128 ymmA,ymmA,xmmF,1
+        vperm2i128 ymmF,ymmB,ymmF,0x31
+
+        vmovdqa ymmB,ymmE
+        vinserti128 ymmE,ymmE,xmmH,1
+        vperm2i128 ymmH,ymmB,ymmH,0x31
+
+        vmovdqa ymmB, ymmE
+        vmovdqa ymmE, ymmF
+        vmovdqa ymmF, ymmB
+
+        vmovdqa    ymmD,ymmA 
+        vpunpcklbw ymmA,ymmA,ymmE 
+        vpunpckhbw ymmD,ymmD,ymmE 
+
+        vmovdqa    ymmC,ymmF 
+        vpunpcklbw ymmF,ymmF,ymmH
+        vpunpckhbw ymmC,ymmC,ymmH
+
+        vmovdqa    ymmB,ymmA 
+        vpunpcklwd ymmA,ymmA,ymmF
+        vpunpckhwd ymmB,ymmB,ymmF
+
+        vmovdqa    ymmG,ymmD 
+        vpunpcklwd ymmD,ymmD,ymmC
+        vpunpckhwd ymmG,ymmG,ymmC
+
+        vmovdqa    ymmE,ymmA 
+        vpunpcklbw ymmA,ymmA,ymmD
+        vpunpckhbw ymmE,ymmE,ymmD
+
+        vmovdqa    ymmH,ymmB 
+        vpunpcklbw ymmB,ymmB,ymmG
+        vpunpckhbw ymmH,ymmH,ymmG
+
+        vpxor      ymmF,ymmF,ymmF 
+
+        vmovdqa    ymmC,ymmA 
+        vpunpcklbw ymmA,ymmA,ymmF
+        vpunpckhbw ymmC,ymmC,ymmF
+
+        vmovdqa    ymmD,ymmB 
+        vpunpcklbw ymmB,ymmB,ymmF
+        vpunpckhbw ymmD,ymmD,ymmF
+
+        vmovdqa    ymmG,ymmE 
+        vpunpcklbw ymmE,ymmE,ymmF
+        vpunpckhbw ymmG,ymmG,ymmF
+
+        vpunpcklbw ymmF,ymmF,ymmH 
+        vpunpckhbw ymmH,ymmH,ymmH 
+        vpsrlw     ymmF,ymmF,8 
+        vpsrlw     ymmH,ymmH,8 
+
+%endif ; RGB_PIXELSIZE 
+
+        ; (Original)
+        ; Y  =  0.29900 * R + 0.58700 * G + 0.11400 * B
+        ;
+        ; (This implementation)
+        ; Y  =  0.29900 * R + 0.33700 * G + 0.11400 * B + 0.25000 * G
+
+        vmovdqa    ymm6,ymm1
+        vpunpcklwd ymm1,ymm1,ymm3
+        vpunpckhwd ymm6,ymm6,ymm3
+        vpmaddwd   ymm1,ymm1,[rel PW_F0299_F0337] ; ymm1=ROL*FIX(0.299)+GOL*FIX(0.337)
+        vpmaddwd   ymm6,ymm6,[rel PW_F0299_F0337] ; ymm6=ROH*FIX(0.299)+GOH*FIX(0.337)
+
+        vmovdqa    ymm7, ymm6    ; ymm7=ROH*FIX(0.299)+GOH*FIX(0.337)
+
+        vmovdqa    ymm6,ymm0
+        vpunpcklwd ymm0,ymm0,ymm2
+        vpunpckhwd ymm6,ymm6,ymm2
+        vpmaddwd   ymm0,ymm0,[rel PW_F0299_F0337] ; ymm0=REL*FIX(0.299)+GEL*FIX(0.337)
+        vpmaddwd   ymm6,ymm6,[rel PW_F0299_F0337] ; ymm6=REH*FIX(0.299)+GEH*FIX(0.337)
+
+        vmovdqa    YMMWORD [wk(0)], ymm0 ; wk(0)=REL*FIX(0.299)+GEL*FIX(0.337)
+        vmovdqa    YMMWORD [wk(1)], ymm6 ; wk(1)=REH*FIX(0.299)+GEH*FIX(0.337)
+
+        vmovdqa    ymm0, ymm5    ; ymm0=BO
+        vmovdqa    ymm6, ymm4    ; ymm6=BE
+
+        vmovdqa    ymm4,ymm0
+        vpunpcklwd ymm0,ymm0,ymm3
+        vpunpckhwd ymm4,ymm4,ymm3
+        vpmaddwd   ymm0,ymm0,[rel PW_F0114_F0250] ; ymm0=BOL*FIX(0.114)+GOL*FIX(0.250)
+        vpmaddwd   ymm4,ymm4,[rel PW_F0114_F0250] ; ymm4=BOH*FIX(0.114)+GOH*FIX(0.250)
+
+        vmovdqa    ymm3,[rel PD_ONEHALF] ; ymm3=[PD_ONEHALF]
+
+        vpaddd     ymm0,ymm0, ymm1
+        vpaddd     ymm4,ymm4, ymm7
+        vpaddd     ymm0,ymm0,ymm3
+        vpaddd     ymm4,ymm4,ymm3
+        vpsrld     ymm0,ymm0,SCALEBITS        ; ymm0=YOL
+        vpsrld     ymm4,ymm4,SCALEBITS        ; ymm4=YOH
+        vpackssdw  ymm0,ymm0,ymm4             ; ymm0=YO
+
+        vmovdqa    ymm4,ymm6
+        vpunpcklwd ymm6,ymm6,ymm2
+        vpunpckhwd ymm4,ymm4,ymm2
+        vpmaddwd   ymm6,ymm6,[rel PW_F0114_F0250] ; ymm6=BEL*FIX(0.114)+GEL*FIX(0.250)
+        vpmaddwd   ymm4,ymm4,[rel PW_F0114_F0250] ; ymm4=BEH*FIX(0.114)+GEH*FIX(0.250)
+
+        vmovdqa    ymm2,[rel PD_ONEHALF] ; ymm2=[PD_ONEHALF]
+
+        vpaddd     ymm6,ymm6, YMMWORD [wk(0)]
+        vpaddd     ymm4,ymm4, YMMWORD [wk(1)]
+        vpaddd     ymm6,ymm6,ymm2
+        vpaddd     ymm4,ymm4,ymm2
+        vpsrld     ymm6,ymm6,SCALEBITS        ; ymm6=YEL
+        vpsrld     ymm4,ymm4,SCALEBITS        ; ymm4=YEH
+        vpackssdw  ymm6,ymm6,ymm4             ; ymm6=YE
+
+        vpsllw     ymm0,ymm0,BYTE_BIT
+        vpor       ymm6,ymm6,ymm0             ; ymm6=Y
+        vmovdqa    YMMWORD [rdi], ymm6   ; Save Y
+
+        sub     rcx, byte SIZEOF_YMMWORD
+        add     rsi, RGB_PIXELSIZE*SIZEOF_YMMWORD  ; inptr
+        add     rdi, byte SIZEOF_YMMWORD                ; outptr0
+        cmp     rcx, byte SIZEOF_YMMWORD
+        jae     near .columnloop
+        test    rcx,rcx
+        jnz     near .column_ld1
+
+        pop     rcx                     ; col
+        pop     rsi
+        pop     rdi
+
+        add     rsi, byte SIZEOF_JSAMPROW       ; input_buf
+        add     rdi, byte SIZEOF_JSAMPROW
+        dec     rax                             ; num_rows
+        jg      near .rowloop
+
+.return:
+        pop     rbx
+        uncollect_args
+        mov     rsp,rbp         ; rsp <- aligned rbp
+        pop     rsp             ; rsp <- original rbp
+        pop     rbp
+        ret
+
+; For some reason, the OS X linker does not honor the request to align the
+; segment unless we do this.
+        align   32

--- a/simd/jcgryext-avx2-64.asm
+++ b/simd/jcgryext-avx2-64.asm
@@ -345,7 +345,7 @@ EXTN(jsimd_rgb_gray_convert_avx2):
 
         vpsllw     ymm0,ymm0,BYTE_BIT
         vpor       ymm6,ymm6,ymm0             ; ymm6=Y
-        vmovdqa    YMMWORD [rdi], ymm6   ; Save Y
+        vmovdqu    YMMWORD [rdi], ymm6   ; Save Y
 
         sub     rcx, byte SIZEOF_YMMWORD
         add     rsi, RGB_PIXELSIZE*SIZEOF_YMMWORD  ; inptr

--- a/simd/jcolsamp.inc
+++ b/simd/jcolsamp.inc
@@ -2,6 +2,7 @@
 ; jcolsamp.inc - private declarations for color conversion & up/downsampling
 ;
 ; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2015 Intel Corporation
 ;
 ; Based on
 ; x86 SIMD extension for IJG JPEG library
@@ -19,21 +20,29 @@
 %define  mmB  mm1
 %define xmmA xmm0
 %define xmmB xmm1
+%define ymmA ymm0
+%define ymmB ymm1
 %elif RGB_GREEN == 0
 %define  mmA  mm2
 %define  mmB  mm3
 %define xmmA xmm2
 %define xmmB xmm3
+%define ymmA ymm2
+%define ymmB ymm3
 %elif RGB_BLUE == 0
 %define  mmA  mm4
 %define  mmB  mm5
 %define xmmA xmm4
 %define xmmB xmm5
+%define ymmA ymm4
+%define ymmB ymm5
 %else
 %define  mmA  mm6
 %define  mmB  mm7
 %define xmmA xmm6
 %define xmmB xmm7
+%define ymmA ymm6
+%define ymmB ymm7
 %endif
 
 %if RGB_RED == 1
@@ -41,21 +50,29 @@
 %define  mmD  mm1
 %define xmmC xmm0
 %define xmmD xmm1
+%define ymmC ymm0
+%define ymmD ymm1
 %elif RGB_GREEN == 1
 %define  mmC  mm2
 %define  mmD  mm3
 %define xmmC xmm2
 %define xmmD xmm3
+%define ymmC ymm2
+%define ymmD ymm3
 %elif RGB_BLUE == 1
 %define  mmC  mm4
 %define  mmD  mm5
 %define xmmC xmm4
 %define xmmD xmm5
+%define ymmC ymm4
+%define ymmD ymm5
 %else
 %define  mmC  mm6
 %define  mmD  mm7
 %define xmmC xmm6
 %define xmmD xmm7
+%define ymmC ymm6
+%define ymmD ymm7
 %endif
 
 %if RGB_RED == 2
@@ -63,21 +80,29 @@
 %define  mmF  mm1
 %define xmmE xmm0
 %define xmmF xmm1
+%define ymmE ymm0
+%define ymmF ymm1
 %elif RGB_GREEN == 2
 %define  mmE  mm2
 %define  mmF  mm3
 %define xmmE xmm2
 %define xmmF xmm3
+%define ymmE ymm2
+%define ymmF ymm3
 %elif RGB_BLUE == 2
 %define  mmE  mm4
 %define  mmF  mm5
 %define xmmE xmm4
 %define xmmF xmm5
+%define ymmE ymm4
+%define ymmF ymm5
 %else
 %define  mmE  mm6
 %define  mmF  mm7
 %define xmmE xmm6
 %define xmmF xmm7
+%define ymmE ymm6
+%define ymmF ymm7
 %endif
 
 %if RGB_RED == 3
@@ -85,21 +110,29 @@
 %define  mmH  mm1
 %define xmmG xmm0
 %define xmmH xmm1
+%define ymmG ymm0
+%define ymmH ymm1
 %elif RGB_GREEN == 3
 %define  mmG  mm2
 %define  mmH  mm3
 %define xmmG xmm2
 %define xmmH xmm3
+%define ymmG ymm2
+%define ymmH ymm3
 %elif RGB_BLUE == 3
 %define  mmG  mm4
 %define  mmH  mm5
 %define xmmG xmm4
 %define xmmH xmm5
+%define ymmG ymm4
+%define ymmH ymm5
 %else
 %define  mmG  mm6
 %define  mmH  mm7
 %define xmmG xmm6
 %define xmmH xmm7
+%define ymmG ymm6
+%define ymmH ymm7
 %endif
 
 ; --------------------------------------------------------------------------

--- a/simd/jcsample-avx2-64.asm
+++ b/simd/jcsample-avx2-64.asm
@@ -1,0 +1,361 @@
+;
+; jcsample.asm - downsampling (64-bit AVX2) ;
+; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2009 D. R. Commander
+; Copyright 2015 Intel Corporation
+;
+; Based on
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be aavxmbled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; [TAB8]
+
+%include "jsimdext.inc"
+
+; --------------------------------------------------------------------------
+        SECTION SEG_TEXT
+        BITS    64
+;
+; Downsample pixel values of a single component.
+; This version handles the common case of 2:1 horizontal and 1:1 vertical,
+; without smoothing.
+;
+; GLOBAL(void)
+; jsimd_h2v1_downsample_avx2 (JDIMENSION image_width, int max_v_samp_factor,
+;                             JDIMENSION v_samp_factor, JDIMENSION width_blocks,
+;                             JSAMPARRAY input_data, JSAMPARRAY output_data);
+;
+
+; r10 = JDIMENSION image_width
+; r11 = int max_v_samp_factor
+; r12 = JDIMENSION v_samp_factor
+; r13 = JDIMENSION width_blocks
+; r14 = JSAMPARRAY input_data
+; r15 = JSAMPARRAY output_data
+
+        align   32
+        global  EXTN(jsimd_h2v1_downsample_avx2)
+
+EXTN(jsimd_h2v1_downsample_avx2):
+        push    rbp
+        mov     rax,rsp
+        mov     rbp,rsp
+        collect_args
+
+        mov rcx, r13
+        shl     rcx,3                   ; imul rcx,DCTSIZE (rcx = output_cols)
+        jz      near .return
+        mov rdx, r10
+
+        ; -- expand_right_edge
+
+        push    rcx
+        shl     rcx,1                           ; output_cols * 2
+        sub     rcx,rdx
+        jle     short .expand_end
+
+        mov     rax, r11
+        test    rax,rax
+        jle     short .expand_end
+
+        cld
+        mov     rsi, r14        ; input_data
+.expandloop:
+        push    rax
+        push    rcx
+
+        mov     rdi, JSAMPROW [rsi]
+        add     rdi,rdx
+        mov     al, JSAMPLE [rdi-1]
+
+        rep stosb
+
+        pop     rcx
+        pop     rax
+
+        add     rsi, byte SIZEOF_JSAMPROW
+        dec     rax
+        jg      short .expandloop
+
+.expand_end:
+        pop     rcx                    
+
+        ; -- h2v1_downsample
+
+        mov     rax, r12        ; rowctr
+        test    eax,eax
+        jle     near .return
+
+        mov     rdx, 0x00010000         ; bias pattern
+        vmovd    xmm7,edx
+        vpshufd  xmm7,xmm7,0x00         ; xmm7={0, 1, 0, 1, 0, 1, 0, 1}
+        vperm2i128 ymm7,ymm7,ymm7,0     ; ymm7={xmm7,xmm7}
+
+        vpcmpeqw ymm6,ymm6,ymm6
+        vpsrlw   ymm6,ymm6,BYTE_BIT     ; ymm6={0xFF 0x00 0xFF 0x00 ..}
+
+        mov     rsi, r14        ; input_data
+        mov     rdi, r15        ; output_data
+.rowloop:
+        push    rcx
+        push    rdi
+        push    rsi
+
+        mov     rsi, JSAMPROW [rsi]             ; inptr
+        mov rdi, JSAMPROW [rdi]         ; outptr
+
+        cmp     rcx, byte SIZEOF_YMMWORD
+        jae     short .columnloop
+
+.columnloop_r24:
+        ;rcx can possibly be 8,16,24
+        cmp rcx,  24
+        jne   .columnloop_r16
+        vmovdqa  ymm0, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqa  xmm1, XMMWORD [rsi+1*SIZEOF_YMMWORD]
+        mov     rcx, SIZEOF_YMMWORD
+        jmp     short .downsample
+.columnloop_r16:
+        cmp rcx,  16
+        jne   .columnloop_r8
+        vmovdqa  ymm0, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vpxor ymm1,ymm1,ymm1
+        mov     rcx, SIZEOF_YMMWORD
+        jmp     short .downsample
+.columnloop_r8:
+        vmovdqa xmm0,XMMWORD[rsi+0*SIZEOF_YMMWORD]
+        vpxor ymm1,ymm1,ymm1
+        mov     rcx, SIZEOF_YMMWORD
+        jmp     short .downsample
+
+.columnloop:
+        vmovdqa  ymm0, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqa  ymm1, YMMWORD [rsi+1*SIZEOF_YMMWORD]
+
+.downsample:
+        vpsrlw   ymm2,ymm0,BYTE_BIT
+        vpand    ymm0,ymm0,ymm6
+        vpsrlw   ymm3,ymm1,BYTE_BIT
+        vpand    ymm1,ymm1,ymm6
+
+        vpaddw   ymm0,ymm0,ymm2
+        vpaddw   ymm1,ymm1,ymm3
+        vpaddw   ymm0,ymm0,ymm7
+        vpaddw   ymm1,ymm1,ymm7
+        vpsrlw   ymm0,ymm0,1
+        vpsrlw   ymm1,ymm1,1
+
+        vpackuswb ymm0,ymm0,ymm1
+        vpermq ymm0,ymm0,0xd8
+
+        vmovdqa  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm0
+
+        sub     rcx, byte SIZEOF_YMMWORD        ; outcol
+        add     rsi, byte 2*SIZEOF_YMMWORD      ; inptr
+        add     rdi, byte 1*SIZEOF_YMMWORD      ; outptr
+        cmp     rcx, byte SIZEOF_YMMWORD
+        jae     short .columnloop
+        test    rcx,rcx
+        jnz     .columnloop_r24
+
+        pop     rsi
+        pop     rdi
+        pop     rcx
+
+        add     rsi, byte SIZEOF_JSAMPROW       ; input_data
+        add     rdi, byte SIZEOF_JSAMPROW       ; output_data
+        dec     rax                             ; rowctr
+        jg      near .rowloop
+
+.return:
+        uncollect_args
+        pop     rbp
+        ret
+
+; --------------------------------------------------------------------------
+;
+; Downsample pixel values of a single component.
+; This version handles the standard case of 2:1 horizontal and 2:1 vertical,
+; without smoothing.
+;
+; GLOBAL(void)
+; jsimd_h2v2_downsample_avx2 (JDIMENSION image_width, int max_v_samp_factor,
+;                             JDIMENSION v_samp_factor, JDIMENSION width_blocks,
+;                             JSAMPARRAY input_data, JSAMPARRAY output_data);
+;
+
+; r10 = JDIMENSION image_width
+; r11 = int max_v_samp_factor
+; r12 = JDIMENSION v_samp_factor
+; r13 = JDIMENSION width_blocks
+; r14 = JSAMPARRAY input_data
+; r15 = JSAMPARRAY output_data
+
+        align   32
+        global  EXTN(jsimd_h2v2_downsample_avx2)
+
+EXTN(jsimd_h2v2_downsample_avx2):
+        push    rbp
+        mov     rax,rsp
+        mov     rbp,rsp
+        collect_args
+
+        mov     rcx, r13
+        shl     rcx,3                   ; imul rcx,DCTSIZE (rcx = output_cols)
+        jz      near .return
+
+        mov     rdx, r10
+
+        ; -- expand_right_edge
+
+        push    rcx
+        shl     rcx,1                           ; output_cols * 2
+        sub     rcx,rdx
+        jle     short .expand_end
+
+        mov     rax, r11
+        test    rax,rax
+        jle     short .expand_end
+
+        cld
+        mov     rsi, r14        ; input_data
+.expandloop:
+        push    rax
+        push    rcx
+
+        mov     rdi, JSAMPROW [rsi]
+        add     rdi,rdx
+        mov     al, JSAMPLE [rdi-1]
+
+        rep stosb
+
+        pop     rcx
+        pop     rax
+
+        add     rsi, byte SIZEOF_JSAMPROW
+        dec     rax
+        jg      short .expandloop
+
+.expand_end:
+        pop     rcx                             ; output_cols = width*8
+
+        ; -- h2v2_downsample
+
+        mov     rax, r12        ; rowctr
+        test    rax,rax
+        jle     near .return
+
+        mov     rdx, 0x00020001         ; bias pattern
+        vmovd    xmm7,edx
+        vpcmpeqw ymm6,ymm6,ymm6
+        vpshufd  xmm7,xmm7,0x00          ; ymm7={1, 2, 1, 2, 1, 2, 1, 2}
+        vperm2i128 ymm7,ymm7,ymm7,0
+        vpsrlw   ymm6,ymm6,BYTE_BIT           ; ymm6={0xFF 0x00 0xFF 0x00 ..}
+
+        mov     rsi, r14        ; input_data
+        mov     rdi, r15        ; output_data
+.rowloop:
+        push    rcx
+        push    rdi
+        push    rsi
+
+        mov     rdx, JSAMPROW [rsi+0*SIZEOF_JSAMPROW]   ; inptr0
+        mov     rsi, JSAMPROW [rsi+1*SIZEOF_JSAMPROW]   ; inptr1
+        mov     rdi, JSAMPROW [rdi]                     ; outptr
+
+        cmp     rcx, byte SIZEOF_YMMWORD
+        jae     short .columnloop
+
+.columnloop_r24:
+;rcx can possibly be 8,16,24
+        cmp rcx,24
+        jne   .columnloop_r16
+        vmovdqa  ymm0, YMMWORD [rdx+0*SIZEOF_YMMWORD]
+        vmovdqa  ymm1, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqa xmm2,XMMWORD [rdx+1*SIZEOF_YMMWORD]
+        vmovdqa xmm3,XMMWORD [rsi+1*SIZEOF_YMMWORD]
+        mov     rcx, SIZEOF_YMMWORD
+        jmp     short .downsample
+.columnloop_r16:
+        cmp rcx,16
+        jne   .columnloop_r8
+        vmovdqa  ymm0, YMMWORD [rdx+0*SIZEOF_YMMWORD]
+        vmovdqa  ymm1, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vpxor    ymm2,ymm2,ymm2
+        vpxor    ymm3,ymm3,ymm3
+        mov     rcx, SIZEOF_YMMWORD
+        jmp     short .downsample
+.columnloop_r8:
+        vmovdqa  xmm0, XMMWORD [rdx+0*SIZEOF_XMMWORD]
+        vmovdqa  xmm1, XMMWORD [rsi+0*SIZEOF_XMMWORD]
+        vpxor    ymm2,ymm2,ymm2
+        vpxor    ymm3,ymm3,ymm3
+        mov     rcx, SIZEOF_YMMWORD
+        jmp     short .downsample
+
+.columnloop:
+        vmovdqa  ymm0, YMMWORD [rdx+0*SIZEOF_YMMWORD]
+        vmovdqa  ymm1, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqa  ymm2, YMMWORD [rdx+1*SIZEOF_YMMWORD]
+        vmovdqa  ymm3, YMMWORD [rsi+1*SIZEOF_YMMWORD]
+
+.downsample:
+        vpand    ymm4,ymm0,ymm6
+        vpsrlw   ymm0,ymm0,BYTE_BIT
+        vpand    ymm5,ymm1,ymm6
+        vpsrlw   ymm1,ymm1,BYTE_BIT
+        vpaddw   ymm0,ymm0,ymm4
+        vpaddw   ymm1,ymm1,ymm5
+
+        vpand    ymm4,ymm2,ymm6
+        vpsrlw   ymm2,ymm2,BYTE_BIT
+        vpand    ymm5,ymm3,ymm6
+        vpsrlw   ymm3,ymm3,BYTE_BIT
+        vpaddw   ymm2,ymm2,ymm4
+        vpaddw   ymm3,ymm3,ymm5
+
+        vpaddw   ymm0,ymm0,ymm1
+        vpaddw   ymm2,ymm2,ymm3
+        vpaddw   ymm0,ymm0,ymm7
+        vpaddw   ymm2,ymm2,ymm7
+        vpsrlw   ymm0,ymm0,2
+        vpsrlw   ymm2,ymm2,2
+
+        vpackuswb ymm0,ymm0,ymm2
+        vpermq ymm0,ymm0,0xd8
+
+        vmovdqa  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm0
+
+        sub     rcx, byte SIZEOF_YMMWORD        ; outcol
+        add     rdx, byte 2*SIZEOF_YMMWORD      ; inptr0
+        add     rsi, byte 2*SIZEOF_YMMWORD      ; inptr1
+        add     rdi, byte 1*SIZEOF_YMMWORD      ; outptr
+        cmp     rcx, byte SIZEOF_YMMWORD
+        jae     near .columnloop
+        test    rcx,rcx
+        jnz     near .columnloop_r24
+
+        pop     rsi
+        pop     rdi
+        pop     rcx
+
+        add     rsi, byte 2*SIZEOF_JSAMPROW     ; input_data
+        add     rdi, byte 1*SIZEOF_JSAMPROW     ; output_data
+        dec     rax                             ; rowctr
+        jg      near .rowloop
+
+.return:
+        uncollect_args
+        pop     rbp
+        ret
+
+; For some reason, the OS X linker does not honor the request to align the
+; segment unless we do this.
+        align   32

--- a/simd/jcsample-avx2-64.asm
+++ b/simd/jcsample-avx2-64.asm
@@ -118,26 +118,26 @@ EXTN(jsimd_h2v1_downsample_avx2):
         ;rcx can possibly be 8,16,24
         cmp rcx,  24
         jne   .columnloop_r16
-        vmovdqa  ymm0, YMMWORD [rsi+0*SIZEOF_YMMWORD]
-        vmovdqa  xmm1, XMMWORD [rsi+1*SIZEOF_YMMWORD]
+        vmovdqu  ymm0, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  xmm1, XMMWORD [rsi+1*SIZEOF_YMMWORD]
         mov     rcx, SIZEOF_YMMWORD
         jmp     short .downsample
 .columnloop_r16:
         cmp rcx,  16
         jne   .columnloop_r8
-        vmovdqa  ymm0, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymm0, YMMWORD [rsi+0*SIZEOF_YMMWORD]
         vpxor ymm1,ymm1,ymm1
         mov     rcx, SIZEOF_YMMWORD
         jmp     short .downsample
 .columnloop_r8:
-        vmovdqa xmm0,XMMWORD[rsi+0*SIZEOF_YMMWORD]
+        vmovdqu xmm0,XMMWORD[rsi+0*SIZEOF_YMMWORD]
         vpxor ymm1,ymm1,ymm1
         mov     rcx, SIZEOF_YMMWORD
         jmp     short .downsample
 
 .columnloop:
-        vmovdqa  ymm0, YMMWORD [rsi+0*SIZEOF_YMMWORD]
-        vmovdqa  ymm1, YMMWORD [rsi+1*SIZEOF_YMMWORD]
+        vmovdqu  ymm0, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymm1, YMMWORD [rsi+1*SIZEOF_YMMWORD]
 
 .downsample:
         vpsrlw   ymm2,ymm0,BYTE_BIT
@@ -155,7 +155,7 @@ EXTN(jsimd_h2v1_downsample_avx2):
         vpackuswb ymm0,ymm0,ymm1
         vpermq ymm0,ymm0,0xd8
 
-        vmovdqa  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm0
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm0
 
         sub     rcx, byte SIZEOF_YMMWORD        ; outcol
         add     rsi, byte 2*SIZEOF_YMMWORD      ; inptr
@@ -274,37 +274,36 @@ EXTN(jsimd_h2v2_downsample_avx2):
         jae     short .columnloop
 
 .columnloop_r24:
-;rcx can possibly be 8,16,24
         cmp rcx,24
         jne   .columnloop_r16
-        vmovdqa  ymm0, YMMWORD [rdx+0*SIZEOF_YMMWORD]
-        vmovdqa  ymm1, YMMWORD [rsi+0*SIZEOF_YMMWORD]
-        vmovdqa xmm2,XMMWORD [rdx+1*SIZEOF_YMMWORD]
-        vmovdqa xmm3,XMMWORD [rsi+1*SIZEOF_YMMWORD]
+        vmovdqu  ymm0, YMMWORD [rdx+0*SIZEOF_YMMWORD]
+        vmovdqu  ymm1, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu xmm2,XMMWORD [rdx+1*SIZEOF_YMMWORD]
+        vmovdqu xmm3,XMMWORD [rsi+1*SIZEOF_YMMWORD]
         mov     rcx, SIZEOF_YMMWORD
         jmp     short .downsample
 .columnloop_r16:
         cmp rcx,16
         jne   .columnloop_r8
-        vmovdqa  ymm0, YMMWORD [rdx+0*SIZEOF_YMMWORD]
-        vmovdqa  ymm1, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymm0, YMMWORD [rdx+0*SIZEOF_YMMWORD]
+        vmovdqu  ymm1, YMMWORD [rsi+0*SIZEOF_YMMWORD]
         vpxor    ymm2,ymm2,ymm2
         vpxor    ymm3,ymm3,ymm3
         mov     rcx, SIZEOF_YMMWORD
         jmp     short .downsample
 .columnloop_r8:
-        vmovdqa  xmm0, XMMWORD [rdx+0*SIZEOF_XMMWORD]
-        vmovdqa  xmm1, XMMWORD [rsi+0*SIZEOF_XMMWORD]
+        vmovdqu  xmm0, XMMWORD [rdx+0*SIZEOF_XMMWORD]
+        vmovdqu  xmm1, XMMWORD [rsi+0*SIZEOF_XMMWORD]
         vpxor    ymm2,ymm2,ymm2
         vpxor    ymm3,ymm3,ymm3
         mov     rcx, SIZEOF_YMMWORD
         jmp     short .downsample
 
 .columnloop:
-        vmovdqa  ymm0, YMMWORD [rdx+0*SIZEOF_YMMWORD]
-        vmovdqa  ymm1, YMMWORD [rsi+0*SIZEOF_YMMWORD]
-        vmovdqa  ymm2, YMMWORD [rdx+1*SIZEOF_YMMWORD]
-        vmovdqa  ymm3, YMMWORD [rsi+1*SIZEOF_YMMWORD]
+        vmovdqu  ymm0, YMMWORD [rdx+0*SIZEOF_YMMWORD]
+        vmovdqu  ymm1, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymm2, YMMWORD [rdx+1*SIZEOF_YMMWORD]
+        vmovdqu  ymm3, YMMWORD [rsi+1*SIZEOF_YMMWORD]
 
 .downsample:
         vpand    ymm4,ymm0,ymm6
@@ -331,7 +330,7 @@ EXTN(jsimd_h2v2_downsample_avx2):
         vpackuswb ymm0,ymm0,ymm2
         vpermq ymm0,ymm0,0xd8
 
-        vmovdqa  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm0
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm0
 
         sub     rcx, byte SIZEOF_YMMWORD        ; outcol
         add     rdx, byte 2*SIZEOF_YMMWORD      ; inptr0

--- a/simd/jdcolext-avx2-64.asm
+++ b/simd/jdcolext-avx2-64.asm
@@ -1,0 +1,434 @@
+;
+; jdcolext.asm - colorspace conversion (64-bit AVX2)
+;
+; Copyright 2009, 2012 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2009, 2012 D. R. Commander
+; Copyright 2015, Intel Corporation
+;
+; Based on
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; [TAB8]
+
+;TODO
+;Need check -tile (for small image)
+;May improve perforance by remove some code, fg 'collect_args'
+
+%include "jcolsamp.inc"
+
+; --------------------------------------------------------------------------
+;
+; Convert some rows of samples to the output colorspace.
+;
+; GLOBAL(void)
+; jsimd_ycc_rgb_convert_avx2 (JDIMENSION out_width,
+;                             JSAMPIMAGE input_buf, JDIMENSION input_row,
+;                             JSAMPARRAY output_buf, int num_rows)
+;
+
+; r10 = JDIMENSION out_width
+; r11 = JSAMPIMAGE input_buf
+; r12 = JDIMENSION input_row
+; r13 = JSAMPARRAY output_buf
+; r14 = int num_rows
+
+%define wk(i)           rbp-(WK_NUM-(i))*SIZEOF_YMMWORD ; ymmword wk[WK_NUM]
+%define WK_NUM          2
+
+        align   32
+        global  EXTN(jsimd_ycc_rgb_convert_avx2)
+
+EXTN(jsimd_ycc_rgb_convert_avx2):
+        push    rbp
+        mov     rax,rsp                         ; rax = original rbp
+        sub     rsp, byte 4
+        and     rsp, byte (-SIZEOF_YMMWORD)     ; align to 128 bits
+        mov     [rsp],rax
+        mov     rbp,rsp                         ; rbp = aligned rbp
+        lea     rsp, [wk(0)]
+        collect_args
+        push    rbx
+
+        mov     rcx, r10        ; num_cols
+        test    rcx,rcx
+        jz      near .return
+
+        push    rcx
+
+        mov     rdi, r11
+        mov     rcx, r12
+        mov     rsi, JSAMPARRAY [rdi+0*SIZEOF_JSAMPARRAY]
+        mov     rbx, JSAMPARRAY [rdi+1*SIZEOF_JSAMPARRAY]
+        mov     rdx, JSAMPARRAY [rdi+2*SIZEOF_JSAMPARRAY]
+        lea     rsi, [rsi+rcx*SIZEOF_JSAMPROW]
+        lea     rbx, [rbx+rcx*SIZEOF_JSAMPROW]
+        lea     rdx, [rdx+rcx*SIZEOF_JSAMPROW]
+
+        pop     rcx
+
+        mov     rdi, r13
+        mov     eax, r14d
+        test    rax,rax
+        jle     near .return
+.rowloop:
+        push    rax
+        push    rdi
+        push    rdx
+        push    rbx
+        push    rsi
+        push    rcx                     
+
+        mov     rsi, JSAMPROW [rsi]     
+        mov     rbx, JSAMPROW [rbx]     
+        mov     rdx, JSAMPROW [rdx]     
+        mov     rdi, JSAMPROW [rdi]     
+.columnloop:
+
+        vmovdqa  ymm5, YMMWORD [rbx]     
+        vmovdqa  ymm1, YMMWORD [rdx]     
+
+        vpcmpeqw ymm0,ymm0,ymm0
+        vpcmpeqw ymm7,ymm7,ymm7
+        vpsrlw   ymm0,ymm0,BYTE_BIT
+        vpsllw   ymm7,ymm7,7                  
+
+        vpand    ymm4,ymm0,ymm5               
+        vpsrlw   ymm5,ymm5,BYTE_BIT           
+        vpand    ymm0,ymm0,ymm1               
+        vpsrlw   ymm1,ymm1,BYTE_BIT           
+
+        vpaddw   ymm2,ymm4,ymm7
+        vpaddw   ymm3,ymm5,ymm7
+        vpaddw   ymm6,ymm0,ymm7
+        vpaddw   ymm7,ymm1,ymm7
+
+        vpaddw   ymm4,ymm2,ymm2               
+        vpaddw   ymm5,ymm3,ymm3               
+        vpaddw   ymm0,ymm6,ymm6               
+        vpaddw   ymm1,ymm7,ymm7               
+
+        vpmulhw  ymm4,ymm4,[rel PW_MF0228]    
+        vpmulhw  ymm5,ymm5,[rel PW_MF0228]    
+        vpmulhw  ymm0,ymm0,[rel PW_F0402]     
+        vpmulhw  ymm1,ymm1,[rel PW_F0402]     
+
+        vpaddw   ymm4,ymm4,[rel PW_ONE]
+        vpaddw   ymm5,ymm5,[rel PW_ONE]
+        vpsraw   ymm4,ymm4,1                  
+        vpsraw   ymm5,ymm5,1                  
+        vpaddw   ymm0,ymm0,[rel PW_ONE]
+        vpaddw   ymm1,ymm1,[rel PW_ONE]
+        vpsraw   ymm0,ymm0,1                  
+        vpsraw   ymm1,ymm1,1                  
+
+        vpaddw   ymm4,ymm4,ymm2
+        vpaddw   ymm5,ymm5,ymm3
+        vpaddw   ymm4,ymm4,ymm2               
+        vpaddw   ymm5,ymm5,ymm3               
+        vpaddw   ymm0,ymm0,ymm6               
+        vpaddw   ymm1,ymm1,ymm7               
+
+        vmovdqa  YMMWORD [wk(0)], ymm4   
+        vmovdqa  YMMWORD [wk(1)], ymm5   
+
+        vpunpckhwd ymm4,ymm2,ymm6     				
+        vpunpcklwd ymm2,ymm2,ymm6
+        vpmaddwd   ymm2,ymm2,[rel PW_MF0344_F0285]
+        vpmaddwd   ymm4,ymm4,[rel PW_MF0344_F0285]
+        vpunpckhwd ymm5,ymm3,ymm7
+        vpunpcklwd ymm3,ymm3,ymm7
+        vpmaddwd   ymm3,ymm3,[rel PW_MF0344_F0285]
+        vpmaddwd   ymm5,ymm5,[rel PW_MF0344_F0285]
+
+        vpaddd     ymm2,ymm2,[rel PD_ONEHALF]
+        vpaddd     ymm4,ymm4,[rel PD_ONEHALF]
+        vpsrad     ymm2,ymm2,SCALEBITS
+        vpsrad     ymm4,ymm4,SCALEBITS
+        vpaddd     ymm3,ymm3,[rel PD_ONEHALF]
+        vpaddd     ymm5,ymm5,[rel PD_ONEHALF]
+        vpsrad     ymm3,ymm3,SCALEBITS
+        vpsrad     ymm5,ymm5,SCALEBITS
+
+        vpackssdw  ymm2,ymm2,ymm4     
+        vpackssdw  ymm3,ymm3,ymm5     
+        vpsubw     ymm2,ymm2,ymm6     
+        vpsubw     ymm3,ymm3,ymm7     
+
+        vmovdqa    ymm5, YMMWORD [rsi]   
+
+        vpcmpeqw   ymm4,ymm4,ymm4
+        vpsrlw     ymm4,ymm4,BYTE_BIT         
+        vpand      ymm4,ymm4,ymm5             
+        vpsrlw     ymm5,ymm5,BYTE_BIT         
+
+        vpaddw     ymm0,ymm0,ymm4             
+        vpaddw     ymm1,ymm1,ymm5             
+        vpackuswb  ymm0,ymm0,ymm0             
+        vpackuswb  ymm1,ymm1,ymm1             
+
+        vpaddw     ymm2,ymm2,ymm4             
+        vpaddw     ymm3,ymm3,ymm5             
+        vpackuswb  ymm2,ymm2,ymm2             
+        vpackuswb  ymm3,ymm3,ymm3             
+
+        vpaddw     ymm4,ymm4, YMMWORD [wk(0)] 
+        vpaddw     ymm5,ymm5, YMMWORD [wk(1)] 
+        vpackuswb  ymm4,ymm4,ymm4             
+        vpackuswb  ymm5,ymm5,ymm5             
+
+%if RGB_PIXELSIZE == 3 ; ---------------
+
+        vpunpcklbw ymmA,ymmA,ymmC     
+        vpunpcklbw ymmE,ymmE,ymmB     
+        vpunpcklbw ymmD,ymmD,ymmF     
+
+        vpsrldq    ymmH,ymmA,2        
+        vpunpckhwd ymmG,ymmA,ymmE     
+        vpunpcklwd ymmA,ymmA,ymmE     
+
+        vpsrldq    ymmE,ymmE,2        
+
+        vmovdqa    ymmC,ymmD
+        vpsrldq    ymmB,ymmD,2        
+        vpunpckhwd ymmC,ymmD,ymmH     
+        vpunpcklwd ymmD,ymmD,ymmH     
+
+        vpunpckhwd ymmF,ymmE,ymmB     
+        vpunpcklwd ymmE,ymmE,ymmB     
+
+        vpshufd    ymmH,ymmA,0x4E
+        vpunpckldq ymmA,ymmA,ymmD
+        vpunpckhdq ymmD,ymmD,ymmE     
+        vpunpckldq ymmE,ymmE,ymmH     
+
+        vpshufd    ymmH,ymmG,0x4E
+        vpunpckldq ymmG,ymmG,ymmC     
+        vpunpckhdq ymmC,ymmC,ymmF     
+        vpunpckldq ymmF,ymmF,ymmH     
+
+        vpunpcklqdq ymmH,ymmA,ymmE    
+        vpunpcklqdq ymmG,ymmD,ymmG    
+        vpunpcklqdq ymmC,ymmF,ymmC    
+
+        vperm2i128 ymmA,ymmH,ymmG,0x20
+        vperm2i128 ymmD,ymmC,ymmH,0x30
+        vperm2i128 ymmF,ymmG,ymmC,0x31
+
+        cmp     rcx, byte SIZEOF_YMMWORD
+        jb      short .column_st64
+
+        test    rdi, SIZEOF_YMMWORD-1
+        jnz     short .out1
+        ; --(aligned)-------------------
+        vmovntdq YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        vmovntdq YMMWORD [rdi+1*SIZEOF_YMMWORD], ymmD
+        vmovntdq YMMWORD [rdi+2*SIZEOF_YMMWORD], ymmF
+        jmp     short .out0
+.out1:  ; --(unaligned)-----------------
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        vmovdqu  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymmD
+        vmovdqu  YMMWORD [rdi+2*SIZEOF_YMMWORD], ymmF
+.out0:
+        add     rdi, byte RGB_PIXELSIZE*SIZEOF_YMMWORD  ; outptr
+        sub     rcx, byte SIZEOF_YMMWORD
+        jz      near .nextrow
+
+        add     rsi, byte SIZEOF_YMMWORD        ; inptr0
+        add     rbx, byte SIZEOF_YMMWORD        ; inptr1
+        add     rdx, byte SIZEOF_YMMWORD        ; inptr2
+        jmp     near .columnloop
+
+.column_st64:
+				lea     rcx, [rcx+rcx*2]                ; imul ecx, RGB_PIXELSIZE
+				cmp     rcx, byte 2*SIZEOF_YMMWORD
+				jb      short .column_st32
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        vmovdqu  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymmD
+        add     rdi, byte 2*SIZEOF_YMMWORD      ; outptr
+        vmovdqa  ymmA,ymmF
+        sub     rcx, byte 2*SIZEOF_YMMWORD
+        jmp     short .column_st31
+.column_st32:
+        cmp     rcx, byte SIZEOF_YMMWORD
+        jb      short .column_st31
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        add     rdi, byte SIZEOF_YMMWORD      ; outptr
+        vmovdqa  ymmA,ymmD
+        sub     rcx, byte SIZEOF_YMMWORD
+        jmp     short .column_st31
+.column_st31:
+        cmp     rcx, byte SIZEOF_XMMWORD
+        jb      short .column_st15
+        vmovdqu  XMMWORD [rdi+0*SIZEOF_XMMWORD], xmmA
+        add     rdi, byte SIZEOF_XMMWORD        ; outptr
+		vperm2i128 ymmA,ymmA,ymmA,1
+		sub     rcx, byte SIZEOF_XMMWORD
+.column_st15:
+        ; Store the lower 8 bytes of xmmA to the output when it has enough
+        ; space.
+        cmp     rcx, byte SIZEOF_MMWORD
+        jb      short .column_st7
+        vmovq    XMM_MMWORD [rdi], xmmA
+        add     rdi, byte SIZEOF_MMWORD
+        sub     rcx, byte SIZEOF_MMWORD
+        vpsrldq  xmmA,xmmA, SIZEOF_MMWORD
+.column_st7:
+        ; Store the lower 4 bytes of xmmA to the output when it has enough
+        ; space.
+        cmp     rcx, byte SIZEOF_DWORD
+        jb      short .column_st3
+        vmovd    XMM_DWORD [rdi], xmmA
+        add     rdi, byte SIZEOF_DWORD
+        sub     rcx, byte SIZEOF_DWORD
+        vpsrldq xmmA, xmmA, SIZEOF_DWORD
+.column_st3:
+        ; Store the lower 2 bytes of rax to the output when it has enough
+        ; space.
+        vmovd    eax, xmmA
+        cmp     rcx, byte SIZEOF_WORD
+        jb      short .column_st1
+        mov     WORD [rdi], ax
+        add     rdi, byte SIZEOF_WORD
+        sub     rcx, byte SIZEOF_WORD
+        shr     rax, 16
+.column_st1:
+        ; Store the lower 1 byte of rax to the output when it has enough
+        ; space.
+        test    rcx, rcx
+        jz      short .nextrow
+        mov     BYTE [rdi], al
+
+%else ; RGB_PIXELSIZE == 4 ; -----------
+
+%ifdef RGBX_FILLER_0XFF
+        vpcmpeqb   ymm6,ymm6,ymm6             
+        vpcmpeqb   ymm7,ymm7,ymm7             
+%else
+        vpxor      ymm6,ymm6,ymm6             
+        vpxor      ymm7,ymm7,ymm7             
+%endif
+
+        vpunpcklbw ymmA,ymmA,ymmC     
+        vpunpcklbw ymmE,ymmE,ymmG     
+        vpunpcklbw ymmB,ymmB,ymmD     
+        vpunpcklbw ymmF,ymmF,ymmH     
+
+        vpunpckhwd ymmC,ymmA,ymmE     
+        vpunpcklwd ymmA,ymmA,ymmE     
+        vpunpckhwd ymmG,ymmB,ymmF     
+        vpunpcklwd ymmB,ymmB,ymmF     
+
+        vpunpckhdq ymmE,ymmA,ymmB     
+        vpunpckldq ymmB,ymmA,ymmB     
+        vpunpckhdq ymmF,ymmC,ymmG     
+        vpunpckldq ymmG,ymmC,ymmG     
+
+
+        vperm2i128 ymmA, ymmB,ymmE,0x20
+        vperm2i128 ymmD, ymmG,ymmF,0x20
+        vperm2i128 ymmC, ymmB,ymmE,0x31
+        vperm2i128 ymmH, ymmG,ymmF,0x31
+
+        cmp     rcx, byte SIZEOF_YMMWORD
+        jb      short .column_st64
+
+        test    rdi, SIZEOF_YMMWORD-1
+        jnz     short .out1
+        ; --(aligned)-------------------
+        vmovntdq YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        vmovntdq YMMWORD [rdi+1*SIZEOF_YMMWORD], ymmD
+        vmovntdq YMMWORD [rdi+2*SIZEOF_YMMWORD], ymmC
+        vmovntdq YMMWORD [rdi+3*SIZEOF_YMMWORD], ymmH
+        jmp     short .out0
+.out1:  ; --(unaligned)-----------------
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        vmovdqu  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymmD
+        vmovdqu  YMMWORD [rdi+2*SIZEOF_YMMWORD], ymmC
+        vmovdqu  YMMWORD [rdi+3*SIZEOF_YMMWORD], ymmH
+.out0:
+        add     rdi, RGB_PIXELSIZE*SIZEOF_YMMWORD  ; outptr
+        sub     rcx, byte SIZEOF_YMMWORD
+        jz      near .nextrow
+
+        add     rsi, byte SIZEOF_YMMWORD        ; inptr0
+        add     rbx, byte SIZEOF_YMMWORD        ; inptr1
+        add     rdx, byte SIZEOF_YMMWORD        ; inptr2
+        jmp     near .columnloop
+
+.column_st64:
+        cmp     rcx, byte SIZEOF_YMMWORD/2
+        jb      short .column_st32
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        vmovdqu  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymmD
+        add     rdi, byte 2*SIZEOF_YMMWORD      ; outptr
+        vmovdqa  ymmA,ymmC
+        vmovdqa  ymmD,ymmH
+        sub     rcx, byte SIZEOF_YMMWORD/2
+.column_st32:
+    		cmp     rcx, byte SIZEOF_YMMWORD/4
+        jb      short .column_st16
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        add     rdi, byte SIZEOF_YMMWORD      ; outptr
+        vmovdqa  ymmA,ymmD
+        sub     rcx, byte SIZEOF_YMMWORD/4
+.column_st16:
+        cmp     rcx, byte SIZEOF_YMMWORD/8
+        jb      short .column_st15
+        vmovdqu  XMMWORD [rdi+0*SIZEOF_XMMWORD], xmmA
+        vperm2i128 ymmA,ymmA,ymmA,1
+        add     rdi, byte SIZEOF_XMMWORD        ; outptr
+        sub     rcx, byte SIZEOF_YMMWORD/8
+.column_st15:
+        ; Store two pixels (8 bytes) of ymmA to the output when it has enough
+        ; space.
+        cmp     rcx, byte SIZEOF_YMMWORD/16
+        jb      short .column_st7
+        vmovq    MMWORD [rdi], xmmA
+        add     rdi, byte 8 
+        sub     rcx, byte 2
+        vpsrldq  xmmA, 8
+.column_st7:
+        ; Store one pixel (4 bytes) of ymmA to the output when it has enough
+        ; space.
+        test    rcx, rcx
+        jz      short .nextrow
+        vmovd    XMM_DWORD [rdi], xmmA
+
+%endif ; RGB_PIXELSIZE ; ---------------
+
+.nextrow:
+        pop     rcx
+        pop     rsi
+        pop     rbx
+        pop     rdx
+        pop     rdi
+        pop     rax
+
+        add     rsi, byte SIZEOF_JSAMPROW
+        add     rbx, byte SIZEOF_JSAMPROW
+        add     rdx, byte SIZEOF_JSAMPROW
+        add     rdi, byte SIZEOF_JSAMPROW       ; output_buf
+        dec     rax                             ; num_rows
+        jg      near .rowloop
+
+        sfence          ; flush the write buffer
+
+.return:
+        pop     rbx
+        uncollect_args
+        mov     rsp,rbp         ; rsp <- aligned rbp
+        pop     rsp             ; rsp <- original rbp
+        pop     rbp
+        ret
+
+; For some reason, the OS X linker does not honor the request to align the
+; segment unless we do this.
+        align   32

--- a/simd/jdcolext-avx2-64.asm
+++ b/simd/jdcolext-avx2-64.asm
@@ -92,8 +92,8 @@ EXTN(jsimd_ycc_rgb_convert_avx2):
         mov     rdi, JSAMPROW [rdi]     
 .columnloop:
 
-        vmovdqa  ymm5, YMMWORD [rbx]     
-        vmovdqa  ymm1, YMMWORD [rdx]     
+        vmovdqu  ymm5, YMMWORD [rbx]     
+        vmovdqu  ymm1, YMMWORD [rdx]     
 
         vpcmpeqw ymm0,ymm0,ymm0
         vpcmpeqw ymm7,ymm7,ymm7
@@ -162,7 +162,7 @@ EXTN(jsimd_ycc_rgb_convert_avx2):
         vpsubw     ymm2,ymm2,ymm6     
         vpsubw     ymm3,ymm3,ymm7     
 
-        vmovdqa    ymm5, YMMWORD [rsi]   
+        vmovdqu    ymm5, YMMWORD [rsi]   
 
         vpcmpeqw   ymm4,ymm4,ymm4
         vpsrlw     ymm4,ymm4,BYTE_BIT         

--- a/simd/jdcolor-avx2-64.asm
+++ b/simd/jdcolor-avx2-64.asm
@@ -1,0 +1,121 @@
+;
+; jdcolor.asm - colorspace conversion (64-bit AVX2)
+;
+; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2009 D. R. Commander
+; Copyright 2015 Intel Corporation
+;
+; Based on
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; [TAB8]
+
+%include "jsimdext.inc"
+
+; --------------------------------------------------------------------------
+
+%define SCALEBITS       16
+
+F_0_344 equ      22554                  ; FIX(0.34414)
+F_0_714 equ      46802                  ; FIX(0.71414)
+F_1_402 equ      91881                  ; FIX(1.40200)
+F_1_772 equ     116130                  ; FIX(1.77200)
+F_0_402 equ     (F_1_402 - 65536)       ; FIX(1.40200) - FIX(1)
+F_0_285 equ     ( 65536 - F_0_714)      ; FIX(1) - FIX(0.71414)
+F_0_228 equ     (131072 - F_1_772)      ; FIX(2) - FIX(1.77200)
+
+; --------------------------------------------------------------------------
+        SECTION SEG_CONST
+
+        alignz  32
+        global  EXTN(jconst_ycc_rgb_convert_avx2)
+
+EXTN(jconst_ycc_rgb_convert_avx2):
+
+PW_F0402        times 16 dw  F_0_402
+PW_MF0228       times 16 dw -F_0_228
+PW_MF0344_F0285 times 8  dw -F_0_344, F_0_285
+PW_ONE          times 16 dw  1
+PD_ONEHALF      times 8  dd  1 << (SCALEBITS-1)
+
+        alignz  32
+
+; --------------------------------------------------------------------------
+        SECTION SEG_TEXT
+        BITS    64
+
+%include "jdcolext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_RGB_RED
+%define RGB_GREEN EXT_RGB_GREEN
+%define RGB_BLUE EXT_RGB_BLUE
+%define RGB_PIXELSIZE EXT_RGB_PIXELSIZE
+%define jsimd_ycc_rgb_convert_avx2 jsimd_ycc_extrgb_convert_avx2
+%include "jdcolext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_RGBX_RED
+%define RGB_GREEN EXT_RGBX_GREEN
+%define RGB_BLUE EXT_RGBX_BLUE
+%define RGB_PIXELSIZE EXT_RGBX_PIXELSIZE
+%define jsimd_ycc_rgb_convert_avx2 jsimd_ycc_extrgbx_convert_avx2
+%include "jdcolext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_BGR_RED
+%define RGB_GREEN EXT_BGR_GREEN
+%define RGB_BLUE EXT_BGR_BLUE
+%define RGB_PIXELSIZE EXT_BGR_PIXELSIZE
+%define jsimd_ycc_rgb_convert_avx2 jsimd_ycc_extbgr_convert_avx2
+%include "jdcolext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_BGRX_RED
+%define RGB_GREEN EXT_BGRX_GREEN
+%define RGB_BLUE EXT_BGRX_BLUE
+%define RGB_PIXELSIZE EXT_BGRX_PIXELSIZE
+%define jsimd_ycc_rgb_convert_avx2 jsimd_ycc_extbgrx_convert_avx2
+%include "jdcolext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_XBGR_RED
+%define RGB_GREEN EXT_XBGR_GREEN
+%define RGB_BLUE EXT_XBGR_BLUE
+%define RGB_PIXELSIZE EXT_XBGR_PIXELSIZE
+%define jsimd_ycc_rgb_convert_avx2 jsimd_ycc_extxbgr_convert_avx2
+%include "jdcolext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_XRGB_RED
+%define RGB_GREEN EXT_XRGB_GREEN
+%define RGB_BLUE EXT_XRGB_BLUE
+%define RGB_PIXELSIZE EXT_XRGB_PIXELSIZE
+%define jsimd_ycc_rgb_convert_avx2 jsimd_ycc_extxrgb_convert_avx2
+%include "jdcolext-avx2-64.asm"

--- a/simd/jdct.inc
+++ b/simd/jdct.inc
@@ -2,6 +2,7 @@
 ; jdct.inc - private declarations for forward & reverse DCT subsystems
 ;
 ; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2015 Intel Corporation
 ;
 ; Based on
 ; x86 SIMD extension for IJG JPEG library
@@ -24,5 +25,6 @@
 %define DWBLOCK(m,n,b,s)        ((b)+(m)*DCTSIZE*(s)+(n)*SIZEOF_DWORD)
 %define MMBLOCK(m,n,b,s)        ((b)+(m)*DCTSIZE*(s)+(n)*SIZEOF_MMWORD)
 %define XMMBLOCK(m,n,b,s)       ((b)+(m)*DCTSIZE*(s)+(n)*SIZEOF_XMMWORD)
+%define YMMBLOCK(m,n,b,s)       ((b)+(m)*DCTSIZE*(s)+(n)*SIZEOF_YMMWORD)
 
 ; --------------------------------------------------------------------------

--- a/simd/jdmerge-avx2-64.asm
+++ b/simd/jdmerge-avx2-64.asm
@@ -1,0 +1,127 @@
+;
+; jdmerge.asm - merged upsampling/color conversion (AVX2)
+;
+; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2009 D. R. Commander
+; Copyright 2015 Intel Corporation
+;
+; Based on
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; [TAB8]
+
+%include "jsimdext.inc"
+
+; --------------------------------------------------------------------------
+
+%define SCALEBITS       16
+
+F_0_344 equ      22554                  ; FIX(0.34414)
+F_0_714 equ      46802                  ; FIX(0.71414)
+F_1_402 equ      91881                  ; FIX(1.40200)
+F_1_772 equ     116130                  ; FIX(1.77200)
+F_0_402 equ     (F_1_402 - 65536)       ; FIX(1.40200) - FIX(1)
+F_0_285 equ     ( 65536 - F_0_714)      ; FIX(1) - FIX(0.71414)
+F_0_228 equ     (131072 - F_1_772)      ; FIX(2) - FIX(1.77200)
+
+; --------------------------------------------------------------------------
+        SECTION SEG_CONST
+
+        alignz  32
+        global  EXTN(jconst_merged_upsample_avx2)
+
+EXTN(jconst_merged_upsample_avx2):
+
+PW_F0402        times 16 dw  F_0_402
+PW_MF0228       times 16 dw -F_0_228
+PW_MF0344_F0285 times 8 dw -F_0_344, F_0_285
+PW_ONE          times 16 dw  1
+PD_ONEHALF      times 8 dd  1 << (SCALEBITS-1)
+
+        alignz  32
+
+; --------------------------------------------------------------------------
+        SECTION SEG_TEXT
+        BITS    64
+
+%include "jdmrgext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_RGB_RED
+%define RGB_GREEN EXT_RGB_GREEN
+%define RGB_BLUE EXT_RGB_BLUE
+%define RGB_PIXELSIZE EXT_RGB_PIXELSIZE
+%define jsimd_h2v1_merged_upsample_avx2 jsimd_h2v1_extrgb_merged_upsample_avx2
+%define jsimd_h2v2_merged_upsample_avx2 jsimd_h2v2_extrgb_merged_upsample_avx2
+%include "jdmrgext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_RGBX_RED
+%define RGB_GREEN EXT_RGBX_GREEN
+%define RGB_BLUE EXT_RGBX_BLUE
+%define RGB_PIXELSIZE EXT_RGBX_PIXELSIZE
+%define jsimd_h2v1_merged_upsample_avx2 jsimd_h2v1_extrgbx_merged_upsample_avx2
+%define jsimd_h2v2_merged_upsample_avx2 jsimd_h2v2_extrgbx_merged_upsample_avx2
+%include "jdmrgext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_BGR_RED
+%define RGB_GREEN EXT_BGR_GREEN
+%define RGB_BLUE EXT_BGR_BLUE
+%define RGB_PIXELSIZE EXT_BGR_PIXELSIZE
+%define jsimd_h2v1_merged_upsample_avx2 jsimd_h2v1_extbgr_merged_upsample_avx2
+%define jsimd_h2v2_merged_upsample_avx2 jsimd_h2v2_extbgr_merged_upsample_avx2
+%include "jdmrgext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_BGRX_RED
+%define RGB_GREEN EXT_BGRX_GREEN
+%define RGB_BLUE EXT_BGRX_BLUE
+%define RGB_PIXELSIZE EXT_BGRX_PIXELSIZE
+%define jsimd_h2v1_merged_upsample_avx2 jsimd_h2v1_extbgrx_merged_upsample_avx2
+%define jsimd_h2v2_merged_upsample_avx2 jsimd_h2v2_extbgrx_merged_upsample_avx2
+%include "jdmrgext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_XBGR_RED
+%define RGB_GREEN EXT_XBGR_GREEN
+%define RGB_BLUE EXT_XBGR_BLUE
+%define RGB_PIXELSIZE EXT_XBGR_PIXELSIZE
+%define jsimd_h2v1_merged_upsample_avx2 jsimd_h2v1_extxbgr_merged_upsample_avx2
+%define jsimd_h2v2_merged_upsample_avx2 jsimd_h2v2_extxbgr_merged_upsample_avx2
+%include "jdmrgext-avx2-64.asm"
+
+%undef RGB_RED
+%undef RGB_GREEN
+%undef RGB_BLUE
+%undef RGB_PIXELSIZE
+%define RGB_RED EXT_XRGB_RED
+%define RGB_GREEN EXT_XRGB_GREEN
+%define RGB_BLUE EXT_XRGB_BLUE
+%define RGB_PIXELSIZE EXT_XRGB_PIXELSIZE
+%define jsimd_h2v1_merged_upsample_avx2 jsimd_h2v1_extxrgb_merged_upsample_avx2
+%define jsimd_h2v2_merged_upsample_avx2 jsimd_h2v2_extxrgb_merged_upsample_avx2
+%include "jdmrgext-avx2-64.asm"

--- a/simd/jdmrgext-avx2-64.asm
+++ b/simd/jdmrgext-avx2-64.asm
@@ -74,8 +74,8 @@ EXTN(jsimd_h2v1_merged_upsample_avx2):
 
 .columnloop:
 
-        vmovdqa    ymm6, YMMWORD [rbx]   ; ymm6=Cb(0123456789ABCDEF)
-        vmovdqa    ymm7, YMMWORD [rdx]   ; ymm7=Cr(0123456789ABCDEF)
+        vmovdqu    ymm6, YMMWORD [rbx]   ; ymm6=Cb(0123456789ABCDEF)
+        vmovdqu    ymm7, YMMWORD [rdx]   ; ymm7=Cr(0123456789ABCDEF)
 
         vpxor      ymm1,ymm1,ymm1             ; ymm1=(all 0's)
         vpcmpeqw   ymm3,ymm3,ymm3
@@ -166,7 +166,7 @@ EXTN(jsimd_h2v1_merged_upsample_avx2):
         vmovdqa  ymm4, YMMWORD [wk(0)]   ; ymm4=(B-Y)H
 
 .Yloop_1st:
-        vmovdqa  ymm7, YMMWORD [rsi]     ; ymm7=Y(0123456789ABCDEF)
+        vmovdqu  ymm7, YMMWORD [rsi]     ; ymm7=Y(0123456789ABCDEF)
 
         vpcmpeqw ymm6,ymm6,ymm6
         vpsrlw   ymm6,ymm6,BYTE_BIT           ; ymm6={0xFF 0x00 0xFF 0x00 ..}

--- a/simd/jdmrgext-avx2-64.asm
+++ b/simd/jdmrgext-avx2-64.asm
@@ -1,0 +1,546 @@
+;
+; jdmrgext.asm - merged upsampling/color conversion (64-bit AVX2)
+;
+; Copyright 2009, 2012 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2009, 2012 D. R. Commander
+; Copyright 2015, Intel Corporation
+;
+; Based on
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; [TAB8]
+
+%include "jcolsamp.inc"
+
+; --------------------------------------------------------------------------
+;
+; Upsample and color convert for the case of 2:1 horizontal and 1:1 vertical.
+;
+; GLOBAL(void)
+; jsimd_h2v1_merged_upsample_avx2 (JDIMENSION output_width,
+;                                  JSAMPIMAGE input_buf,
+;                                  JDIMENSION in_row_group_ctr,
+;                                  JSAMPARRAY output_buf);
+;
+
+; r10 = JDIMENSION output_width
+; r11 = JSAMPIMAGE input_buf
+; r12 = JDIMENSION in_row_group_ctr
+; r13 = JSAMPARRAY output_buf
+
+%define wk(i)           rbp-(WK_NUM-(i))*SIZEOF_YMMWORD ; ymmword wk[WK_NUM]
+%define WK_NUM          3
+
+        align   32
+        global  EXTN(jsimd_h2v1_merged_upsample_avx2)
+
+EXTN(jsimd_h2v1_merged_upsample_avx2):
+        push    rbp
+        mov     rax,rsp                         ; rax = original rbp
+        sub     rsp, byte 4
+        and     rsp, byte (-SIZEOF_YMMWORD)     ; align to 256 bits
+        mov     [rsp],rax
+        mov     rbp,rsp                         ; rbp = aligned rbp
+        lea     rsp, [wk(0)]
+        collect_args
+        push    rbx
+
+        mov     rcx, r10        ; col
+        test    rcx,rcx
+        jz      near .return
+
+        push    rcx
+
+        mov     rdi, r11
+        mov     rcx, r12
+        mov     rsi, JSAMPARRAY [rdi+0*SIZEOF_JSAMPARRAY]
+        mov     rbx, JSAMPARRAY [rdi+1*SIZEOF_JSAMPARRAY]
+        mov     rdx, JSAMPARRAY [rdi+2*SIZEOF_JSAMPARRAY]
+        mov     rdi, r13
+        mov     rsi, JSAMPROW [rsi+rcx*SIZEOF_JSAMPROW]         ; inptr0
+        mov     rbx, JSAMPROW [rbx+rcx*SIZEOF_JSAMPROW]         ; inptr1
+        mov     rdx, JSAMPROW [rdx+rcx*SIZEOF_JSAMPROW]         ; inptr2
+        mov     rdi, JSAMPROW [rdi]                             ; outptr
+
+        pop     rcx                     ; col
+
+.columnloop:
+
+        vmovdqa    ymm6, YMMWORD [rbx]   ; ymm6=Cb(0123456789ABCDEF)
+        vmovdqa    ymm7, YMMWORD [rdx]   ; ymm7=Cr(0123456789ABCDEF)
+
+        vpxor      ymm1,ymm1,ymm1             ; ymm1=(all 0's)
+        vpcmpeqw   ymm3,ymm3,ymm3
+        vpsllw     ymm3,ymm3,7                ; ymm3={0xFF80 0xFF80 0xFF80 0xFF80 ..}
+
+        vpermq     ymm6,ymm6,0xd8
+        vpermq     ymm7,ymm7,0xd8
+        vpunpcklbw ymm4,ymm6,ymm1             ; ymm4=Cb(01234567)=CbL
+        vpunpckhbw ymm6,ymm6,ymm1             ; ymm6=Cb(89ABCDEF)=CbH
+        vpunpcklbw ymm0,ymm7,ymm1             ; ymm0=Cr(01234567)=CrL
+        vpunpckhbw ymm7,ymm7,ymm1             ; ymm7=Cr(89ABCDEF)=CrH
+
+        vpaddw     ymm5,ymm6,ymm3
+        vpaddw     ymm2,ymm4,ymm3
+        vpaddw     ymm1,ymm7,ymm3
+        vpaddw     ymm3,ymm0,ymm3
+
+        ; (Original)
+        ; R = Y                + 1.40200 * Cr
+        ; G = Y - 0.34414 * Cb - 0.71414 * Cr
+        ; B = Y + 1.77200 * Cb
+        ;
+        ; (This implementation)
+        ; R = Y                + 0.40200 * Cr + Cr
+        ; G = Y - 0.34414 * Cb + 0.28586 * Cr - Cr
+        ; B = Y - 0.22800 * Cb + Cb + Cb
+
+        vpaddw   ymm6,ymm5,ymm5               ; ymm6=2*CbH
+        vpaddw   ymm4,ymm2,ymm2               ; ymm4=2*CbL
+        vpaddw   ymm7,ymm1,ymm1               ; ymm7=2*CrH
+        vpaddw   ymm0,ymm3,ymm3               ; ymm0=2*CrL
+
+        vpmulhw  ymm6,ymm6,[rel PW_MF0228]    ; ymm6=(2*CbH * -FIX(0.22800))
+        vpmulhw  ymm4,ymm4,[rel PW_MF0228]    ; ymm4=(2*CbL * -FIX(0.22800))
+        vpmulhw  ymm7,ymm7,[rel PW_F0402]     ; ymm7=(2*CrH * FIX(0.40200))
+        vpmulhw  ymm0,ymm0,[rel PW_F0402]     ; ymm0=(2*CrL * FIX(0.40200))
+
+        vpaddw   ymm6,ymm6,[rel PW_ONE]
+        vpaddw   ymm4,ymm4,[rel PW_ONE]
+        vpsraw   ymm6,ymm6,1                  ; ymm6=(CbH * -FIX(0.22800))
+        vpsraw   ymm4,ymm4,1                  ; ymm4=(CbL * -FIX(0.22800))
+        vpaddw   ymm7,ymm7,[rel PW_ONE]
+        vpaddw   ymm0,ymm0,[rel PW_ONE]
+        vpsraw   ymm7,ymm7,1                  ; ymm7=(CrH * FIX(0.40200))
+        vpsraw   ymm0,ymm0,1                  ; ymm0=(CrL * FIX(0.40200))
+
+        vpaddw   ymm6,ymm6,ymm5
+        vpaddw   ymm4,ymm4,ymm2
+        vpaddw   ymm6,ymm6,ymm5               ; ymm6=(CbH * FIX(1.77200))=(B-Y)H
+        vpaddw   ymm4,ymm4,ymm2               ; ymm4=(CbL * FIX(1.77200))=(B-Y)L
+        vpaddw   ymm7,ymm7,ymm1               ; ymm7=(CrH * FIX(1.40200))=(R-Y)H
+        vpaddw   ymm0,ymm0,ymm3               ; ymm0=(CrL * FIX(1.40200))=(R-Y)L
+
+        vmovdqa  YMMWORD [wk(0)], ymm6   ; wk(0)=(B-Y)H
+        vmovdqa  YMMWORD [wk(1)], ymm7   ; wk(1)=(R-Y)H
+
+        vpunpckhwd ymm6,ymm5,ymm1
+        vpunpcklwd ymm5,ymm5,ymm1
+        vpmaddwd   ymm5,ymm5,[rel PW_MF0344_F0285]
+        vpmaddwd   ymm6,ymm6,[rel PW_MF0344_F0285]
+        vpunpckhwd ymm7,ymm2,ymm3
+        vpunpcklwd ymm2,ymm2,ymm3
+        vpmaddwd   ymm2,ymm2,[rel PW_MF0344_F0285]
+        vpmaddwd   ymm7,ymm7,[rel PW_MF0344_F0285]
+
+        vpaddd     ymm5,ymm5,[rel PD_ONEHALF]
+        vpaddd     ymm6,ymm6,[rel PD_ONEHALF]
+        vpsrad     ymm5,ymm5,SCALEBITS
+        vpsrad     ymm6,ymm6,SCALEBITS
+        vpaddd     ymm2,ymm2,[rel PD_ONEHALF]
+        vpaddd     ymm7,ymm7,[rel PD_ONEHALF]
+        vpsrad     ymm2,ymm2,SCALEBITS
+        vpsrad     ymm7,ymm7,SCALEBITS
+
+        vpackssdw  ymm5,ymm5,ymm6     ; ymm5=CbH*-FIX(0.344)+CrH*FIX(0.285)
+        vpackssdw  ymm2,ymm2,ymm7     ; ymm2=CbL*-FIX(0.344)+CrL*FIX(0.285)
+        vpsubw     ymm5,ymm5,ymm1     ; ymm5=CbH*-FIX(0.344)+CrH*-FIX(0.714)=(G-Y)H
+        vpsubw     ymm2,ymm2,ymm3     ; ymm2=CbL*-FIX(0.344)+CrL*-FIX(0.714)=(G-Y)L
+
+        vmovdqa  YMMWORD [wk(2)], ymm5   ; wk(2)=(G-Y)H
+
+        mov     al,2                    ; Yctr
+        jmp     short .Yloop_1st
+
+.Yloop_2nd:
+        vmovdqa  ymm0, YMMWORD [wk(1)]   ; ymm0=(R-Y)H
+        vmovdqa  ymm2, YMMWORD [wk(2)]   ; ymm2=(G-Y)H
+        vmovdqa  ymm4, YMMWORD [wk(0)]   ; ymm4=(B-Y)H
+
+.Yloop_1st:
+        vmovdqa  ymm7, YMMWORD [rsi]     ; ymm7=Y(0123456789ABCDEF)
+
+        vpcmpeqw ymm6,ymm6,ymm6
+        vpsrlw   ymm6,ymm6,BYTE_BIT           ; ymm6={0xFF 0x00 0xFF 0x00 ..}
+        vpand    ymm6,ymm6,ymm7               ; ymm6=Y(02468ACE)=YE
+        vpsrlw   ymm7,ymm7,BYTE_BIT           ; ymm7=Y(13579BDF)=YO
+
+        vmovdqa  ymm1,ymm0               ; ymm1=ymm0=(R-Y)(L/H)
+        vmovdqa  ymm3,ymm2               ; ymm3=ymm2=(G-Y)(L/H)
+        vmovdqa  ymm5,ymm4               ; ymm5=ymm4=(B-Y)(L/H)
+
+        vpaddw     ymm0,ymm0,ymm6             ; ymm0=((R-Y)+YE)=RE=R(02468ACE)
+        vpaddw     ymm1,ymm1,ymm7             ; ymm1=((R-Y)+YO)=RO=R(13579BDF)
+        vpackuswb  ymm0,ymm0,ymm0             ; ymm0=R(02468ACE********)
+        vpackuswb  ymm1,ymm1,ymm1             ; ymm1=R(13579BDF********)
+
+        vpaddw     ymm2,ymm2,ymm6             ; ymm2=((G-Y)+YE)=GE=G(02468ACE)
+        vpaddw     ymm3,ymm3,ymm7             ; ymm3=((G-Y)+YO)=GO=G(13579BDF)
+        vpackuswb  ymm2,ymm2,ymm2             ; ymm2=G(02468ACE********)
+        vpackuswb  ymm3,ymm3,ymm3             ; ymm3=G(13579BDF********)
+
+        vpaddw     ymm4,ymm4,ymm6             ; ymm4=((B-Y)+YE)=BE=B(02468ACE)
+        vpaddw     ymm5,ymm5,ymm7             ; ymm5=((B-Y)+YO)=BO=B(13579BDF)
+        vpackuswb  ymm4,ymm4,ymm4             ; ymm4=B(02468ACE********)
+        vpackuswb  ymm5,ymm5,ymm5             ; ymm5=B(13579BDF********)
+
+%if RGB_PIXELSIZE == 3 ; ---------------
+
+        vpunpcklbw ymmA,ymmA,ymmC     
+        vpunpcklbw ymmE,ymmE,ymmB     
+        vpunpcklbw ymmD,ymmD,ymmF     
+
+        vmovdqa    ymmG,ymmA
+        vmovdqa    ymmH,ymmA
+        vpunpcklwd ymmA,ymmA,ymmE     
+        vpunpckhwd ymmG,ymmG,ymmE     
+
+        vpsrldq    ymmH,ymmH,2        
+        vpsrldq    ymmE,ymmE,2        
+
+        vmovdqa    ymmC,ymmD
+        vmovdqa    ymmB,ymmD
+        vpunpcklwd ymmD,ymmD,ymmH     
+        vpunpckhwd ymmC,ymmC,ymmH     
+
+        vpsrldq    ymmB,ymmB,2        
+
+        vmovdqa    ymmF,ymmE
+        vpunpcklwd ymmE,ymmE,ymmB     
+        vpunpckhwd ymmF,ymmF,ymmB     
+
+        vpshufd    ymmH,ymmA,0x4E
+        vmovdqa    ymmB,ymmE
+        vpunpckldq ymmA,ymmA,ymmD     
+        vpunpckldq ymmE,ymmE,ymmH     
+        vpunpckhdq ymmD,ymmD,ymmB     
+
+        vpshufd    ymmH,ymmG,0x4E
+        vmovdqa    ymmB,ymmF
+        vpunpckldq ymmG,ymmG,ymmC     
+        vpunpckldq ymmF,ymmF,ymmH     
+        vpunpckhdq ymmC,ymmC,ymmB     
+
+        vpunpcklqdq ymmH,ymmA,ymmE    
+        vpunpcklqdq ymmG,ymmD,ymmG    
+        vpunpcklqdq ymmC,ymmF,ymmC    
+    
+        vperm2i128 ymmA,ymmH,ymmG,0x20
+        vperm2i128 ymmD,ymmC,ymmH,0x30
+        vperm2i128 ymmF,ymmG,ymmC,0x31
+
+        cmp     rcx, byte SIZEOF_YMMWORD
+        jb      short .column_st64
+
+        test    rdi, SIZEOF_YMMWORD-1
+        jnz     short .out1
+        ; --(aligned)-------------------
+        vmovntdq YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        vmovntdq YMMWORD [rdi+1*SIZEOF_YMMWORD], ymmD
+        vmovntdq YMMWORD [rdi+2*SIZEOF_YMMWORD], ymmF
+        jmp     short .out0
+.out1:  ; --(unaligned)-----------------
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        vmovdqu  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymmD
+        vmovdqu  YMMWORD [rdi+2*SIZEOF_YMMWORD], ymmF
+.out0:
+        add     rdi, byte RGB_PIXELSIZE*SIZEOF_YMMWORD  ; outptr
+        sub     rcx, byte SIZEOF_YMMWORD
+        jz      near .endcolumn
+
+        add     rsi, byte SIZEOF_YMMWORD        ; inptr0
+        dec     al                      ; Yctr
+        jnz     near .Yloop_2nd
+
+        add     rbx, byte SIZEOF_YMMWORD        ; inptr1
+        add     rdx, byte SIZEOF_YMMWORD        ; inptr2
+        jmp     near .columnloop
+
+.column_st64:
+        lea     rcx, [rcx+rcx*2]                ; imul ecx, RGB_PIXELSIZE
+        cmp     rcx, byte 2*SIZEOF_YMMWORD
+        jb      short .column_st32
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        vmovdqu  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymmD
+        add     rdi, byte 2*SIZEOF_YMMWORD      ; outptr
+        vmovdqa  ymmA,ymmF
+        sub     rcx, byte 2*SIZEOF_YMMWORD
+        jmp     short .column_st31
+.column_st32:
+        cmp     rcx, byte SIZEOF_YMMWORD
+        jb      short .column_st31
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        add     rdi, byte SIZEOF_YMMWORD      ; outptr
+        vmovdqa  ymmA,ymmD
+        sub     rcx, byte SIZEOF_YMMWORD
+        jmp     short .column_st31
+.column_st31:
+        cmp     rcx, byte SIZEOF_XMMWORD
+        jb      short .column_st15
+        vmovdqu  XMMWORD [rdi+0*SIZEOF_XMMWORD], xmmA
+        add     rdi, byte SIZEOF_XMMWORD        ; outptr
+        vperm2i128 ymmA,ymmA,ymmA,1
+        sub     rcx, byte SIZEOF_XMMWORD
+.column_st15:
+        ; Store the lower 8 bytes of xmmA to the output when it has enough
+        ; space.
+        cmp     rcx, byte SIZEOF_MMWORD
+        jb      short .column_st7
+        vmovq    XMM_MMWORD [rdi], xmmA
+        add     rdi, byte SIZEOF_MMWORD
+        sub     rcx, byte SIZEOF_MMWORD
+        vpsrldq  xmmA,xmmA, SIZEOF_MMWORD
+.column_st7:
+        ; Store the lower 4 bytes of xmmA to the output when it has enough
+        ; space.
+        cmp     rcx, byte SIZEOF_DWORD
+        jb      short .column_st3
+        vmovd    XMM_DWORD [rdi], xmmA
+        add     rdi, byte SIZEOF_DWORD
+        sub     rcx, byte SIZEOF_DWORD
+        vpsrldq xmmA, xmmA, SIZEOF_DWORD
+.column_st3:
+        ; Store the lower 2 bytes of rax to the output when it has enough
+        ; space.
+        vmovd    eax, xmmA
+        cmp     rcx, byte SIZEOF_WORD
+        jb      short .column_st1
+        mov     WORD [rdi], ax
+        add     rdi, byte SIZEOF_WORD
+        sub     rcx, byte SIZEOF_WORD
+        shr     rax, 16
+.column_st1:
+
+        ; Store the lower 1 byte of rax to the output when it has enough
+        ; space.
+        test    rcx, rcx
+        jz      short .endcolumn
+        mov     BYTE [rdi], al
+
+%else ; RGB_PIXELSIZE == 4 ; -----------
+
+%ifdef RGBX_FILLER_0XFF
+        vpcmpeqb   ymm6,ymm6,ymm6             
+        vpcmpeqb   ymm7,ymm7,ymm7             
+%else
+        vpxor      ymm6,ymm6,ymm6             
+        vpxor      ymm7,ymm7,ymm7             
+%endif
+        
+        vpunpcklbw ymmA,ymmA,ymmC     
+        vpunpcklbw ymmE,ymmE,ymmG     
+        vpunpcklbw ymmB,ymmB,ymmD     
+        vpunpcklbw ymmF,ymmF,ymmH     
+
+        vpunpckhwd ymmC,ymmA,ymmE     
+        vpunpcklwd ymmA,ymmA,ymmE     
+        vpunpckhwd ymmG,ymmB,ymmF     
+        vpunpcklwd ymmB,ymmB,ymmF     
+
+        vpunpckhdq ymmE,ymmA,ymmB     
+        vpunpckldq ymmB,ymmA,ymmB     
+        vpunpckhdq ymmF,ymmC,ymmG     
+        vpunpckldq ymmG,ymmC,ymmG    
+
+
+        vperm2i128 ymmA, ymmB,ymmE,0x20
+        vperm2i128 ymmD, ymmG,ymmF,0x20
+        vperm2i128 ymmC, ymmB,ymmE,0x31
+        vperm2i128 ymmH, ymmG,ymmF,0x31
+
+        cmp     rcx, byte SIZEOF_YMMWORD
+        jb      short .column_st64
+
+        test    rdi, SIZEOF_YMMWORD-1
+        jnz     short .out1
+        ; --(aligned)-------------------
+        vmovntdq YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        vmovntdq YMMWORD [rdi+1*SIZEOF_YMMWORD], ymmD
+        vmovntdq YMMWORD [rdi+2*SIZEOF_YMMWORD], ymmC
+        vmovntdq YMMWORD [rdi+3*SIZEOF_YMMWORD], ymmH
+        jmp     short .out0
+.out1:  ; --(unaligned)-----------------
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        vmovdqu  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymmD
+        vmovdqu  YMMWORD [rdi+2*SIZEOF_YMMWORD], ymmC
+        vmovdqu  YMMWORD [rdi+3*SIZEOF_YMMWORD], ymmH
+.out0:
+        add     rdi, RGB_PIXELSIZE*SIZEOF_YMMWORD  ; outptr
+        sub     rcx, byte SIZEOF_YMMWORD
+        jz      near .endcolumn
+
+        add     rsi, byte SIZEOF_YMMWORD        ; inptr0
+    dec   al
+    jnz   near .Yloop_2nd
+
+        add     rbx, byte SIZEOF_YMMWORD        ; inptr1
+        add     rdx, byte SIZEOF_YMMWORD        ; inptr2
+        jmp     near .columnloop
+
+.column_st64:
+        cmp     rcx, byte SIZEOF_YMMWORD/2
+        jb      short .column_st32
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        vmovdqu  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymmD
+        add     rdi, byte 2*SIZEOF_YMMWORD      ; outptr
+        vmovdqa  ymmA,ymmC
+        vmovdqa  ymmD,ymmH
+        sub     rcx, byte SIZEOF_YMMWORD/2
+.column_st32:
+    cmp     rcx, byte SIZEOF_YMMWORD/4
+        jb      short .column_st16
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymmA
+        add     rdi, byte SIZEOF_YMMWORD      ; outptr
+        vmovdqa  ymmA,ymmD
+        sub     rcx, byte SIZEOF_YMMWORD/4
+.column_st16:
+        cmp     rcx, byte SIZEOF_YMMWORD/8
+        jb      short .column_st15
+        vmovdqu  XMMWORD [rdi+0*SIZEOF_YMMWORD], xmmA
+        add     rdi, byte SIZEOF_XMMWORD        ; outptr
+        vperm2i128 ymmA,ymmA,ymmA,1
+        sub     rcx, byte SIZEOF_YMMWORD/8
+.column_st15:
+        ; Store two pixels (8 bytes) of ymmA to the output when it has enough
+        ; space.
+        cmp     rcx, byte SIZEOF_YMMWORD/16
+        jb      short .column_st7
+        vmovq   XMM_MMWORD [rdi], xmmA
+        add     rdi, byte 2*4
+        sub     rcx, byte 2
+        vpsrldq  xmmA, 2*4
+.column_st7:
+        ; Store one pixel (4 bytes) of ymmA to the output when it has enough
+        ; space.
+        test    rcx, rcx
+        jz      short .endcolumn
+        vmovd    XMM_DWORD [rdi], xmmA
+
+%endif ; RGB_PIXELSIZE ; ---------------
+
+.endcolumn:
+        sfence          ; flush the write buffer
+
+.return:
+        pop     rbx
+        uncollect_args
+        mov     rsp,rbp         ; rsp <- aligned rbp
+        pop     rsp             ; rsp <- original rbp
+        pop     rbp
+        ret
+
+; --------------------------------------------------------------------------
+;
+; Upsample and color convert for the case of 2:1 horizontal and 2:1 vertical.
+;
+; GLOBAL(void)
+; jsimd_h2v2_merged_upsample_avx2 (JDIMENSION output_width,
+;                                  JSAMPIMAGE input_buf,
+;                                  JDIMENSION in_row_group_ctr,
+;                                  JSAMPARRAY output_buf);
+;
+
+; r10 = JDIMENSION output_width
+; r11 = JSAMPIMAGE input_buf
+; r12 = JDIMENSION in_row_group_ctr
+; r13 = JSAMPARRAY output_buf
+
+        align   32
+        global  EXTN(jsimd_h2v2_merged_upsample_avx2)
+
+EXTN(jsimd_h2v2_merged_upsample_avx2):
+        push    rbp
+        mov     rax,rsp
+        mov     rbp,rsp
+        collect_args
+        push    rbx
+
+        mov     rax, r10
+
+        mov     rdi, r11
+        mov     rcx, r12
+        mov     rsi, JSAMPARRAY [rdi+0*SIZEOF_JSAMPARRAY]
+        mov     rbx, JSAMPARRAY [rdi+1*SIZEOF_JSAMPARRAY]
+        mov     rdx, JSAMPARRAY [rdi+2*SIZEOF_JSAMPARRAY]
+        mov     rdi, r13
+        lea     rsi, [rsi+rcx*SIZEOF_JSAMPROW]
+
+        push    rdx                     ; inptr2
+        push    rbx                     ; inptr1
+        push    rsi                     ; inptr00
+        mov     rbx,rsp
+
+        push    rdi
+        push    rcx
+        push    rax
+
+        %ifdef WIN64
+        mov r8, rcx
+        mov r9, rdi
+        mov rcx, rax
+        mov rdx, rbx
+        %else
+        mov rdx, rcx
+        mov rcx, rdi
+        mov     rdi, rax
+        mov rsi, rbx
+        %endif
+
+        call    EXTN(jsimd_h2v1_merged_upsample_avx2)
+
+        pop rax
+        pop rcx
+        pop rdi
+        pop rsi
+        pop rbx
+        pop rdx
+
+        add     rdi, byte SIZEOF_JSAMPROW       ; outptr1
+        add     rsi, byte SIZEOF_JSAMPROW       ; inptr01
+
+        push    rdx                     ; inptr2
+        push    rbx                     ; inptr1
+        push    rsi                     ; inptr00
+        mov     rbx,rsp
+
+        push    rdi
+        push    rcx
+        push    rax
+
+        %ifdef WIN64
+        mov r8, rcx
+        mov r9, rdi
+        mov rcx, rax
+        mov rdx, rbx
+        %else
+        mov rdx, rcx
+        mov rcx, rdi
+        mov     rdi, rax
+        mov rsi, rbx
+        %endif
+
+        call    EXTN(jsimd_h2v1_merged_upsample_avx2)
+
+        pop rax
+        pop rcx
+        pop rdi
+        pop rsi
+        pop rbx
+        pop rdx
+
+        pop     rbx
+        uncollect_args
+        pop     rbp
+        ret
+
+; For some reason, the OS X linker does not honor the request to align the
+; segment unless we do this.
+        align   32

--- a/simd/jdsample-avx2-64.asm
+++ b/simd/jdsample-avx2-64.asm
@@ -1,0 +1,713 @@
+;
+; jdsample.asm - upsampling (64-bit AVX2)
+;
+; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2009 D. R. Commander
+; Copyright 2015 Intel Corporation
+;
+; Based on
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; [TAB8]
+
+%include "jsimdext.inc"
+
+; --------------------------------------------------------------------------
+        SECTION SEG_CONST
+
+        alignz  32
+        global  EXTN(jconst_fancy_upsample_avx2)
+
+EXTN(jconst_fancy_upsample_avx2):
+
+PW_ONE          times 16 dw  1
+PW_TWO          times 16 dw  2
+PW_THREE        times 16 dw  3
+PW_SEVEN        times 16 dw  7
+PW_EIGHT        times 16 dw  8
+
+        alignz  32
+
+; --------------------------------------------------------------------------
+        SECTION SEG_TEXT
+        BITS    64
+;
+; Fancy processing for the common case of 2:1 horizontal and 1:1 vertical.
+;
+; The upsampling algorithm is linear interpolation between pixel centers,
+; also known as a "triangle filter".  This is a good compromise between
+; speed and visual quality.  The centers of the output pixels are 1/4 and 3/4
+; of the way between input pixel centers.
+;
+; GLOBAL(void)
+; jsimd_h2v1_fancy_upsample_avx2 (int max_v_samp_factor,
+;                                 JDIMENSION downsampled_width,
+;                                 JSAMPARRAY input_data,
+;                                 JSAMPARRAY * output_data_ptr);
+;
+
+; r10 = int max_v_samp_factor
+; r11 = JDIMENSION downsampled_width
+; r12 = JSAMPARRAY input_data
+; r13 = JSAMPARRAY * output_data_ptr
+
+        align   32
+        global  EXTN(jsimd_h2v1_fancy_upsample_avx2)
+
+EXTN(jsimd_h2v1_fancy_upsample_avx2):
+        push    rbp
+        mov     rax,rsp
+        mov     rbp,rsp
+        collect_args
+
+        mov     rax, r11  ; colctr
+        test    rax,rax
+        jz      near .return
+
+        mov     rcx, r10        ; rowctr
+        test    rcx,rcx
+        jz      near .return
+
+        mov     rsi, r12        ; input_data
+        mov     rdi, r13
+        mov     rdi, JSAMPARRAY [rdi]                   ; output_data
+
+        vpxor    ymm0,ymm0,ymm0               ; ymm0=(all 0's)
+        vpcmpeqb xmm14,xmm14,xmm14
+        vpsrldq  xmm15,xmm14,(SIZEOF_XMMWORD-1); (ff -- -- -- ... -- --); LSB is ff
+
+        vpslldq xmm14,xmm14,(SIZEOF_XMMWORD-1)
+        vperm2i128 ymm14,ymm14,ymm14,1 ;(---- ---- ... ---- ---- ff) MSB is ff
+
+.rowloop:
+        push    rax                     ; colctr
+        push    rdi
+        push    rsi
+
+        mov     rsi, JSAMPROW [rsi]     ; inptr
+        mov     rdi, JSAMPROW [rdi]     ; outptr
+
+        test    rax, SIZEOF_YMMWORD-1
+        jz      short .skip
+        mov     dl, JSAMPLE [rsi+(rax-1)*SIZEOF_JSAMPLE]
+        mov     JSAMPLE [rsi+rax*SIZEOF_JSAMPLE], dl    ; insert a dummy sample
+.skip:
+        vpand    ymm7,ymm15, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+
+        add     rax, byte SIZEOF_YMMWORD-1
+        and     rax, byte -SIZEOF_YMMWORD
+        cmp     rax, byte SIZEOF_YMMWORD
+        ja      short .columnloop
+
+.columnloop_last:
+        vpand    ymm6,ymm14, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        jmp     short .upsample
+
+.columnloop:
+        vmovdqa  ymm6, YMMWORD [rsi+1*SIZEOF_YMMWORD]
+        vperm2i128 ymm8,ymm0,ymm6,0x20  
+        vpslldq ymm6,ymm8,15      
+
+.upsample:
+        vmovdqa  ymm1, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqa  ymm2,ymm1
+        vmovdqa  ymm3,ymm1               
+
+        vperm2i128 ymm8,ymm0,ymm2,0x20  
+        vpalignr ymm2,ymm2,ymm8,15
+
+        vperm2i128 ymm8,ymm0,ymm3,0x03  
+        vpalignr ymm3,ymm8,ymm3,1
+
+        vpor     ymm2,ymm2,ymm7               
+        vpor     ymm3,ymm3,ymm6               
+
+        vpsrldq  ymm7,ymm8,(SIZEOF_XMMWORD-1) 
+
+        vpunpckhbw ymm4,ymm1,ymm0             
+        vpunpcklbw ymm8,ymm1,ymm0             
+        vperm2i128 ymm1,ymm8,ymm4,0x20
+        vperm2i128 ymm4,ymm8,ymm4,0x31
+
+        vpunpckhbw ymm5,ymm2,ymm0             
+        vpunpcklbw ymm8,ymm2,ymm0             
+        vperm2i128 ymm2,ymm8,ymm5,0x20
+        vperm2i128 ymm5,ymm8,ymm5,0x31
+
+        vpunpckhbw ymm6,ymm3,ymm0             
+        vpunpcklbw ymm8,ymm3,ymm0             
+        vperm2i128 ymm3,ymm8,ymm6,0x20
+        vperm2i128 ymm6,ymm8,ymm6,0x31
+
+        vpmullw  ymm1,ymm1,[rel PW_THREE]
+        vpmullw  ymm4,ymm4,[rel PW_THREE]
+        vpaddw   ymm2,ymm2,[rel PW_ONE]
+        vpaddw   ymm5,ymm5,[rel PW_ONE]
+        vpaddw   ymm3,ymm3,[rel PW_TWO]
+        vpaddw   ymm6,ymm6,[rel PW_TWO]
+
+        vpaddw   ymm2,ymm2,ymm1
+        vpaddw   ymm5,ymm5,ymm4
+        vpsrlw   ymm2,ymm2,2                  
+        vpsrlw   ymm5,ymm5,2                  
+        vpaddw   ymm3,ymm3,ymm1
+        vpaddw   ymm6,ymm6,ymm4
+        vpsrlw   ymm3,ymm3,2                  
+        vpsrlw   ymm6,ymm6,2                  
+
+        vpsllw   ymm3,ymm3,BYTE_BIT
+        vpsllw   ymm6,ymm6,BYTE_BIT
+        vpor     ymm2,ymm2,ymm3               
+        vpor     ymm5,ymm5,ymm6               
+
+        vmovdqa  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm2
+        vmovdqa  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymm5
+
+        sub     rax, byte SIZEOF_YMMWORD
+        add     rsi, byte 1*SIZEOF_YMMWORD      ; inptr
+        add     rdi, byte 2*SIZEOF_YMMWORD      ; outptr
+        cmp     rax, byte SIZEOF_YMMWORD
+        ja      near .columnloop
+        test    eax,eax
+        jnz     near .columnloop_last
+
+        pop     rsi
+        pop     rdi
+        pop     rax
+
+        add     rsi, byte SIZEOF_JSAMPROW       ; input_data
+        add     rdi, byte SIZEOF_JSAMPROW       ; output_data
+        dec     rcx                             ; rowctr
+        jg      near .rowloop
+
+.return:
+        uncollect_args
+        pop     rbp
+        ret
+
+; --------------------------------------------------------------------------
+;
+; Fancy processing for the common case of 2:1 horizontal and 2:1 vertical.
+; Again a triangle filter; see comments for h2v1 case, above.
+;
+; GLOBAL(void)
+; jsimd_h2v2_fancy_upsample_avx2 (int max_v_samp_factor,
+;                                 JDIMENSION downsampled_width,
+;                                 JSAMPARRAY input_data,
+;                                 JSAMPARRAY * output_data_ptr);
+;
+
+; r10 = int max_v_samp_factor
+; r11 = JDIMENSION downsampled_width
+; r12 = JSAMPARRAY input_data
+; r13 = JSAMPARRAY * output_data_ptr
+
+%define wk(i)           rbp-(WK_NUM-(i))*SIZEOF_YMMWORD ; ymmword wk[WK_NUM]
+%define WK_NUM          4
+
+        align   32
+        global  EXTN(jsimd_h2v2_fancy_upsample_avx2)
+
+EXTN(jsimd_h2v2_fancy_upsample_avx2):
+        push    rbp
+        mov     rax,rsp                         ; rax = original rbp
+        sub     rsp, byte 4
+        and     rsp, byte (-SIZEOF_YMMWORD)     ; align to 128 bits
+        mov     [rsp],rax
+        mov     rbp,rsp                         ; rbp = aligned rbp
+        lea     rsp, [wk(0)]
+        collect_args
+        push    rbx
+
+        mov     rax, r11  ; colctr
+        test    rax,rax
+        jz      near .return
+
+        mov     rcx, r10        ; rowctr
+        test    rcx,rcx
+        jz      near .return
+
+        mov     rsi, r12        ; input_data
+        mov     rdi, r13
+        mov     rdi, JSAMPARRAY [rdi]                   ; output_data
+.rowloop:
+        push    rax                                     ; colctr
+        push    rcx
+        push    rdi
+        push    rsi
+
+        mov     rcx, JSAMPROW [rsi-1*SIZEOF_JSAMPROW]   ; inptr1(above)
+        mov     rbx, JSAMPROW [rsi+0*SIZEOF_JSAMPROW]   ; inptr0
+        mov     rsi, JSAMPROW [rsi+1*SIZEOF_JSAMPROW]   ; inptr1(below)
+        mov     rdx, JSAMPROW [rdi+0*SIZEOF_JSAMPROW]   ; outptr0
+        mov     rdi, JSAMPROW [rdi+1*SIZEOF_JSAMPROW]   ; outptr1
+
+    vpxor ymm13,ymm13,ymm13
+    vpcmpeqb xmm14,xmm14,xmm14
+        vpsrldq  xmm15,xmm14,(SIZEOF_XMMWORD-2); (ffff ---- ---- ... ---- ----) LSB is ffff
+    vpslldq  xmm14,xmm14,(SIZEOF_XMMWORD-2)
+    vperm2i128 ymm14,ymm14,ymm14,1       ; (---- ---- ... ---- ---- ffff) MSB is ffff
+
+        test    rax, SIZEOF_YMMWORD-1
+        jz      short .skip
+        push    rdx
+        mov     dl, JSAMPLE [rcx+(rax-1)*SIZEOF_JSAMPLE]
+        mov     JSAMPLE [rcx+rax*SIZEOF_JSAMPLE], dl
+        mov     dl, JSAMPLE [rbx+(rax-1)*SIZEOF_JSAMPLE]
+        mov     JSAMPLE [rbx+rax*SIZEOF_JSAMPLE], dl
+        mov     dl, JSAMPLE [rsi+(rax-1)*SIZEOF_JSAMPLE]
+        mov     JSAMPLE [rsi+rax*SIZEOF_JSAMPLE], dl    ; insert a dummy sample
+        pop     rdx
+.skip:
+        ; -- process the first column block
+
+        vmovdqa  ymm0, YMMWORD [rbx+0*SIZEOF_YMMWORD]    
+        vmovdqa  ymm1, YMMWORD [rcx+0*SIZEOF_YMMWORD]    
+        vmovdqa  ymm2, YMMWORD [rsi+0*SIZEOF_YMMWORD]    
+
+        vpunpckhbw ymm4,ymm0,ymm13             
+        vpunpcklbw ymm8,ymm0,ymm13             
+        vperm2i128 ymm0,ymm8,ymm4,0x20
+        vperm2i128 ymm4,ymm8,ymm4,0x31
+
+        vpunpckhbw ymm5,ymm1,ymm13             
+        vpunpcklbw ymm8,ymm1,ymm13             
+        vperm2i128 ymm1,ymm8,ymm5,0x20
+        vperm2i128 ymm5,ymm8,ymm5,0x31
+
+        vpunpckhbw ymm6,ymm2,ymm13             
+        vpunpcklbw ymm8,ymm2,ymm13             
+        vperm2i128 ymm2,ymm8,ymm6,0x20
+        vperm2i128 ymm6,ymm8,ymm6,0x31
+
+        vpmullw  ymm0,ymm0,[rel PW_THREE]
+        vpmullw  ymm4,ymm4,[rel PW_THREE]
+
+        vpaddw   ymm1,ymm1,ymm0               
+        vpaddw   ymm5,ymm5,ymm4               
+        vpaddw   ymm2,ymm2,ymm0               
+        vpaddw   ymm6,ymm6,ymm4               
+
+        vmovdqa  YMMWORD [rdx+0*SIZEOF_YMMWORD], ymm1    
+        vmovdqa  YMMWORD [rdx+1*SIZEOF_YMMWORD], ymm5    
+        vmovdqa  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm2
+        vmovdqa  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymm6
+
+        vpand    ymm1,ymm1,ymm15               
+        vpand    ymm2,ymm2,ymm15               
+
+        vmovdqa  YMMWORD [wk(0)], ymm1
+        vmovdqa  YMMWORD [wk(1)], ymm2
+
+        add     rax, byte SIZEOF_YMMWORD-1
+        and     rax, byte -SIZEOF_YMMWORD
+        cmp     rax, byte SIZEOF_YMMWORD
+        ja      short .columnloop
+
+        .columnloop_last:
+        ; -- process the last column block
+
+        vpand    ymm1,ymm14, YMMWORD [rdx+1*SIZEOF_YMMWORD]
+        vpand    ymm2,ymm14, YMMWORD [rdi+1*SIZEOF_YMMWORD]
+
+        vmovdqa  YMMWORD [wk(2)], ymm1   
+        vmovdqa  YMMWORD [wk(3)], ymm2   
+
+        jmp     near .upsample
+
+        .columnloop:
+        ; -- process the next column block
+
+        vmovdqa  ymm0, YMMWORD [rbx+1*SIZEOF_YMMWORD]    
+        vmovdqa  ymm1, YMMWORD [rcx+1*SIZEOF_YMMWORD]    
+        vmovdqa  ymm2, YMMWORD [rsi+1*SIZEOF_YMMWORD]    
+
+        vpunpckhbw ymm4,ymm0,ymm13             
+        vpunpcklbw ymm8,ymm0,ymm13             
+        vperm2i128 ymm0,ymm8,ymm4,0x20
+        vperm2i128 ymm4,ymm8,ymm4,0x31
+
+        vpunpckhbw ymm5,ymm1,ymm13             
+        vpunpcklbw ymm8,ymm1,ymm13             
+        vperm2i128 ymm1,ymm8,ymm5,0x20
+        vperm2i128 ymm5,ymm8,ymm5,0x31
+
+        vpunpckhbw ymm6,ymm2,ymm13             
+        vpunpcklbw ymm8,ymm2,ymm13             
+        vperm2i128 ymm2,ymm8,ymm6,0x20
+        vperm2i128 ymm6,ymm8,ymm6,0x31
+
+        vpmullw  ymm0,ymm0,[rel PW_THREE]
+        vpmullw  ymm4,ymm4,[rel PW_THREE]
+
+        vpaddw   ymm1,ymm1,ymm0               
+        vpaddw   ymm5,ymm5,ymm4               
+        vpaddw   ymm2,ymm2,ymm0               
+        vpaddw   ymm6,ymm6,ymm4               
+
+        vmovdqa  YMMWORD [rdx+2*SIZEOF_YMMWORD], ymm1    
+        vmovdqa  YMMWORD [rdx+3*SIZEOF_YMMWORD], ymm5    
+        vmovdqa  YMMWORD [rdi+2*SIZEOF_YMMWORD], ymm2
+        vmovdqa  YMMWORD [rdi+3*SIZEOF_YMMWORD], ymm6
+
+        vperm2i128 ymm1,ymm13,ymm1,0x20     
+        vpslldq  ymm1,ymm1,14       
+        vperm2i128 ymm2,ymm13,ymm2,0x20
+        vpslldq  ymm2,ymm2,14
+
+        vmovdqa  YMMWORD [wk(2)], ymm1
+        vmovdqa  YMMWORD [wk(3)], ymm2
+
+.upsample:
+        ; -- process the upper row
+
+        vmovdqa  ymm7, YMMWORD [rdx+0*SIZEOF_YMMWORD]
+        vmovdqa  ymm3, YMMWORD [rdx+1*SIZEOF_YMMWORD]
+        vmovdqa  ymm0,ymm7               
+        vmovdqa  ymm4,ymm3               
+        vperm2i128 ymm8,ymm13,ymm0,0x03  
+        vpalignr ymm0,ymm8,ymm0,2    
+        vperm2i128 ymm4,ymm13,ymm4,0x20  
+        vpslldq   ymm4,ymm4,14       
+        vmovdqa  ymm5,ymm7
+        vmovdqa  ymm6,ymm3
+        vperm2i128 ymm5,ymm13,ymm5,0x03
+        vpsrldq   ymm5,ymm5,14
+        vperm2i128 ymm8,ymm13,ymm6,0x20
+        vpalignr ymm6,ymm6,ymm8,14
+
+        vpor     ymm0,ymm0,ymm4               
+        vpor     ymm5,ymm5,ymm6               
+
+        vmovdqa  ymm1,ymm7
+        vmovdqa  ymm2,ymm3
+        vperm2i128 ymm8,ymm13,ymm1,0x20
+        vpalignr ymm1,ymm1,ymm8,14
+        vperm2i128 ymm8,ymm13,ymm2,0x03
+        vpalignr ymm2,ymm8,ymm2,2
+        vmovdqa  ymm4,ymm3
+        vperm2i128 ymm4,ymm13,ymm4,0x03
+        vpsrldq  ymm4,ymm4,14
+
+        vpor     ymm1,ymm1, YMMWORD [wk(0)]   
+        vpor     ymm2,ymm2, YMMWORD [wk(2)]   
+
+        vmovdqa  YMMWORD [wk(0)], ymm4
+
+        vpmullw  ymm7,ymm7,[rel PW_THREE]
+        vpmullw  ymm3,ymm3,[rel PW_THREE]
+        vpaddw   ymm1,ymm1,[rel PW_EIGHT]
+        vpaddw   ymm5,ymm5,[rel PW_EIGHT]
+        vpaddw   ymm0,ymm0,[rel PW_SEVEN]
+        vpaddw   ymm2,[rel PW_SEVEN]
+
+        vpaddw   ymm1,ymm1,ymm7
+        vpaddw   ymm5,ymm5,ymm3
+        vpsrlw   ymm1,ymm1,4                  
+        vpsrlw   ymm5,ymm5,4                  
+        vpaddw   ymm0,ymm0,ymm7
+        vpaddw   ymm2,ymm2,ymm3
+        vpsrlw   ymm0,ymm0,4                  
+        vpsrlw   ymm2,ymm2,4                  
+
+        vpsllw   ymm0,ymm0,BYTE_BIT
+        vpsllw   ymm2,ymm2,BYTE_BIT
+        vpor     ymm1,ymm1,ymm0               
+        vpor     ymm5,ymm5,ymm2               
+
+        vmovdqa  YMMWORD [rdx+0*SIZEOF_YMMWORD], ymm1
+        vmovdqa  YMMWORD [rdx+1*SIZEOF_YMMWORD], ymm5
+
+        ; -- process the lower row
+
+        vmovdqa  ymm6, YMMWORD [rdi+0*SIZEOF_YMMWORD]
+        vmovdqa  ymm4, YMMWORD [rdi+1*SIZEOF_YMMWORD]
+
+        vmovdqa  ymm7,ymm6               
+        vmovdqa  ymm3,ymm4               
+
+        vperm2i128 ymm8,ymm13,ymm7,0x03
+        vpalignr ymm7,ymm8,ymm7,2
+        vperm2i128 ymm3,ymm13,ymm3,0x20
+        vpslldq ymm3,ymm3,14
+
+        vmovdqa  ymm0,ymm6
+        vmovdqa  ymm2,ymm4
+
+        vperm2i128 ymm0,ymm13,ymm0,0x03
+        vpsrldq ymm0,ymm0,14
+        vperm2i128 ymm8,ymm13,ymm2,0x20
+        vpalignr ymm2,ymm2,ymm8,14
+
+        vpor     ymm7,ymm7,ymm3               
+        vpor     ymm0,ymm0,ymm2               
+
+        vmovdqa  ymm1,ymm6
+        vmovdqa  ymm5,ymm4
+        vperm2i128 ymm8,ymm13,ymm1,0x20
+        vpalignr ymm1,ymm1,ymm8,14
+        vperm2i128 ymm8,ymm13,ymm5,0x03
+        vpalignr ymm5,ymm8,ymm5,2
+
+        vmovdqa  ymm3,ymm4
+
+        vperm2i128 ymm3,ymm13,ymm3,0x03
+        vpsrldq   ymm3,ymm3,14
+
+        vpor     ymm1,ymm1, YMMWORD [wk(1)]   
+        vpor     ymm5,ymm5, YMMWORD [wk(3)]   
+
+        vmovdqa  YMMWORD [wk(1)], ymm3
+
+        vpmullw  ymm6,ymm6,[rel PW_THREE]
+        vpmullw  ymm4,ymm4,[rel PW_THREE]
+        vpaddw   ymm1,ymm1,[rel PW_EIGHT]
+        vpaddw   ymm0,ymm0,[rel PW_EIGHT]
+        vpaddw   ymm7,ymm7,[rel PW_SEVEN]
+        vpaddw   ymm5,ymm5,[rel PW_SEVEN]
+
+        vpaddw   ymm1,ymm1,ymm6
+        vpaddw   ymm0,ymm0,ymm4
+        vpsrlw   ymm1,ymm1,4                  
+        vpsrlw   ymm0,ymm0,4                  
+        vpaddw   ymm7,ymm7,ymm6
+        vpaddw   ymm5,ymm5,ymm4
+        vpsrlw   ymm7,ymm7,4                  
+        vpsrlw   ymm5,ymm5,4                  
+
+        vpsllw   ymm7,ymm7,BYTE_BIT
+        vpsllw   ymm5,ymm5,BYTE_BIT
+        vpor     ymm1,ymm1,ymm7               
+        vpor     ymm0,ymm0,ymm5               
+
+        vmovdqa  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm1
+        vmovdqa  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymm0
+
+        sub     rax, byte SIZEOF_YMMWORD
+        add     rcx, byte 1*SIZEOF_YMMWORD      
+        add     rbx, byte 1*SIZEOF_YMMWORD      
+        add     rsi, byte 1*SIZEOF_YMMWORD      
+        add     rdx, byte 2*SIZEOF_YMMWORD      
+        add     rdi, byte 2*SIZEOF_YMMWORD      
+        cmp     rax, byte SIZEOF_YMMWORD
+        ja      near .columnloop
+        test    rax,rax
+        jnz     near .columnloop_last
+
+        pop     rsi
+        pop     rdi
+        pop     rcx
+        pop     rax
+
+        add     rsi, byte 1*SIZEOF_JSAMPROW     ; input_data
+        add     rdi, byte 2*SIZEOF_JSAMPROW     ; output_data
+        sub     rcx, byte 2                     ; rowctr
+        jg      near .rowloop
+
+        .return:
+        pop     rbx
+        uncollect_args
+        mov     rsp,rbp         ; rsp <- aligned rbp
+        pop     rsp             ; rsp <- original rbp
+        pop     rbp
+        ret
+
+        ; --------------------------------------------------------------------------
+;
+; Fast processing for the common case of 2:1 horizontal and 1:1 vertical.
+; It's still a box filter.
+;
+; GLOBAL(void)
+; jsimd_h2v1_upsample_avx2 (int max_v_samp_factor,
+;                           JDIMENSION output_width,
+;                           JSAMPARRAY input_data,
+;                           JSAMPARRAY * output_data_ptr);
+;
+
+; r10 = int max_v_samp_factor
+; r11 = JDIMENSION output_width
+; r12 = JSAMPARRAY input_data
+; r13 = JSAMPARRAY * output_data_ptr
+
+        align   32
+        global  EXTN(jsimd_h2v1_upsample_avx2)
+
+EXTN(jsimd_h2v1_upsample_avx2):
+        push    rbp
+        mov     rax,rsp
+        mov     rbp,rsp
+        collect_args
+
+        mov     rdx, r11
+        add     rdx, byte (SIZEOF_YMMWORD-1)
+        and     rdx, -SIZEOF_YMMWORD
+        jz      near .return
+
+        mov     rcx, r10        ; rowctr
+        test    rcx,rcx
+        jz      short .return
+
+        mov     rsi, r12 ; input_data
+        mov     rdi, r13
+        mov     rdi, JSAMPARRAY [rdi]                   ; output_data
+.rowloop:
+        push    rdi
+        push    rsi
+
+        mov     rsi, JSAMPROW [rsi]             ; inptr
+        mov     rdi, JSAMPROW [rdi]             ; outptr
+
+        mov     rax,rdx                         ; colctr
+
+.columnloop:
+
+    cmp   rax, byte SIZEOF_YMMWORD
+    ja    near .above_16
+
+        vmovdqa  xmm0, XMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vpunpckhbw xmm1,xmm0,xmm0
+        vpunpcklbw xmm0,xmm0,xmm0
+        vmovdqa  XMMWORD [rdi+0*SIZEOF_XMMWORD], xmm0
+        vmovdqa  XMMWORD [rdi+1*SIZEOF_XMMWORD], xmm1
+    jmp   short .nextrow
+
+.above_16:
+        vmovdqa  ymm0, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+
+        vpermq     ymm0,ymm0,0xd8
+        vpunpckhbw ymm1,ymm0,ymm0
+        vpunpcklbw ymm0,ymm0,ymm0
+
+        vmovdqa  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm0
+        vmovdqa  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymm1
+
+        sub     rax, byte 2*SIZEOF_YMMWORD
+        jz      short .nextrow
+
+        add     rsi, byte SIZEOF_YMMWORD      ; inptr
+        add     rdi, byte 2*SIZEOF_YMMWORD      ; outptr
+        jmp     short .columnloop
+
+.nextrow:
+        pop     rsi
+        pop     rdi
+
+        add     rsi, byte SIZEOF_JSAMPROW       ; input_data
+        add     rdi, byte SIZEOF_JSAMPROW       ; output_data
+        dec     rcx                             ; rowctr
+        jg      short .rowloop
+
+.return:
+        uncollect_args
+        pop     rbp
+        ret
+
+; --------------------------------------------------------------------------
+;
+; Fast processing for the common case of 2:1 horizontal and 2:1 vertical.
+; It's still a box filter.
+;
+; GLOBAL(void)
+; jsimd_h2v2_upsample_avx2 (nt max_v_samp_factor,
+;                           JDIMENSION output_width,
+;                           JSAMPARRAY input_data,
+;                           JSAMPARRAY * output_data_ptr);
+;
+
+; r10 = int max_v_samp_factor
+; r11 = JDIMENSION output_width
+; r12 = JSAMPARRAY input_data
+; r13 = JSAMPARRAY * output_data_ptr
+
+        align   32
+        global  EXTN(jsimd_h2v2_upsample_avx2)
+
+EXTN(jsimd_h2v2_upsample_avx2):
+        push    rbp
+        mov     rax,rsp
+        mov     rbp,rsp
+        collect_args
+        push    rbx
+
+        mov     rdx, r11
+        add     rdx, byte (SIZEOF_YMMWORD-1)
+        and     rdx, -SIZEOF_YMMWORD
+        jz      near .return
+
+        mov     rcx, r10        ; rowctr
+        test    rcx,rcx
+        jz      near .return
+
+        mov     rsi, r12        ; input_data
+        mov     rdi, r13
+        mov     rdi, JSAMPARRAY [rdi]                   ; output_data
+.rowloop:
+        push    rdi
+        push    rsi
+
+        mov     rsi, JSAMPROW [rsi]                     ; inptr
+        mov     rbx, JSAMPROW [rdi+0*SIZEOF_JSAMPROW]   ; outptr0
+        mov     rdi, JSAMPROW [rdi+1*SIZEOF_JSAMPROW]   ; outptr1
+        mov     rax,rdx                                 ; colctr
+
+.columnloop:
+
+        cmp rax, byte SIZEOF_YMMWORD
+        ja    short .above_16
+
+        vmovdqa  xmm0, XMMWORD [rsi+0*SIZEOF_XMMWORD]
+        vpunpckhbw xmm1,xmm0,xmm0
+        vpunpcklbw xmm0,xmm0,xmm0
+        vmovdqa  XMMWORD [rbx+0*SIZEOF_XMMWORD], xmm0
+        vmovdqa  XMMWORD [rbx+1*SIZEOF_XMMWORD], xmm1
+        vmovdqa  XMMWORD [rdi+0*SIZEOF_XMMWORD], xmm0
+        vmovdqa  XMMWORD [rdi+1*SIZEOF_XMMWORD], xmm1
+
+        jmp   near .nextrow
+
+.above_16:
+        vmovdqa  ymm0, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+    
+        vpermq     ymm0,ymm0,0xd8
+        vpunpckhbw ymm1,ymm0,ymm0 
+        vpunpcklbw ymm0,ymm0,ymm0 
+
+        vmovdqa  YMMWORD [rbx+0*SIZEOF_YMMWORD], ymm0
+        vmovdqa  YMMWORD [rbx+1*SIZEOF_YMMWORD], ymm1
+        vmovdqa  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm0
+        vmovdqa  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymm1
+
+        sub     rax, byte 2*SIZEOF_YMMWORD
+        jz      short .nextrow
+
+        add     rsi, byte SIZEOF_YMMWORD      ; inptr
+        add     rbx, 2*SIZEOF_YMMWORD      ; outptr0
+        add     rdi, 2*SIZEOF_YMMWORD      ; outptr1
+        jmp     short .columnloop
+
+.nextrow:
+        pop     rsi
+        pop     rdi
+
+        add     rsi, byte 1*SIZEOF_JSAMPROW     ; input_data
+        add     rdi, byte 2*SIZEOF_JSAMPROW     ; output_data
+        sub     rcx, byte 2                     ; rowctr
+        jg      near .rowloop
+
+.return:
+        pop     rbx
+        uncollect_args
+        pop     rbp
+        ret
+
+; For some reason, the OS X linker does not honor the request to align the
+; segment unless we do this.
+        align   32

--- a/simd/jdsample-avx2-64.asm
+++ b/simd/jdsample-avx2-64.asm
@@ -112,12 +112,12 @@ EXTN(jsimd_h2v1_fancy_upsample_avx2):
         jmp     short .upsample
 
 .columnloop:
-        vmovdqa  ymm6, YMMWORD [rsi+1*SIZEOF_YMMWORD]
+        vmovdqu  ymm6, YMMWORD [rsi+1*SIZEOF_YMMWORD]
         vperm2i128 ymm8,ymm0,ymm6,0x20  
         vpslldq ymm6,ymm8,15      
 
 .upsample:
-        vmovdqa  ymm1, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymm1, YMMWORD [rsi+0*SIZEOF_YMMWORD]
         vmovdqa  ymm2,ymm1
         vmovdqa  ymm3,ymm1               
 
@@ -168,8 +168,8 @@ EXTN(jsimd_h2v1_fancy_upsample_avx2):
         vpor     ymm2,ymm2,ymm3               
         vpor     ymm5,ymm5,ymm6               
 
-        vmovdqa  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm2
-        vmovdqa  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymm5
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm2
+        vmovdqu  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymm5
 
         sub     rax, byte SIZEOF_YMMWORD
         add     rsi, byte 1*SIZEOF_YMMWORD      ; inptr
@@ -269,9 +269,9 @@ EXTN(jsimd_h2v2_fancy_upsample_avx2):
 .skip:
         ; -- process the first column block
 
-        vmovdqa  ymm0, YMMWORD [rbx+0*SIZEOF_YMMWORD]    
-        vmovdqa  ymm1, YMMWORD [rcx+0*SIZEOF_YMMWORD]    
-        vmovdqa  ymm2, YMMWORD [rsi+0*SIZEOF_YMMWORD]    
+        vmovdqu  ymm0, YMMWORD [rbx+0*SIZEOF_YMMWORD]    
+        vmovdqu  ymm1, YMMWORD [rcx+0*SIZEOF_YMMWORD]    
+        vmovdqu  ymm2, YMMWORD [rsi+0*SIZEOF_YMMWORD]    
 
         vpunpckhbw ymm4,ymm0,ymm13             
         vpunpcklbw ymm8,ymm0,ymm13             
@@ -296,10 +296,10 @@ EXTN(jsimd_h2v2_fancy_upsample_avx2):
         vpaddw   ymm2,ymm2,ymm0               
         vpaddw   ymm6,ymm6,ymm4               
 
-        vmovdqa  YMMWORD [rdx+0*SIZEOF_YMMWORD], ymm1    
-        vmovdqa  YMMWORD [rdx+1*SIZEOF_YMMWORD], ymm5    
-        vmovdqa  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm2
-        vmovdqa  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymm6
+        vmovdqu  YMMWORD [rdx+0*SIZEOF_YMMWORD], ymm1    
+        vmovdqu  YMMWORD [rdx+1*SIZEOF_YMMWORD], ymm5    
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm2
+        vmovdqu  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymm6
 
         vpand    ymm1,ymm1,ymm15               
         vpand    ymm2,ymm2,ymm15               
@@ -326,9 +326,9 @@ EXTN(jsimd_h2v2_fancy_upsample_avx2):
         .columnloop:
         ; -- process the next column block
 
-        vmovdqa  ymm0, YMMWORD [rbx+1*SIZEOF_YMMWORD]    
-        vmovdqa  ymm1, YMMWORD [rcx+1*SIZEOF_YMMWORD]    
-        vmovdqa  ymm2, YMMWORD [rsi+1*SIZEOF_YMMWORD]    
+        vmovdqu  ymm0, YMMWORD [rbx+1*SIZEOF_YMMWORD]    
+        vmovdqu  ymm1, YMMWORD [rcx+1*SIZEOF_YMMWORD]    
+        vmovdqu  ymm2, YMMWORD [rsi+1*SIZEOF_YMMWORD]    
 
         vpunpckhbw ymm4,ymm0,ymm13             
         vpunpcklbw ymm8,ymm0,ymm13             
@@ -353,10 +353,10 @@ EXTN(jsimd_h2v2_fancy_upsample_avx2):
         vpaddw   ymm2,ymm2,ymm0               
         vpaddw   ymm6,ymm6,ymm4               
 
-        vmovdqa  YMMWORD [rdx+2*SIZEOF_YMMWORD], ymm1    
-        vmovdqa  YMMWORD [rdx+3*SIZEOF_YMMWORD], ymm5    
-        vmovdqa  YMMWORD [rdi+2*SIZEOF_YMMWORD], ymm2
-        vmovdqa  YMMWORD [rdi+3*SIZEOF_YMMWORD], ymm6
+        vmovdqu  YMMWORD [rdx+2*SIZEOF_YMMWORD], ymm1    
+        vmovdqu  YMMWORD [rdx+3*SIZEOF_YMMWORD], ymm5    
+        vmovdqu  YMMWORD [rdi+2*SIZEOF_YMMWORD], ymm2
+        vmovdqu  YMMWORD [rdi+3*SIZEOF_YMMWORD], ymm6
 
         vperm2i128 ymm1,ymm13,ymm1,0x20     
         vpslldq  ymm1,ymm1,14       
@@ -369,8 +369,8 @@ EXTN(jsimd_h2v2_fancy_upsample_avx2):
 .upsample:
         ; -- process the upper row
 
-        vmovdqa  ymm7, YMMWORD [rdx+0*SIZEOF_YMMWORD]
-        vmovdqa  ymm3, YMMWORD [rdx+1*SIZEOF_YMMWORD]
+        vmovdqu  ymm7, YMMWORD [rdx+0*SIZEOF_YMMWORD]
+        vmovdqu  ymm3, YMMWORD [rdx+1*SIZEOF_YMMWORD]
         vmovdqa  ymm0,ymm7               
         vmovdqa  ymm4,ymm3               
         vperm2i128 ymm8,ymm13,ymm0,0x03  
@@ -423,13 +423,13 @@ EXTN(jsimd_h2v2_fancy_upsample_avx2):
         vpor     ymm1,ymm1,ymm0               
         vpor     ymm5,ymm5,ymm2               
 
-        vmovdqa  YMMWORD [rdx+0*SIZEOF_YMMWORD], ymm1
-        vmovdqa  YMMWORD [rdx+1*SIZEOF_YMMWORD], ymm5
+        vmovdqu  YMMWORD [rdx+0*SIZEOF_YMMWORD], ymm1
+        vmovdqu  YMMWORD [rdx+1*SIZEOF_YMMWORD], ymm5
 
         ; -- process the lower row
 
-        vmovdqa  ymm6, YMMWORD [rdi+0*SIZEOF_YMMWORD]
-        vmovdqa  ymm4, YMMWORD [rdi+1*SIZEOF_YMMWORD]
+        vmovdqu  ymm6, YMMWORD [rdi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymm4, YMMWORD [rdi+1*SIZEOF_YMMWORD]
 
         vmovdqa  ymm7,ymm6               
         vmovdqa  ymm3,ymm4               
@@ -488,8 +488,8 @@ EXTN(jsimd_h2v2_fancy_upsample_avx2):
         vpor     ymm1,ymm1,ymm7               
         vpor     ymm0,ymm0,ymm5               
 
-        vmovdqa  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm1
-        vmovdqa  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymm0
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm1
+        vmovdqu  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymm0
 
         sub     rax, byte SIZEOF_YMMWORD
         add     rcx, byte 1*SIZEOF_YMMWORD      
@@ -572,22 +572,22 @@ EXTN(jsimd_h2v1_upsample_avx2):
     cmp   rax, byte SIZEOF_YMMWORD
     ja    near .above_16
 
-        vmovdqa  xmm0, XMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  xmm0, XMMWORD [rsi+0*SIZEOF_YMMWORD]
         vpunpckhbw xmm1,xmm0,xmm0
         vpunpcklbw xmm0,xmm0,xmm0
-        vmovdqa  XMMWORD [rdi+0*SIZEOF_XMMWORD], xmm0
-        vmovdqa  XMMWORD [rdi+1*SIZEOF_XMMWORD], xmm1
+        vmovdqu  XMMWORD [rdi+0*SIZEOF_XMMWORD], xmm0
+        vmovdqu  XMMWORD [rdi+1*SIZEOF_XMMWORD], xmm1
     jmp   short .nextrow
 
 .above_16:
-        vmovdqa  ymm0, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymm0, YMMWORD [rsi+0*SIZEOF_YMMWORD]
 
         vpermq     ymm0,ymm0,0xd8
         vpunpckhbw ymm1,ymm0,ymm0
         vpunpcklbw ymm0,ymm0,ymm0
 
-        vmovdqa  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm0
-        vmovdqa  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymm1
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm0
+        vmovdqu  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymm1
 
         sub     rax, byte 2*SIZEOF_YMMWORD
         jz      short .nextrow
@@ -663,27 +663,27 @@ EXTN(jsimd_h2v2_upsample_avx2):
         cmp rax, byte SIZEOF_YMMWORD
         ja    short .above_16
 
-        vmovdqa  xmm0, XMMWORD [rsi+0*SIZEOF_XMMWORD]
+        vmovdqu  xmm0, XMMWORD [rsi+0*SIZEOF_XMMWORD]
         vpunpckhbw xmm1,xmm0,xmm0
         vpunpcklbw xmm0,xmm0,xmm0
-        vmovdqa  XMMWORD [rbx+0*SIZEOF_XMMWORD], xmm0
-        vmovdqa  XMMWORD [rbx+1*SIZEOF_XMMWORD], xmm1
-        vmovdqa  XMMWORD [rdi+0*SIZEOF_XMMWORD], xmm0
-        vmovdqa  XMMWORD [rdi+1*SIZEOF_XMMWORD], xmm1
+        vmovdqu  XMMWORD [rbx+0*SIZEOF_XMMWORD], xmm0
+        vmovdqu  XMMWORD [rbx+1*SIZEOF_XMMWORD], xmm1
+        vmovdqu  XMMWORD [rdi+0*SIZEOF_XMMWORD], xmm0
+        vmovdqu  XMMWORD [rdi+1*SIZEOF_XMMWORD], xmm1
 
         jmp   near .nextrow
 
 .above_16:
-        vmovdqa  ymm0, YMMWORD [rsi+0*SIZEOF_YMMWORD]
+        vmovdqu  ymm0, YMMWORD [rsi+0*SIZEOF_YMMWORD]
     
         vpermq     ymm0,ymm0,0xd8
         vpunpckhbw ymm1,ymm0,ymm0 
         vpunpcklbw ymm0,ymm0,ymm0 
 
-        vmovdqa  YMMWORD [rbx+0*SIZEOF_YMMWORD], ymm0
-        vmovdqa  YMMWORD [rbx+1*SIZEOF_YMMWORD], ymm1
-        vmovdqa  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm0
-        vmovdqa  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymm1
+        vmovdqu  YMMWORD [rbx+0*SIZEOF_YMMWORD], ymm0
+        vmovdqu  YMMWORD [rbx+1*SIZEOF_YMMWORD], ymm1
+        vmovdqu  YMMWORD [rdi+0*SIZEOF_YMMWORD], ymm0
+        vmovdqu  YMMWORD [rdi+1*SIZEOF_YMMWORD], ymm1
 
         sub     rax, byte 2*SIZEOF_YMMWORD
         jz      short .nextrow

--- a/simd/jfdctflt-avx2-64.asm
+++ b/simd/jfdctflt-avx2-64.asm
@@ -1,0 +1,168 @@
+;
+; jfdctflt.asm - floating-point FDCT (64-bit SSE)
+;
+; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2009 D. R. Commander
+; Copyright 2015 Intel Corporation
+;
+; Based on
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; This file contains a floating-point implementation of the forward DCT
+; (Discrete Cosine Transform). The following code is based directly on
+; the IJG's original jfdctflt.c; see the jfdctflt.c for more details.
+;
+; [TAB8]
+
+%include "jsimdext.inc"
+%include "jdct.inc"
+
+; --------------------------------------------------------------------------
+        SECTION SEG_CONST
+
+        alignz  32
+        global  EXTN(jconst_fdct_float_avx2)
+
+EXTN(jconst_fdct_float_avx2):
+
+PD_0_382        times 8 dd  0.382683432365089771728460
+PD_0_707        times 8 dd  0.707106781186547524400844
+PD_0_541        times 8 dd  0.541196100146196984399723
+PD_1_306        times 8 dd  1.306562964876376527856643
+
+        alignz  32
+
+; --------------------------------------------------------------------------
+        SECTION SEG_TEXT
+        BITS    64
+;
+; Perform the forward DCT on one block of samples.
+;
+; GLOBAL(void)
+; jsimd_fdct_float_avx2 (FAST_FLOAT * data)
+;
+
+; r10 = FAST_FLOAT * data
+
+        align   32
+        global  EXTN(jsimd_fdct_float_avx2)
+
+EXTN(jsimd_fdct_float_avx2):
+
+        ; ---- Pass 1: process rows.
+
+        mov     rdx, rdi        ; (FAST_FLOAT *)
+        mov     rcx, DCTSIZE/4
+
+        vmovaps  ymm0, YMMWORD [YMMBLOCK(0,0,rdx,SIZEOF_FAST_FLOAT)]
+        vmovaps  ymm1, YMMWORD [YMMBLOCK(1,0,rdx,SIZEOF_FAST_FLOAT)]
+        vmovaps  ymm2, YMMWORD [YMMBLOCK(2,0,rdx,SIZEOF_FAST_FLOAT)]
+        vmovaps  ymm3, YMMWORD [YMMBLOCK(3,0,rdx,SIZEOF_FAST_FLOAT)]
+        vmovaps  ymm4, YMMWORD [YMMBLOCK(4,0,rdx,SIZEOF_FAST_FLOAT)]
+        vmovaps  ymm5, YMMWORD [YMMBLOCK(5,0,rdx,SIZEOF_FAST_FLOAT)]
+        vmovaps  ymm6, YMMWORD [YMMBLOCK(6,0,rdx,SIZEOF_FAST_FLOAT)]
+        vmovaps  ymm7, YMMWORD [YMMBLOCK(7,0,rdx,SIZEOF_FAST_FLOAT)]
+
+        jmp near .rowloop
+        nop
+
+.columnloop:
+.rowloop:
+
+        vunpcklps ymm10,ymm2,ymm3
+        vunpckhps ymm11,ymm2,ymm3
+        vunpcklps ymm8,ymm0,ymm1
+        vunpckhps ymm9,ymm0,ymm1
+        vunpcklpd ymm0,ymm8,ymm10
+        vunpckhpd ymm2,ymm8,ymm10
+        vunpcklpd ymm1,ymm9,ymm11
+        vunpckhpd ymm3,ymm9,ymm11
+
+        vunpcklps ymm14,ymm6,ymm7
+        vunpckhps ymm15,ymm6,ymm7
+        vunpcklps ymm12,ymm4,ymm5
+        vunpckhps ymm13,ymm4,ymm5
+        vunpcklpd ymm4,ymm12,ymm14
+        vunpckhpd ymm6,ymm12,ymm14
+        vunpcklpd ymm5,ymm13,ymm15
+        vunpckhpd ymm7,ymm13,ymm15
+        vperm2f128 ymm8,ymm0,ymm4,0x20 
+        vperm2f128 ymm12,ymm0,ymm4,0x31
+        vperm2f128 ymm10,ymm1,ymm5,0x20
+        vperm2f128 ymm14,ymm1,ymm5,0x31
+        vperm2f128 ymm9,ymm2,ymm6,0x20
+        vperm2f128 ymm13,ymm2,ymm6,0x31
+        vperm2f128 ymm11,ymm3,ymm7,0x20
+        vperm2f128 ymm15,ymm3,ymm7,0x31
+
+        vaddps ymm0,ymm8,ymm15
+        vsubps ymm7,ymm8,ymm15
+        vaddps ymm1,ymm9,ymm14
+        vsubps ymm8,ymm9,ymm14
+        vaddps ymm2,ymm10,ymm13
+        vsubps ymm5,ymm10,ymm13
+        vaddps ymm3,ymm11,ymm12
+        vsubps ymm9,ymm11,ymm12
+
+        vaddps ymm10, ymm0,ymm3
+        vsubps ymm13, ymm0,ymm3
+        vaddps ymm11, ymm1,ymm2
+        vsubps ymm12, ymm1,ymm2
+
+        vaddps ymm0, ymm10,ymm11 
+        vsubps ymm4, ymm10,ymm11 
+
+        vaddps ymm10,ymm12,ymm13
+        vmulps ymm12,ymm10,[rel PD_0_707]
+        vaddps ymm2, ymm13,ymm12
+        vsubps ymm6, ymm13,ymm12
+
+        vaddps ymm12, ymm9, ymm5
+        vaddps ymm13, ymm5, ymm8
+        vaddps ymm14, ymm8, ymm7
+        
+        vsubps ymm15, ymm12, ymm14
+        vmulps ymm8, ymm15, [rel PD_0_382] 
+        vmulps ymm12,ymm12,[rel PD_0_541]
+        vaddps ymm12,ymm12,ymm8
+        vmulps ymm14,ymm14,[rel PD_1_306]
+        vaddps ymm14,ymm14,ymm8
+
+
+        vmulps ymm15,ymm13,[rel PD_0_707]
+
+        vaddps ymm8,ymm7,ymm15 
+        vsubps ymm1,ymm7,ymm15 
+        
+        vaddps ymm5,ymm1,ymm12 
+        vsubps ymm3,ymm1,ymm12
+        vaddps ymm1,ymm8,ymm14
+        vsubps ymm7,ymm8,ymm14
+
+        ; ---- Pass 2: process columns.
+
+        dec     rcx
+        jnz     near .columnloop
+
+        vmovaps   YMMWORD [YMMBLOCK(0,0,rdx,SIZEOF_FAST_FLOAT)],ymm0
+        vmovaps   YMMWORD [YMMBLOCK(1,0,rdx,SIZEOF_FAST_FLOAT)],ymm1
+        vmovaps   YMMWORD [YMMBLOCK(2,0,rdx,SIZEOF_FAST_FLOAT)],ymm2
+        vmovaps   YMMWORD [YMMBLOCK(3,0,rdx,SIZEOF_FAST_FLOAT)],ymm3
+        vmovaps   YMMWORD [YMMBLOCK(4,0,rdx,SIZEOF_FAST_FLOAT)],ymm4
+        vmovaps   YMMWORD [YMMBLOCK(5,0,rdx,SIZEOF_FAST_FLOAT)],ymm5
+        vmovaps   YMMWORD [YMMBLOCK(6,0,rdx,SIZEOF_FAST_FLOAT)],ymm6
+        vmovaps   YMMWORD [YMMBLOCK(7,0,rdx,SIZEOF_FAST_FLOAT)],ymm7
+        
+        ret
+
+; For some reason, the OS X linker does not honor the request to align the
+; segment unless we do this.
+        align   32

--- a/simd/jfdctflt-avx2-64.asm
+++ b/simd/jfdctflt-avx2-64.asm
@@ -1,5 +1,5 @@
 ;
-; jfdctflt.asm - floating-point FDCT (64-bit SSE)
+; jfdctflt.asm - floating-point FDCT (64-bit AVX2)
 ;
 ; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
 ; Copyright 2009 D. R. Commander

--- a/simd/jfdctmflt-avx2-64.asm
+++ b/simd/jfdctmflt-avx2-64.asm
@@ -1,0 +1,270 @@
+;
+; jfdctflt.asm - floating-point FDCT (64-bit SSE)
+;
+; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2009 D. R. Commander
+; Copyright 2015 Intel Corporation
+;
+; Based on
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; This file contains a floating-point implementation of the forward DCT
+; (Discrete Cosine Transform). The following code is based directly on
+; the IJG's original jfdctflt.c; see the jfdctflt.c for more details.
+;
+; [TAB8]
+
+%include "jsimdext.inc"
+%include "jdct.inc"
+
+; --------------------------------------------------------------------------
+        SECTION SEG_TEXT
+        BITS    64
+
+        alignz  32
+        global  EXTN(jconst_fdct_merged_float_avx2)
+
+EXTN(jconst_fdct_merged_float_avx2):
+
+PD_0_382        times 8 dd  0.382683432365089771728460
+PD_0_707        times 8 dd  0.707106781186547524400844
+PD_0_541        times 8 dd  0.541196100146196984399723
+PD_1_306        times 8 dd  1.306562964876376527856643
+
+;
+        align   32
+        global  EXTN(jsimd_fdct_merged_float_avx2)
+
+EXTN(jsimd_fdct_merged_float_avx2):
+        push    rbp
+        mov     rbp,rsp
+
+        push rbx
+        collect_args
+
+.convsamp:
+        mov rsi, r10
+        mov rax, r11
+        vpcmpeqw  ymm15,ymm15,ymm15
+        vpsllw    ymm15,ymm15,7
+        vpacksswb ymm15,ymm15,ymm15
+
+        mov     rbx, JSAMPROW [rsi+0*SIZEOF_JSAMPROW]   ; (JSAMPLE *)
+        mov rdx, JSAMPROW [rsi+1*SIZEOF_JSAMPROW]       ; (JSAMPLE *)
+        vmovq    xmm0, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]
+        vmovq    xmm1, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]
+
+        vperm2i128 ymm9, ymm0,ymm1,0x20
+        vpsubb ymm0,ymm9,ymm15
+
+        vpunpcklbw ymm1,ymm0,ymm0 
+        vpermq ymm8,ymm1,0xd8
+        vpunpcklwd ymm0,ymm1,ymm8 
+        vpunpckhwd ymm1,ymm9,ymm8 
+        
+        vpsrad ymm8,ymm0,(DWORD_BIT-BYTE_BIT) 
+        vpsrad ymm9,ymm1,(DWORD_BIT-BYTE_BIT)
+        vcvtdq2ps ymm0,ymm8
+        vcvtdq2ps ymm1,ymm9
+
+        mov     rbx, JSAMPROW [rsi+2*SIZEOF_JSAMPROW]   ; (JSAMPLE *)
+        mov rdx, JSAMPROW [rsi+3*SIZEOF_JSAMPROW]       ; (JSAMPLE *)
+
+        vmovq    xmm2, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]
+        vmovq    xmm3, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]
+
+        vperm2i128 ymm11, ymm2,ymm3,0x20
+        vpsubb ymm2,ymm11,ymm15
+
+        vpunpcklbw ymm3,ymm2,ymm2
+        vpermq ymm10,ymm3,0xd8
+        vpunpcklwd ymm2,ymm3,ymm10 
+        vpunpckhwd ymm3,ymm11,ymm10 
+        
+        vpsrad ymm10,ymm2,(DWORD_BIT-BYTE_BIT) 
+        vpsrad ymm11,ymm3,(DWORD_BIT-BYTE_BIT)
+        vcvtdq2ps ymm2,ymm10
+        vcvtdq2ps ymm3,ymm11
+
+        mov     rbx, JSAMPROW [rsi+4*SIZEOF_JSAMPROW]   ; (JSAMPLE *)
+        mov rdx, JSAMPROW [rsi+5*SIZEOF_JSAMPROW]       ; (JSAMPLE *)
+
+        vmovq    xmm4, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]
+        vmovq    xmm5, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]
+
+        vperm2i128 ymm13, ymm4,ymm5,0x20
+        vpsubb ymm4,ymm13,ymm15
+
+        vpunpcklbw ymm5,ymm4,ymm4
+        vpermq ymm12,ymm5,0xd8
+        vpunpcklwd ymm4,ymm5,ymm12 
+        vpunpckhwd ymm5,ymm13,ymm12 
+        
+        vpsrad ymm12,ymm4,(DWORD_BIT-BYTE_BIT) 
+        vpsrad ymm13,ymm5,(DWORD_BIT-BYTE_BIT)
+        vcvtdq2ps ymm4,ymm12
+        vcvtdq2ps ymm5,ymm13
+
+        mov     rbx, JSAMPROW [rsi+6*SIZEOF_JSAMPROW]   ; (JSAMPLE *)
+        mov     rdx, JSAMPROW [rsi+7*SIZEOF_JSAMPROW]       ; (JSAMPLE *)
+
+        vmovq    xmm6, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]
+        vmovq    xmm7, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]
+
+        vperm2i128 ymm9, ymm6,ymm7,0x20
+        vpsubb ymm6,ymm9,ymm15
+
+        vpunpcklbw ymm7,ymm6,ymm6 
+        vpermq ymm14,ymm7,0xd8
+        vpunpcklwd ymm6,ymm7,ymm14 
+        vpunpckhwd ymm7,ymm9,ymm14 
+        
+        vpsrad ymm14,ymm6,(DWORD_BIT-BYTE_BIT) 
+        vpsrad ymm9,ymm7,(DWORD_BIT-BYTE_BIT)
+        vcvtdq2ps ymm6,ymm14
+        vcvtdq2ps ymm7,ymm9
+
+.dct:
+
+        mov     rcx, DCTSIZE/4
+.dctloop:
+        vunpcklps ymm10,ymm2,ymm3
+        vunpckhps ymm11,ymm2,ymm3
+        vunpcklps ymm8,ymm0,ymm1
+        vunpckhps ymm9,ymm0,ymm1
+        vunpcklpd ymm0,ymm8,ymm10
+        vunpckhpd ymm2,ymm8,ymm10
+        vunpcklpd ymm1,ymm9,ymm11
+        vunpckhpd ymm3,ymm9,ymm11
+
+        vunpcklps ymm14,ymm6,ymm7
+        vunpckhps ymm15,ymm6,ymm7
+        vunpcklps ymm12,ymm4,ymm5
+        vunpckhps ymm13,ymm4,ymm5
+        vunpcklpd ymm4,ymm12,ymm14
+        vunpckhpd ymm6,ymm12,ymm14
+        vunpcklpd ymm5,ymm13,ymm15
+        vunpckhpd ymm7,ymm13,ymm15
+        vperm2f128 ymm8,ymm0,ymm4,0x20 
+        vperm2f128 ymm12,ymm0,ymm4,0x31
+        vperm2f128 ymm10,ymm1,ymm5,0x20
+        vperm2f128 ymm14,ymm1,ymm5,0x31
+        vperm2f128 ymm9,ymm2,ymm6,0x20
+        vperm2f128 ymm13,ymm2,ymm6,0x31
+        vperm2f128 ymm11,ymm3,ymm7,0x20
+        vperm2f128 ymm15,ymm3,ymm7,0x31
+
+        vaddps ymm0,ymm8,ymm15
+        vsubps ymm7,ymm8,ymm15
+        vaddps ymm1,ymm9,ymm14
+        vsubps ymm8,ymm9,ymm14
+        vaddps ymm2,ymm10,ymm13
+        vsubps ymm5,ymm10,ymm13
+        vaddps ymm3,ymm11,ymm12
+        vsubps ymm9,ymm11,ymm12
+
+        vaddps ymm10, ymm0,ymm3
+        vsubps ymm13, ymm0,ymm3
+        vaddps ymm11, ymm1,ymm2
+        vsubps ymm12, ymm1,ymm2
+
+        vaddps ymm0, ymm10,ymm11
+        vsubps ymm4, ymm10,ymm11
+
+        vaddps ymm10,ymm12,ymm13
+        vmulps ymm12,ymm10,[rel PD_0_707]
+        vaddps ymm2, ymm13,ymm12
+        vsubps ymm6, ymm13,ymm12
+
+        ;/*Odd part*/
+        vaddps ymm12, ymm9, ymm5
+        vaddps ymm13, ymm5, ymm8
+        vaddps ymm14, ymm8, ymm7
+        
+        vsubps ymm15, ymm12, ymm14
+        vmulps ymm8, ymm15, [rel PD_0_382]
+        vmulps ymm12,ymm12,[rel PD_0_541]
+        vaddps ymm12,ymm12,ymm8
+        vmulps ymm14,ymm14,[rel PD_1_306]
+        vaddps ymm14,ymm14,ymm8
+
+
+        vmulps ymm15,ymm13,[rel PD_0_707]
+
+        vaddps ymm8,ymm7,ymm15 
+        vsubps ymm1,ymm7,ymm15 
+        
+        vaddps ymm5,ymm1,ymm12 
+        vsubps ymm3,ymm1,ymm12 
+        vaddps ymm1,ymm8,ymm14
+        vsubps ymm7,ymm8,ymm14
+
+        ; ---- Pass 2: process columns.
+
+        dec     rcx
+        jnz     near .dctloop
+.quantize:
+        mov rdx, r13
+        mov rdi, r12
+
+        vmulps   ymm0,ymm0, YMMWORD [YMMBLOCK(0,0,rdx,SIZEOF_FAST_FLOAT)]
+        vmulps   ymm1,ymm1, YMMWORD [YMMBLOCK(1,0,rdx,SIZEOF_FAST_FLOAT)]
+
+        vcvtps2dq ymm0,ymm0
+        vcvtps2dq ymm1,ymm1
+
+        vpackssdw ymm1,ymm0,ymm1
+        vpermq ymm0,ymm1,0xD8
+
+        vmovdqa  YMMWORD [YMMBLOCK(0,0,rdi,2*SIZEOF_JCOEF)], ymm0
+        vmulps   ymm2,ymm2, YMMWORD [YMMBLOCK(2,0,rdx,SIZEOF_FAST_FLOAT)]
+        vmulps   ymm3,ymm3, YMMWORD [YMMBLOCK(3,0,rdx,SIZEOF_FAST_FLOAT)]
+
+        vcvtps2dq ymm2,ymm2
+        vcvtps2dq ymm3,ymm3
+
+        vpackssdw ymm3,ymm2,ymm3
+        vpermq ymm2,ymm3,0xD8
+
+        vmovdqa  YMMWORD [YMMBLOCK(1,0,rdi,2*SIZEOF_JCOEF)], ymm2
+        vmulps   ymm4,ymm4, YMMWORD [YMMBLOCK(4,0,rdx,SIZEOF_FAST_FLOAT)]
+        vmulps   ymm5,ymm5, YMMWORD [YMMBLOCK(5,0,rdx,SIZEOF_FAST_FLOAT)]
+
+        vcvtps2dq ymm4,ymm4
+        vcvtps2dq ymm5,ymm5
+
+        vpackssdw ymm5,ymm4,ymm5
+        vpermq ymm4,ymm5,0xD8
+
+        vmovdqa  YMMWORD [YMMBLOCK(2,0,rdi,2*SIZEOF_JCOEF)], ymm4
+
+        vmulps   ymm6,ymm6, YMMWORD [YMMBLOCK(6,0,rdx,SIZEOF_FAST_FLOAT)]
+        vmulps   ymm7,ymm7, YMMWORD [YMMBLOCK(7,0,rdx,SIZEOF_FAST_FLOAT)]
+
+        vcvtps2dq ymm6,ymm6
+        vcvtps2dq ymm7,ymm7
+
+        vpackssdw ymm7,ymm6,ymm7
+        vpermq ymm6,ymm7,0xD8
+
+        vmovdqa  YMMWORD [YMMBLOCK(3,0,rdi,2*SIZEOF_JCOEF)], ymm6
+
+        uncollect_args
+        pop     rbx
+        pop     rbp
+        ret
+
+; For some reason, the OS X linker does not honor the request to align the
+; segment unless we do this.
+        align   32
+
+
+

--- a/simd/jfdctmflt-avx2-64.asm
+++ b/simd/jfdctmflt-avx2-64.asm
@@ -1,5 +1,5 @@
 ;
-; jfdctflt.asm - floating-point FDCT (64-bit SSE)
+; jfdctflt.asm - floating-point FDCT (64-bit AVX2)
 ;
 ; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
 ; Copyright 2009 D. R. Commander

--- a/simd/jfdctmfst-avx2-64.asm
+++ b/simd/jfdctmfst-avx2-64.asm
@@ -89,17 +89,17 @@ EXTN(jsimd_fdct_merged_ifast_avx2):
         mov     rbx, JSAMPROW [rsi+0*SIZEOF_JSAMPROW]   
         mov rdx, JSAMPROW [rsi+1*SIZEOF_JSAMPROW]       
 
-        vmovdqa    xmm0, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm0, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
 		vpermq	   ymm0, ymm0, 0x10
-        vmovdqa    xmm1, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm1, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
 		vpermq	   ymm1, ymm1, 0x10
 
         mov     rbx, JSAMPROW [rsi+2*SIZEOF_JSAMPROW]   
         mov     rdx, JSAMPROW [rsi+3*SIZEOF_JSAMPROW]   
 
-        vmovdqa    xmm2, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm2, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
 		vpermq	   ymm2, ymm2, 0x10
-        vmovdqa    xmm3, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm3, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
 		vpermq	   ymm3, ymm3, 0x10
 
         vpunpcklbw ymm0,ymm0,ymm14             
@@ -114,17 +114,17 @@ EXTN(jsimd_fdct_merged_ifast_avx2):
         mov     rbx, JSAMPROW [rsi+4*SIZEOF_JSAMPROW]   
         mov     rdx, JSAMPROW [rsi+5*SIZEOF_JSAMPROW]       
 
-        vmovdqa    xmm8, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm8, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
 		vpermq	   ymm8, ymm8, 0x10
-        vmovdqa    xmm9, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm9, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
 		vpermq	   ymm9, ymm9, 0x10
 
         mov     rbx, JSAMPROW [rsi+6*SIZEOF_JSAMPROW]   
         mov     rdx, JSAMPROW [rsi+7*SIZEOF_JSAMPROW]   
 
-        vmovdqa    xmm10, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm10, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
 		vpermq	   ymm10, ymm10, 0x10
-        vmovdqa    xmm11, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm11, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
 		vpermq	   ymm11, ymm11, 0x10
 
         vpunpcklbw ymm8,ymm8,ymm14             
@@ -308,14 +308,14 @@ EXTN(jsimd_fdct_merged_ifast_avx2):
 		vperm2i128 ymm2,ymm4,ymm5,0x31
 		vperm2i128 ymm3,ymm6,ymm7,0x31
 
-		vmovdqa  YMMWORD [YMMBLOCK(0,0,rdi,2*SIZEOF_DCTELEM)], ymm8
-        vmovdqa  YMMWORD [YMMBLOCK(1,0,rdi,2*SIZEOF_DCTELEM)], ymm9
-        vmovdqa  YMMWORD [YMMBLOCK(2,0,rdi,2*SIZEOF_DCTELEM)], ymm10
-        vmovdqa  YMMWORD [YMMBLOCK(3,0,rdi,2*SIZEOF_DCTELEM)], ymm11
-		vmovdqa  YMMWORD [YMMBLOCK(4,0,rdi,2*SIZEOF_DCTELEM)], ymm0
-        vmovdqa  YMMWORD [YMMBLOCK(5,0,rdi,2*SIZEOF_DCTELEM)], ymm1
-        vmovdqa  YMMWORD [YMMBLOCK(6,0,rdi,2*SIZEOF_DCTELEM)], ymm2
-        vmovdqa  YMMWORD [YMMBLOCK(7,0,rdi,2*SIZEOF_DCTELEM)], ymm3
+		vmovdqu  YMMWORD [YMMBLOCK(0,0,rdi,2*SIZEOF_DCTELEM)], ymm8
+        vmovdqu  YMMWORD [YMMBLOCK(1,0,rdi,2*SIZEOF_DCTELEM)], ymm9
+        vmovdqu  YMMWORD [YMMBLOCK(2,0,rdi,2*SIZEOF_DCTELEM)], ymm10
+        vmovdqu  YMMWORD [YMMBLOCK(3,0,rdi,2*SIZEOF_DCTELEM)], ymm11
+		vmovdqu  YMMWORD [YMMBLOCK(4,0,rdi,2*SIZEOF_DCTELEM)], ymm0
+        vmovdqu  YMMWORD [YMMBLOCK(5,0,rdi,2*SIZEOF_DCTELEM)], ymm1
+        vmovdqu  YMMWORD [YMMBLOCK(6,0,rdi,2*SIZEOF_DCTELEM)], ymm2
+        vmovdqu  YMMWORD [YMMBLOCK(7,0,rdi,2*SIZEOF_DCTELEM)], ymm3
 
 .exit:
 

--- a/simd/jfdctmfst-avx2-64.asm
+++ b/simd/jfdctmfst-avx2-64.asm
@@ -1,5 +1,5 @@
 ;
-; jfdctflt.asm - floating-point FDCT (64-bit SSE)
+; jfdctflt.asm - floating-point FDCT (64-bit AVX2)
 ;
 ; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
 ; Copyright 2009 D. R. Commander

--- a/simd/jfdctmfst-avx2-64.asm
+++ b/simd/jfdctmfst-avx2-64.asm
@@ -1,0 +1,331 @@
+;
+; jfdctflt.asm - floating-point FDCT (64-bit SSE)
+;
+; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2009 D. R. Commander
+; Copyright 2015 Intel Corporation
+;
+; Based on
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; This file contains a floating-point implementation of the forward DCT
+; (Discrete Cosine Transform). The following code is based directly on
+; the IJG's original jfdctflt.c; see the jfdctflt.c for more details.
+;
+; [TAB8]
+
+%include "jsimdext.inc"
+%include "jdct.inc"
+
+        alignz  32
+; --------------------------------------------------------------------------
+
+%define RECIPROCAL(m,n,b) YMMBLOCK(DCTSIZE*0+(m),(n),(b),2*SIZEOF_DCTELEM)
+%define CORRECTION(m,n,b) YMMBLOCK(DCTSIZE*1+(m),(n),(b),2*SIZEOF_DCTELEM)
+%define SCALE(m,n,b)      YMMBLOCK(DCTSIZE*2+(m),(n),(b),2*SIZEOF_DCTELEM)
+
+; --------------------------------------------------------------------------
+
+%define CONST_BITS      8       ; 14 is also OK.
+
+%if CONST_BITS == 8
+F_0_382 equ      98             ; FIX(0.382683433)
+F_0_541 equ     139             ; FIX(0.541196100)
+F_0_707 equ     181             ; FIX(0.707106781)
+F_1_306 equ     334             ; FIX(1.306562965)
+%else
+; NASM cannot do compile-time arithmetic on floating-point constants.
+%define DESCALE(x,n)  (((x)+(1<<((n)-1)))>>(n))
+F_0_382 equ     DESCALE( 410903207,30-CONST_BITS)       ; FIX(0.382683433)
+F_0_541 equ     DESCALE( 581104887,30-CONST_BITS)       ; FIX(0.541196100)
+F_0_707 equ     DESCALE( 759250124,30-CONST_BITS)       ; FIX(0.707106781)
+F_1_306 equ     DESCALE(1402911301,30-CONST_BITS)       ; FIX(1.306562965)
+%endif
+        SECTION SEG_CONST
+
+%define PRE_MULTIPLY_SCALE_BITS   2
+%define CONST_SHIFT     (16 - PRE_MULTIPLY_SCALE_BITS - CONST_BITS)
+        alignz  32
+        global  EXTN(jconst_conv_fdct_quan_ifast_avx2)
+
+EXTN(jconst_fdct_merged_ifast_avx2):
+
+PW_F0707        times 16 dw  F_0_707 << CONST_SHIFT
+PW_F0382        times 16 dw  F_0_382 << CONST_SHIFT
+PW_F0541        times 16 dw  F_0_541 << CONST_SHIFT
+PW_F1306        times 16 dw  F_1_306 << CONST_SHIFT
+
+;
+        SECTION SEG_TEXT
+        BITS    64
+
+; --------------------------------------------------------------------------
+        align   32
+        global  EXTN(jsimd_fdct_merged_ifast_avx2)
+
+EXTN(jsimd_fdct_merged_ifast_avx2):
+        push    rbp
+        mov     rbp,rsp
+
+		push rbx
+        collect_args
+
+.convsamp:
+		mov rsi, r10
+        mov rax, r11
+
+        vpxor    ymm14,ymm14,ymm14               
+        vpcmpeqw ymm15,ymm15,ymm15
+        vpsllw   ymm15,ymm15,7                  
+.convloop:
+        mov     rbx, JSAMPROW [rsi+0*SIZEOF_JSAMPROW]   
+        mov rdx, JSAMPROW [rsi+1*SIZEOF_JSAMPROW]       
+
+        vmovdqa    xmm0, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+		vpermq	   ymm0, ymm0, 0x10
+        vmovdqa    xmm1, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+		vpermq	   ymm1, ymm1, 0x10
+
+        mov     rbx, JSAMPROW [rsi+2*SIZEOF_JSAMPROW]   
+        mov     rdx, JSAMPROW [rsi+3*SIZEOF_JSAMPROW]   
+
+        vmovdqa    xmm2, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+		vpermq	   ymm2, ymm2, 0x10
+        vmovdqa    xmm3, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+		vpermq	   ymm3, ymm3, 0x10
+
+        vpunpcklbw ymm0,ymm0,ymm14             
+        vpunpcklbw ymm1,ymm1,ymm14             
+        vpaddw     ymm0,ymm0,ymm15
+        vpaddw     ymm1,ymm1,ymm15
+        vpunpcklbw ymm2,ymm2,ymm14             
+        vpunpcklbw ymm3,ymm3,ymm14             
+        vpaddw     ymm2,ymm2,ymm15
+        vpaddw     ymm3,ymm3,ymm15
+
+        mov     rbx, JSAMPROW [rsi+4*SIZEOF_JSAMPROW]   
+        mov     rdx, JSAMPROW [rsi+5*SIZEOF_JSAMPROW]       
+
+        vmovdqa    xmm8, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+		vpermq	   ymm8, ymm8, 0x10
+        vmovdqa    xmm9, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+		vpermq	   ymm9, ymm9, 0x10
+
+        mov     rbx, JSAMPROW [rsi+6*SIZEOF_JSAMPROW]   
+        mov     rdx, JSAMPROW [rsi+7*SIZEOF_JSAMPROW]   
+
+        vmovdqa    xmm10, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+		vpermq	   ymm10, ymm10, 0x10
+        vmovdqa    xmm11, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+		vpermq	   ymm11, ymm11, 0x10
+
+        vpunpcklbw ymm8,ymm8,ymm14             
+        vpunpcklbw ymm9,ymm9,ymm14             
+        vpaddw     ymm4,ymm8,ymm15
+        vpaddw     ymm5,ymm9,ymm15
+        vpunpcklbw ymm10,ymm10,ymm14             
+        vpunpcklbw ymm11,ymm11,ymm14             
+        vpaddw     ymm6,ymm10,ymm15
+        vpaddw     ymm7,ymm11,ymm15
+
+.dct:
+
+        mov     rcx, DCTSIZE/4
+.dctloop:
+		vpunpcklwd ymm12,ymm2,ymm6
+		vpunpckhwd ymm13,ymm2,ymm6
+		vpunpcklwd ymm8,ymm0,ymm4
+		vpunpckhwd ymm9,ymm0,ymm4
+		vpunpcklwd ymm10,ymm1,ymm5
+		vpunpckhwd ymm11,ymm1,ymm5
+		vpunpcklwd ymm14,ymm3,ymm7
+		vpunpckhwd ymm15,ymm3,ymm7
+
+		vpunpcklwd ymm0,ymm8,ymm12
+		vpunpckhwd ymm1,ymm8,ymm12
+		vpunpcklwd ymm2,ymm9,ymm13
+		vpunpckhwd ymm3,ymm9,ymm13
+		vpunpcklwd ymm4,ymm10,ymm14
+		vpunpckhwd ymm5,ymm10,ymm14
+		vpunpcklwd ymm6,ymm11,ymm15
+		vpunpckhwd ymm7,ymm11,ymm15
+
+		vpunpcklwd ymm8,ymm0,ymm4
+		vpunpckhwd ymm9,ymm0,ymm4
+		vpunpcklwd ymm10,ymm1,ymm5
+		vpunpckhwd ymm11,ymm1,ymm5
+		vpunpcklwd ymm12,ymm2,ymm6
+		vpunpckhwd ymm13,ymm2,ymm6
+		vpunpcklwd ymm14,ymm3,ymm7
+		vpunpckhwd ymm15,ymm3,ymm7
+
+		;
+		vpaddw ymm0,ymm8,ymm15
+		vpsubw ymm7,ymm8,ymm15
+		vpaddw ymm1,ymm9,ymm14
+		vpsubw ymm8,ymm9,ymm14
+		vpaddw ymm2,ymm10,ymm13
+		vpsubw ymm5,ymm10,ymm13
+		vpaddw ymm3,ymm11,ymm12
+		vpsubw ymm9,ymm11,ymm12
+
+		vpaddw ymm10, ymm0,ymm3
+		vpsubw ymm13, ymm0,ymm3
+		vpaddw ymm11, ymm1,ymm2
+		vpsubw ymm12, ymm1,ymm2
+
+		vpaddw ymm0, ymm10,ymm11 
+		vpsubw ymm4, ymm10,ymm11 
+
+		vpaddw ymm10,ymm12,ymm13
+		vpsllw  ymm10,ymm10,PRE_MULTIPLY_SCALE_BITS
+		vpmulhw ymm12, ymm10,[rel PW_F0707]
+		vpaddw ymm2, ymm13,ymm12
+		vpsubw ymm6, ymm13,ymm12
+
+		;/*Odd part*/
+		vpaddw ymm12, ymm9, ymm5
+		vpaddw ymm13, ymm5, ymm8
+		vpaddw ymm14, ymm8, ymm7
+		
+		vpsubw ymm15, ymm12, ymm14
+
+		vpsllw  ymm15,ymm15,PRE_MULTIPLY_SCALE_BITS
+		vpsllw  ymm12,ymm12,PRE_MULTIPLY_SCALE_BITS
+		vpsllw  ymm14,ymm14,PRE_MULTIPLY_SCALE_BITS
+
+		vpmulhw ymm8, ymm15,[rel PW_F0382]
+		vpmulhw ymm12, ymm12,[rel PW_F0541]
+		vpaddw ymm12,ymm12,ymm8
+		vpmulhw ymm14, ymm14,[rel PW_F1306]
+		vpaddw ymm14,ymm14,ymm8
+
+		vpsllw  ymm13,ymm13,PRE_MULTIPLY_SCALE_BITS
+		vpmulhw ymm15, ymm13,[rel PW_F0707]
+
+		vpaddw ymm8,ymm7,ymm15 
+		vpsubw ymm1,ymm7,ymm15 
+		
+		vpaddw ymm5,ymm1,ymm12 
+		vpsubw ymm3,ymm1,ymm12 
+		vpaddw ymm1,ymm8,ymm14 
+		vpsubw ymm7,ymm8,ymm14 
+
+	 	dec     rcx
+        jnz     near .dctloop
+
+
+.quantize:
+        mov rdx, r13
+        mov rdi, r12
+
+
+        vpsraw   ymm8,ymm0,(WORD_BIT-1)
+        vpsraw   ymm9,ymm1,(WORD_BIT-1)
+        vpsraw   ymm10,ymm2,(WORD_BIT-1)
+        vpsraw   ymm11,ymm3,(WORD_BIT-1)
+        vpxor    ymm0,ymm0,ymm8
+        vpxor    ymm1,ymm1,ymm9
+        vpxor    ymm2,ymm2,ymm10
+        vpxor    ymm3,ymm3,ymm11
+        vpsubw   ymm0,ymm0,ymm8               
+        vpsubw   ymm1,ymm1,ymm9               
+        vpsubw   ymm2,ymm2,ymm10               
+        vpsubw   ymm3,ymm3,ymm11               
+
+        vpaddw   ymm0,ymm0, YMMWORD [CORRECTION(0,0,rdx)]  
+        vpaddw   ymm1,ymm1, YMMWORD [CORRECTION(1,0,rdx)]
+        vpaddw   ymm2,ymm2, YMMWORD [CORRECTION(2,0,rdx)]
+        vpaddw   ymm3,ymm3, YMMWORD [CORRECTION(3,0,rdx)]
+        vpmulhuw ymm0,ymm0, YMMWORD [RECIPROCAL(0,0,rdx)]  
+        vpmulhuw ymm1,ymm1, YMMWORD [RECIPROCAL(1,0,rdx)]
+        vpmulhuw ymm2,ymm2, YMMWORD [RECIPROCAL(2,0,rdx)]
+        vpmulhuw ymm3,ymm3, YMMWORD [RECIPROCAL(3,0,rdx)]
+        vpmulhuw ymm0,ymm0, YMMWORD [SCALE(0,0,rdx)]  
+        vpmulhuw ymm1,ymm1, YMMWORD [SCALE(1,0,rdx)]
+        vpmulhuw ymm2,ymm2, YMMWORD [SCALE(2,0,rdx)]
+        vpmulhuw ymm3,ymm3, YMMWORD [SCALE(3,0,rdx)]
+
+        vpxor    ymm0,ymm0,ymm8
+        vpxor    ymm1,ymm1,ymm9
+        vpxor    ymm2,ymm2,ymm10
+        vpxor    ymm3,ymm3,ymm11
+        vpsubw   ymm0,ymm0,ymm8
+        vpsubw   ymm1,ymm1,ymm9
+        vpsubw   ymm2,ymm2,ymm10
+        vpsubw   ymm3,ymm3,ymm11
+
+        vpsraw   ymm12,ymm4,(WORD_BIT-1)
+        vpsraw   ymm13,ymm5,(WORD_BIT-1)
+        vpsraw   ymm14,ymm6,(WORD_BIT-1)
+        vpsraw   ymm15,ymm7,(WORD_BIT-1)
+        vpxor    ymm8,ymm4,ymm12
+        vpxor    ymm9,ymm5,ymm13
+        vpxor    ymm10,ymm6,ymm14
+        vpxor    ymm11,ymm7,ymm15
+        vpsubw   ymm8,ymm8,ymm12 
+        vpsubw   ymm9,ymm9,ymm13
+        vpsubw   ymm10,ymm10,ymm14
+        vpsubw   ymm11,ymm11,ymm15
+
+        vpaddw   ymm8,ymm8, YMMWORD [CORRECTION(4,0,rdx)]  
+        vpaddw   ymm9,ymm9, YMMWORD [CORRECTION(5,0,rdx)]
+        vpaddw   ymm10,ymm10, YMMWORD [CORRECTION(6,0,rdx)]
+        vpaddw   ymm11,ymm11, YMMWORD [CORRECTION(7,0,rdx)]
+        vpmulhuw ymm8,ymm8, YMMWORD [RECIPROCAL(4,0,rdx)]  
+        vpmulhuw ymm9,ymm9, YMMWORD [RECIPROCAL(5,0,rdx)]
+        vpmulhuw ymm10,ymm10, YMMWORD [RECIPROCAL(6,0,rdx)]
+        vpmulhuw ymm11,ymm11, YMMWORD [RECIPROCAL(7,0,rdx)]
+        vpmulhuw ymm8,ymm8, YMMWORD [SCALE(4,0,rdx)]  
+        vpmulhuw ymm9,ymm9, YMMWORD [SCALE(5,0,rdx)]
+        vpmulhuw ymm10,ymm10, YMMWORD [SCALE(6,0,rdx)]
+        vpmulhuw ymm11,ymm11, YMMWORD [SCALE(7,0,rdx)]
+
+        vpxor    ymm8,ymm8,ymm12
+        vpxor    ymm9,ymm9,ymm13
+        vpxor    ymm10,ymm10,ymm14
+        vpxor    ymm11,ymm11,ymm15
+        vpsubw   ymm4,ymm8,ymm12
+        vpsubw   ymm5,ymm9,ymm13
+        vpsubw   ymm6,ymm10,ymm14
+        vpsubw   ymm7,ymm11,ymm15
+
+		vperm2i128 ymm8,ymm0,ymm1,0x20
+		vperm2i128 ymm9,ymm2,ymm3,0x20
+		vperm2i128 ymm10,ymm4,ymm5,0x20
+		vperm2i128 ymm11,ymm6,ymm7,0x20
+
+		vperm2i128 ymm0,ymm0,ymm1,0x31
+		vperm2i128 ymm1,ymm2,ymm3,0x31
+		vperm2i128 ymm2,ymm4,ymm5,0x31
+		vperm2i128 ymm3,ymm6,ymm7,0x31
+
+		vmovdqa  YMMWORD [YMMBLOCK(0,0,rdi,2*SIZEOF_DCTELEM)], ymm8
+        vmovdqa  YMMWORD [YMMBLOCK(1,0,rdi,2*SIZEOF_DCTELEM)], ymm9
+        vmovdqa  YMMWORD [YMMBLOCK(2,0,rdi,2*SIZEOF_DCTELEM)], ymm10
+        vmovdqa  YMMWORD [YMMBLOCK(3,0,rdi,2*SIZEOF_DCTELEM)], ymm11
+		vmovdqa  YMMWORD [YMMBLOCK(4,0,rdi,2*SIZEOF_DCTELEM)], ymm0
+        vmovdqa  YMMWORD [YMMBLOCK(5,0,rdi,2*SIZEOF_DCTELEM)], ymm1
+        vmovdqa  YMMWORD [YMMBLOCK(6,0,rdi,2*SIZEOF_DCTELEM)], ymm2
+        vmovdqa  YMMWORD [YMMBLOCK(7,0,rdi,2*SIZEOF_DCTELEM)], ymm3
+
+.exit:
+
+
+		uncollect_args
+		pop     rbx
+        pop     rbp
+        ret
+
+; For some reason, the OS X linker does not honor the request to align the
+; segment unless we do this.
+        align   32
+

--- a/simd/jfdctmint-avx2-64.asm
+++ b/simd/jfdctmint-avx2-64.asm
@@ -1,0 +1,493 @@
+;
+; jfdctflt.asm - floating-point FDCT (64-bit SSE)
+;
+; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2009 D. R. Commander
+; Copyright 2015 Intel Corporation
+;
+; Based on
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; This file contains a floating-point implementation of the forward DCT
+; (Discrete Cosine Transform). The following code is based directly on
+; the IJG's original jfdctflt.c; see the jfdctflt.c for more details.
+;
+; [TAB8]
+
+
+%include "jsimdext.inc"
+%include "jdct.inc"
+
+        alignz  32
+; --------------------------------------------------------------------------
+
+%define RECIPROCAL(m,n,b) YMMBLOCK(DCTSIZE*0+(m),(n),(b),2*SIZEOF_DCTELEM)
+%define CORRECTION(m,n,b) YMMBLOCK(DCTSIZE*1+(m),(n),(b),2*SIZEOF_DCTELEM)
+%define SCALE(m,n,b)      YMMBLOCK(DCTSIZE*2+(m),(n),(b),2*SIZEOF_DCTELEM)
+
+; --------------------------------------------------------------------------
+
+%define CONST_BITS      13
+%define PASS1_BITS      2
+
+%define DESCALE_P1      (CONST_BITS-PASS1_BITS)
+%define DESCALE_P2      (CONST_BITS+PASS1_BITS)
+
+%if CONST_BITS == 13
+F_0_298 equ      2446           ; FIX(0.298631336)
+F_0_390 equ      3196           ; FIX(0.390180644)
+F_0_541 equ      4433           ; FIX(0.541196100)
+F_0_765 equ      6270           ; FIX(0.765366865)
+F_0_899 equ      7373           ; FIX(0.899976223)
+F_1_175 equ      9633           ; FIX(1.175875602)
+F_1_501 equ     12299           ; FIX(1.501321110)
+F_1_847 equ     15137           ; FIX(1.847759065)
+F_1_961 equ     16069           ; FIX(1.961570560)
+F_2_053 equ     16819           ; FIX(2.053119869)
+F_2_562 equ     20995           ; FIX(2.562915447)
+F_3_072 equ     25172           ; FIX(3.072711026)
+%else
+; NASM cannot do compile-time arithmetic on floating-point constants.
+%define DESCALE(x,n)  (((x)+(1<<((n)-1)))>>(n))
+F_0_298 equ     DESCALE( 320652955,30-CONST_BITS)       ; FIX(0.298631336)
+F_0_390 equ     DESCALE( 418953276,30-CONST_BITS)       ; FIX(0.390180644)
+F_0_541 equ     DESCALE( 581104887,30-CONST_BITS)       ; FIX(0.541196100)
+F_0_765 equ     DESCALE( 821806413,30-CONST_BITS)       ; FIX(0.765366865)
+F_0_899 equ     DESCALE( 966342111,30-CONST_BITS)       ; FIX(0.899976223)
+F_1_175 equ     DESCALE(1262586813,30-CONST_BITS)       ; FIX(1.175875602)
+F_1_501 equ     DESCALE(1612031267,30-CONST_BITS)       ; FIX(1.501321110)
+F_1_847 equ     DESCALE(1984016188,30-CONST_BITS)       ; FIX(1.847759065)
+F_1_961 equ     DESCALE(2106220350,30-CONST_BITS)       ; FIX(1.961570560)
+F_2_053 equ     DESCALE(2204520673,30-CONST_BITS)       ; FIX(2.053119869)
+F_2_562 equ     DESCALE(2751909506,30-CONST_BITS)       ; FIX(2.562915447)
+F_3_072 equ     DESCALE(3299298341,30-CONST_BITS)       ; FIX(3.072711026)
+%endif
+
+        SECTION SEG_CONST
+
+%define PRE_MULTIPLY_SCALE_BITS   2
+%define CONST_SHIFT     (16 - PRE_MULTIPLY_SCALE_BITS - CONST_BITS)
+        alignz  32
+        alignz  32
+        global  EXTN(jconst_fdct_merged_islow_avx2)
+
+EXTN(jconst_fdct_merged_islow_avx2):
+
+PW_F130_F054    times 8 dw  (F_0_541+F_0_765), F_0_541
+PW_F054_MF130   times 8 dw  F_0_541, (F_0_541-F_1_847)
+PW_MF078_F117   times 8 dw  (F_1_175-F_1_961), F_1_175
+PW_F117_F078    times 8 dw  F_1_175, (F_1_175-F_0_390)
+PW_MF060_MF089  times 8 dw  (F_0_298-F_0_899),-F_0_899
+PW_MF089_F060   times 8 dw -F_0_899, (F_1_501-F_0_899)
+PW_MF050_MF256  times 8 dw  (F_2_053-F_2_562),-F_2_562
+PW_MF256_F050   times 8 dw -F_2_562, (F_3_072-F_2_562)
+PD_DESCALE_P1   times 8 dd  1 << (DESCALE_P1-1)
+PD_DESCALE_P2   times 8 dd  1 << (DESCALE_P2-1)
+PW_DESCALE_P2X  times 16 dw  1 << (PASS1_BITS-1)
+
+
+; --------------------------------------------------------------------------
+        SECTION SEG_TEXT
+        BITS    64
+
+; --------------------------------------------------------------------------
+        align   32
+        global  EXTN(jsimd_fdct_merged_islow_avx2)
+
+EXTN(jsimd_fdct_merged_islow_avx2):
+        push    rbp
+        mov     rbp,rsp
+
+            push rbx
+        collect_args
+
+.convsamp:
+            mov rsi, r10
+        mov rax, r11
+
+        vpxor    ymm14,ymm14,ymm14               
+        vpcmpeqw ymm15,ymm15,ymm15
+        vpsllw   ymm15,ymm15,7                  
+.convloop:
+        mov     rbx, JSAMPROW [rsi+0*SIZEOF_JSAMPROW]   
+        mov     rdx, JSAMPROW [rsi+1*SIZEOF_JSAMPROW]       
+
+        vmovdqa    xmm0, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+        vpermq     ymm0, ymm0, 0x10
+        vmovdqa    xmm1, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+        vpermq     ymm1, ymm1, 0x10
+
+        mov     rbx, JSAMPROW [rsi+2*SIZEOF_JSAMPROW]   
+        mov     rdx, JSAMPROW [rsi+3*SIZEOF_JSAMPROW]   
+
+        vmovdqa    xmm2, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+        vpermq     ymm2, ymm2, 0x10
+        vmovdqa    xmm3, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+        vpermq     ymm3, ymm3, 0x10
+
+        vpunpcklbw ymm0,ymm0,ymm14             
+        vpunpcklbw ymm1,ymm1,ymm14             
+        vpaddw     ymm0,ymm0,ymm15
+        vpaddw     ymm1,ymm1,ymm15
+        vpunpcklbw ymm2,ymm2,ymm14             
+        vpunpcklbw ymm3,ymm3,ymm14             
+        vpaddw     ymm2,ymm2,ymm15
+        vpaddw     ymm3,ymm3,ymm15
+
+        mov     rbx, JSAMPROW [rsi+4*SIZEOF_JSAMPROW]   
+        mov     rdx, JSAMPROW [rsi+5*SIZEOF_JSAMPROW]       
+
+        vmovdqa    xmm8, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+        vpermq     ymm8, ymm8, 0x10
+        vmovdqa    xmm9, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+        vpermq     ymm9, ymm9, 0x10
+
+        mov     rbx, JSAMPROW [rsi+6*SIZEOF_JSAMPROW]   
+        mov     rdx, JSAMPROW [rsi+7*SIZEOF_JSAMPROW]   
+
+        vmovdqa    xmm10, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+        vpermq     ymm10, ymm10, 0x10
+        vmovdqa    xmm11, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+        vpermq     ymm11, ymm11, 0x10
+
+        vpunpcklbw ymm8,ymm8,ymm14             
+        vpunpcklbw ymm9,ymm9,ymm14             
+        vpaddw     ymm4,ymm8,ymm15
+        vpaddw     ymm5,ymm9,ymm15
+        vpunpcklbw ymm10,ymm10,ymm14             
+        vpunpcklbw ymm11,ymm11,ymm14             
+        vpaddw     ymm6,ymm10,ymm15
+        vpaddw     ymm7,ymm11,ymm15
+
+        
+        
+
+.dct:
+
+        mov     rcx, 2
+
+.dctloop:
+            dec     rcx
+        
+        vpunpcklwd ymm12,ymm2,ymm6
+        vpunpckhwd ymm13,ymm2,ymm6
+        vpunpcklwd ymm8,ymm0,ymm4
+        vpunpckhwd ymm9,ymm0,ymm4
+        vpunpcklwd ymm10,ymm1,ymm5
+        vpunpckhwd ymm11,ymm1,ymm5
+        vpunpcklwd ymm14,ymm3,ymm7
+        vpunpckhwd ymm15,ymm3,ymm7
+
+        vpunpcklwd ymm0,ymm8,ymm12
+        vpunpckhwd ymm1,ymm8,ymm12
+        vpunpcklwd ymm2,ymm9,ymm13
+        vpunpckhwd ymm3,ymm9,ymm13
+        vpunpcklwd ymm4,ymm10,ymm14
+        vpunpckhwd ymm5,ymm10,ymm14
+        vpunpcklwd ymm6,ymm11,ymm15
+        vpunpckhwd ymm7,ymm11,ymm15
+
+        vpunpcklwd ymm8,ymm0,ymm4
+        vpunpckhwd ymm9,ymm0,ymm4
+        vpunpcklwd ymm10,ymm1,ymm5
+        vpunpckhwd ymm11,ymm1,ymm5
+        vpunpcklwd ymm12,ymm2,ymm6
+        vpunpckhwd ymm13,ymm2,ymm6
+        vpunpcklwd ymm14,ymm3,ymm7
+        vpunpckhwd ymm15,ymm3,ymm7
+
+        vpaddw ymm0,ymm8,ymm15
+        vpsubw ymm7,ymm8,ymm15
+        vpaddw ymm1,ymm9,ymm14
+        vpsubw ymm8,ymm9,ymm14 
+        vpaddw ymm2,ymm10,ymm13
+        vpsubw ymm5,ymm10,ymm13
+        vpaddw ymm3,ymm11,ymm12
+        vpsubw ymm9,ymm11,ymm12 
+
+        vpaddw ymm10, ymm0,ymm3
+        vpsubw ymm13, ymm0,ymm3
+        vpaddw ymm11, ymm1,ymm2
+        vpsubw ymm12, ymm1,ymm2
+
+        
+        vpaddw ymm0, ymm10,ymm11 
+        vpsubw ymm4, ymm10,ymm11 
+        test     rcx,rcx
+        jnz     near .row_data04
+        vpaddw   ymm0,ymm0,[rel PW_DESCALE_P2X]
+        vpaddw   ymm4,ymm4,[rel PW_DESCALE_P2X]
+        vpsraw   ymm0,ymm0,PASS1_BITS         
+        vpsraw   ymm4,ymm4,PASS1_BITS         
+        jmp near .data04
+.row_data04:
+        vpsllw ymm0,ymm0,PASS1_BITS
+        vpsllw ymm4,ymm4,PASS1_BITS
+.data04:
+        vpunpcklwd ymm14,ymm13,ymm12
+        vpunpckhwd ymm15,ymm13,ymm12
+        vpmaddwd   ymm10,ymm14,[rel PW_F130_F054]     
+        vpmaddwd   ymm11,ymm15,[rel PW_F130_F054]     
+        vpmaddwd   ymm12,ymm14,[rel PW_F054_MF130]    
+        vpmaddwd   ymm13,ymm15,[rel PW_F054_MF130]    
+        test rcx,rcx
+        jnz near .row_data26
+        vpaddd   ymm10,ymm10,[rel PD_DESCALE_P2]
+        vpaddd   ymm11,ymm11,[rel PD_DESCALE_P2]
+        vpaddd   ymm12,ymm12,[rel PD_DESCALE_P2]
+        vpaddd   ymm13,ymm13,[rel PD_DESCALE_P2]
+        vpsrad   ymm10,ymm10,DESCALE_P2
+        vpsrad   ymm11,ymm11,DESCALE_P2
+        vpsrad   ymm12,ymm12,DESCALE_P2
+        vpsrad   ymm13,ymm13,DESCALE_P2
+        jmp near .data26
+.row_data26:
+        vpaddd   ymm10,ymm10,[rel PD_DESCALE_P1]
+        vpaddd   ymm11,ymm11,[rel PD_DESCALE_P1]
+        vpaddd   ymm12,ymm12,[rel PD_DESCALE_P1]
+        vpaddd   ymm13,ymm13,[rel PD_DESCALE_P1]
+        vpsrad   ymm10,ymm10,DESCALE_P1
+        vpsrad   ymm11,ymm11,DESCALE_P1
+        vpsrad   ymm12,ymm12,DESCALE_P1
+        vpsrad   ymm13,ymm13,DESCALE_P1
+.data26:
+        vpackssdw  ymm2,ymm10,ymm11             ; ymm2=data2
+        vpackssdw  ymm6,ymm12,ymm13             ; ymm6=data6
+
+.ck_data26:
+        ; -- Odd part
+
+        vpaddw ymm12, ymm9, ymm8 ;z3
+        vpaddw ymm13, ymm5, ymm7 ;z4
+
+        ; (Original)
+        ; z5 = (z3 + z4) * 1.175875602;
+        ; z3 = z3 * -1.961570560;  z4 = z4 * -0.390180644;
+        ; z3 += z5;  z4 += z5;
+        ;
+        ; (This implementation)
+        ; z3 = z3 * (1.175875602 - 1.961570560) + z4 * 1.175875602;
+        ; z4 = z3 * 1.175875602 + z4 * (1.175875602 - 0.390180644);
+
+        vpunpcklwd ymm10, ymm12,ymm13
+        vpunpckhwd ymm11, ymm12,ymm13
+        vpmaddwd   ymm12,ymm10,[rel PW_MF078_F117]      ; ymm12=z3L
+        vpmaddwd   ymm13,ymm11,[rel PW_MF078_F117]      ; ymm13=z3H
+        vpmaddwd   ymm10,ymm10,[rel PW_F117_F078]       ; ymm10=z4L
+        vpmaddwd   ymm11,ymm11,[rel PW_F117_F078]       ; ymm11=z4H
+
+        ; (Original)
+        ; z1 = tmp4 + tmp7;  z2 = tmp5 + tmp6;
+        ; tmp4 = tmp4 * 0.298631336;  tmp5 = tmp5 * 2.053119869;
+        ; tmp6 = tmp6 * 3.072711026;  tmp7 = tmp7 * 1.501321110;
+        ; z1 = z1 * -0.899976223;  z2 = z2 * -2.562915447;
+        ; data7 = tmp4 + z1 + z3;  data5 = tmp5 + z2 + z4;
+        ; data3 = tmp6 + z2 + z3;  data1 = tmp7 + z1 + z4;
+        ;
+        ; (This implementation)
+        ; tmp4 = tmp4 * (0.298631336 - 0.899976223) + tmp7 * -0.899976223;
+        ; tmp5 = tmp5 * (2.053119869 - 2.562915447) + tmp6 * -2.562915447;
+        ; tmp6 = tmp5 * -2.562915447 + tmp6 * (3.072711026 - 2.562915447);
+        ; tmp7 = tmp4 * -0.899976223 + tmp7 * (1.501321110 - 0.899976223);
+        ; data7 = tmp4 + z3;  data5 = tmp5 + z4;
+        ; data3 = tmp6 + z3;  data1 = tmp7 + z4;
+
+        vpunpcklwd ymm1,ymm9,ymm7 ; ymm7 = tmp7, ymm9 = tmp4
+        vpunpckhwd ymm3,ymm9,ymm7
+        vpmaddwd   ymm15,ymm1,[rel PW_MF060_MF089]     ; ymm15=tmp4L
+        vpmaddwd   ymm7,ymm3,[rel PW_MF060_MF089]     ; ymm7=tmp4H
+        vpmaddwd   ymm1,ymm1,[rel PW_MF089_F060]      ; ymm1=tmp7L
+        vpmaddwd   ymm3,ymm3,[rel PW_MF089_F060]      ; ymm3=tmp7H
+
+        vpaddd   ymm15,ymm15, ymm12   ; ymm15=data7L
+        vpaddd   ymm7,ymm7, ymm13   ; ymm7=data7H
+        vpaddd   ymm1,ymm1,ymm10    ; ymm1=data1L
+        vpaddd   ymm3,ymm3,ymm11    ; ymm3=data1H
+
+        test rcx,rcx
+        jnz near .row_data17
+        vpaddd   ymm15,ymm15,[rel PD_DESCALE_P2]
+        vpaddd   ymm7,ymm7,[rel PD_DESCALE_P2]
+        vpsrad   ymm15,ymm15,DESCALE_P2
+        vpsrad   ymm7,ymm7,DESCALE_P2
+        vpaddd   ymm1,ymm1,[rel PD_DESCALE_P2]
+        vpaddd   ymm3,ymm3,[rel PD_DESCALE_P2]
+        vpsrad   ymm1,ymm1,DESCALE_P2
+        vpsrad   ymm3,ymm3,DESCALE_P2
+        jmp near .data17
+.row_data17:
+        vpaddd   ymm15,ymm15,[rel PD_DESCALE_P1]
+        vpaddd   ymm7,ymm7,[rel PD_DESCALE_P1]
+        vpsrad   ymm15,ymm15,DESCALE_P1
+        vpsrad   ymm7,ymm7,DESCALE_P1
+        vpaddd   ymm1,ymm1,[rel PD_DESCALE_P1]
+        vpaddd   ymm3,ymm3,[rel PD_DESCALE_P1]
+        vpsrad   ymm1,ymm1,DESCALE_P1
+        vpsrad   ymm3,ymm3,DESCALE_P1
+.data17:
+        vpackssdw  ymm7,ymm15,ymm7             ; ymm7=data7
+        vpackssdw  ymm1,ymm1,ymm3             ; ymm1=data1
+.ck_data17:
+
+        vpunpcklwd ymm3,ymm5,ymm8
+        vpunpckhwd ymm5,ymm5,ymm8
+
+        vpmaddwd   ymm14,ymm3,[rel PW_MF050_MF256]     ; ymm14=tmp5L
+        vpmaddwd   ymm15,ymm5,[rel PW_MF050_MF256]     ; ymm15=tmp5H
+        vpmaddwd   ymm3,ymm3,[rel PW_MF256_F050]      ; ymm3=tmp6L
+        vpmaddwd   ymm5,ymm5,[rel PW_MF256_F050]      ; ymm5=tmp6H
+
+        vpaddd   ymm14,ymm14,ymm10               ; ymm1=data5L
+        vpaddd   ymm15,ymm15,ymm11               ; ymm5=data5H
+        vpaddd   ymm3,ymm3, ymm12   ; ymm5=data3L
+        vpaddd   ymm5,ymm5, ymm13   ; ymm3=data3H
+        test rcx,rcx
+        jnz near .row_data35
+        vpaddd   ymm14,ymm14,[rel PD_DESCALE_P2]
+        vpaddd   ymm15,ymm15,[rel PD_DESCALE_P2]
+        vpsrad   ymm14,ymm14,DESCALE_P2
+        vpsrad   ymm15,ymm15,DESCALE_P2
+        vpaddd   ymm10,ymm3,[rel PD_DESCALE_P2]
+        vpaddd   ymm11,ymm5,[rel PD_DESCALE_P2]
+        vpsrad   ymm10,ymm10,DESCALE_P2
+        vpsrad   ymm11,ymm11,DESCALE_P2
+        jmp .data35
+.row_data35:
+        vpaddd   ymm14,ymm14,[rel PD_DESCALE_P1]
+        vpaddd   ymm15,ymm15,[rel PD_DESCALE_P1]
+        vpsrad   ymm14,ymm14,DESCALE_P1
+        vpsrad   ymm15,ymm15,DESCALE_P1
+        vpaddd   ymm10,ymm3,[rel PD_DESCALE_P1]
+        vpaddd   ymm11,ymm5,[rel PD_DESCALE_P1]
+        vpsrad   ymm10,ymm10,DESCALE_P1
+        vpsrad   ymm11,ymm11,DESCALE_P1
+.data35:
+        vpackssdw  ymm5,ymm14,ymm15             ; ymm5=data5
+        vpackssdw  ymm3,ymm10,ymm11             ; ymm3=data3
+.ck_data35:
+            test rcx,rcx
+        jnz     near .dctloop
+
+.quantize:
+        mov rdx, r13
+        mov rdi, r12
+
+
+        vpsraw   ymm8,ymm0,(WORD_BIT-1)
+        vpsraw   ymm9,ymm1,(WORD_BIT-1)
+        vpsraw   ymm10,ymm2,(WORD_BIT-1)
+        vpsraw   ymm11,ymm3,(WORD_BIT-1)
+        vpxor    ymm0,ymm0,ymm8
+        vpxor    ymm1,ymm1,ymm9
+        vpxor    ymm2,ymm2,ymm10
+        vpxor    ymm3,ymm3,ymm11
+        vpsubw   ymm0,ymm0,ymm8               ; if (ymm0 < 0) ymm0 = -ymm0;
+        vpsubw   ymm1,ymm1,ymm9               ; if (ymm1 < 0) ymm1 = -ymm1;
+        vpsubw   ymm2,ymm2,ymm10               ; if (ymm2 < 0) ymm2 = -ymm2;
+        vpsubw   ymm3,ymm3,ymm11               ; if (ymm3 < 0) ymm3 = -ymm3;
+
+        vpaddw   ymm0,ymm0, YMMWORD [CORRECTION(0,0,rdx)]  ; correction + roundfactor
+        vpaddw   ymm1,ymm1, YMMWORD [CORRECTION(1,0,rdx)]
+        vpaddw   ymm2,ymm2, YMMWORD [CORRECTION(2,0,rdx)]
+        vpaddw   ymm3,ymm3, YMMWORD [CORRECTION(3,0,rdx)]
+        vpmulhuw ymm0,ymm0, YMMWORD [RECIPROCAL(0,0,rdx)]  ; reciprocal
+        vpmulhuw ymm1,ymm1, YMMWORD [RECIPROCAL(1,0,rdx)]
+        vpmulhuw ymm2,ymm2, YMMWORD [RECIPROCAL(2,0,rdx)]
+        vpmulhuw ymm3,ymm3, YMMWORD [RECIPROCAL(3,0,rdx)]
+        vpmulhuw ymm0,ymm0, YMMWORD [SCALE(0,0,rdx)]  ; scale
+        vpmulhuw ymm1,ymm1, YMMWORD [SCALE(1,0,rdx)]
+        vpmulhuw ymm2,ymm2, YMMWORD [SCALE(2,0,rdx)]
+        vpmulhuw ymm3,ymm3, YMMWORD [SCALE(3,0,rdx)]
+
+        vpxor    ymm0,ymm0,ymm8
+        vpxor    ymm1,ymm1,ymm9
+        vpxor    ymm2,ymm2,ymm10
+        vpxor    ymm3,ymm3,ymm11
+        vpsubw   ymm0,ymm0,ymm8
+        vpsubw   ymm1,ymm1,ymm9
+        vpsubw   ymm2,ymm2,ymm10
+        vpsubw   ymm3,ymm3,ymm11
+
+; next half
+
+        vpsraw   ymm12,ymm4,(WORD_BIT-1)
+        vpsraw   ymm13,ymm5,(WORD_BIT-1)
+        vpsraw   ymm14,ymm6,(WORD_BIT-1)
+        vpsraw   ymm15,ymm7,(WORD_BIT-1)
+        vpxor    ymm8,ymm4,ymm12
+        vpxor    ymm9,ymm5,ymm13
+        vpxor    ymm10,ymm6,ymm14
+        vpxor    ymm11,ymm7,ymm15
+        vpsubw   ymm8,ymm8,ymm12 
+        vpsubw   ymm9,ymm9,ymm13
+        vpsubw   ymm10,ymm10,ymm14
+        vpsubw   ymm11,ymm11,ymm15
+
+        vpaddw   ymm8,ymm8, YMMWORD [CORRECTION(4,0,rdx)]  ; correction + roundfactor
+        vpaddw   ymm9,ymm9, YMMWORD [CORRECTION(5,0,rdx)]
+        vpaddw   ymm10,ymm10, YMMWORD [CORRECTION(6,0,rdx)]
+        vpaddw   ymm11,ymm11, YMMWORD [CORRECTION(7,0,rdx)]
+        vpmulhuw ymm8,ymm8, YMMWORD [RECIPROCAL(4,0,rdx)]  ; reciprocal
+        vpmulhuw ymm9,ymm9, YMMWORD [RECIPROCAL(5,0,rdx)]
+        vpmulhuw ymm10,ymm10, YMMWORD [RECIPROCAL(6,0,rdx)]
+        vpmulhuw ymm11,ymm11, YMMWORD [RECIPROCAL(7,0,rdx)]
+        vpmulhuw ymm8,ymm8, YMMWORD [SCALE(4,0,rdx)]  ; scale
+        vpmulhuw ymm9,ymm9, YMMWORD [SCALE(5,0,rdx)]
+        vpmulhuw ymm10,ymm10, YMMWORD [SCALE(6,0,rdx)]
+        vpmulhuw ymm11,ymm11, YMMWORD [SCALE(7,0,rdx)]
+
+        vpxor    ymm8,ymm8,ymm12
+        vpxor    ymm9,ymm9,ymm13
+        vpxor    ymm10,ymm10,ymm14
+        vpxor    ymm11,ymm11,ymm15
+        vpsubw   ymm4,ymm8,ymm12
+        vpsubw   ymm5,ymm9,ymm13
+        vpsubw   ymm6,ymm10,ymm14
+        vpsubw   ymm7,ymm11,ymm15
+
+        ;ymm0 = [blk0 low128][blk1 low128]
+        ;ymmN = [blk0 128<<N][blk1 128<<N]
+        ;vperm2i128 bit1:0 = 00b,bit5:4=10b
+        ;src2[127:0] -> dest[255:128] ; src1[127:0] -> dest[127:0]
+        vperm2i128 ymm8,ymm0,ymm1,0x20
+        vperm2i128 ymm9,ymm2,ymm3,0x20
+        vperm2i128 ymm10,ymm4,ymm5,0x20
+        vperm2i128 ymm11,ymm6,ymm7,0x20
+        ;vperm2i128 bit1:0 = 01b,bit5:4=11b
+        ;src2[255:128] -> dest[255:128] ; src1[255:128] -> dest[127:0]
+        vperm2i128 ymm0,ymm0,ymm1,0x31
+        vperm2i128 ymm1,ymm2,ymm3,0x31
+        vperm2i128 ymm2,ymm4,ymm5,0x31
+        vperm2i128 ymm3,ymm6,ymm7,0x31
+
+        vmovdqa  YMMWORD [YMMBLOCK(0,0,rdi,2*SIZEOF_DCTELEM)], ymm8
+        vmovdqa  YMMWORD [YMMBLOCK(1,0,rdi,2*SIZEOF_DCTELEM)], ymm9
+        vmovdqa  YMMWORD [YMMBLOCK(2,0,rdi,2*SIZEOF_DCTELEM)], ymm10
+        vmovdqa  YMMWORD [YMMBLOCK(3,0,rdi,2*SIZEOF_DCTELEM)], ymm11
+        vmovdqa  YMMWORD [YMMBLOCK(4,0,rdi,2*SIZEOF_DCTELEM)], ymm0
+        vmovdqa  YMMWORD [YMMBLOCK(5,0,rdi,2*SIZEOF_DCTELEM)], ymm1
+        vmovdqa  YMMWORD [YMMBLOCK(6,0,rdi,2*SIZEOF_DCTELEM)], ymm2
+        vmovdqa  YMMWORD [YMMBLOCK(7,0,rdi,2*SIZEOF_DCTELEM)], ymm3
+
+.exit:
+
+
+        uncollect_args
+        pop     rbx
+        pop     rbp
+        ret
+
+; For some reason, the OS X linker does not honor the request to align the
+; segment unless we do this.
+        align   32
+
+
+

--- a/simd/jfdctmint-avx2-64.asm
+++ b/simd/jfdctmint-avx2-64.asm
@@ -1,5 +1,5 @@
 ;
-; jfdctflt.asm - floating-point FDCT (64-bit SSE)
+; jfdctflt.asm - floating-point FDCT (64-bit AVX2)
 ;
 ; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
 ; Copyright 2009 D. R. Commander

--- a/simd/jfdctmint-avx2-64.asm
+++ b/simd/jfdctmint-avx2-64.asm
@@ -120,17 +120,17 @@ EXTN(jsimd_fdct_merged_islow_avx2):
         mov     rbx, JSAMPROW [rsi+0*SIZEOF_JSAMPROW]   
         mov     rdx, JSAMPROW [rsi+1*SIZEOF_JSAMPROW]       
 
-        vmovdqa    xmm0, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm0, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
         vpermq     ymm0, ymm0, 0x10
-        vmovdqa    xmm1, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm1, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
         vpermq     ymm1, ymm1, 0x10
 
         mov     rbx, JSAMPROW [rsi+2*SIZEOF_JSAMPROW]   
         mov     rdx, JSAMPROW [rsi+3*SIZEOF_JSAMPROW]   
 
-        vmovdqa    xmm2, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm2, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
         vpermq     ymm2, ymm2, 0x10
-        vmovdqa    xmm3, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm3, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
         vpermq     ymm3, ymm3, 0x10
 
         vpunpcklbw ymm0,ymm0,ymm14             
@@ -145,17 +145,17 @@ EXTN(jsimd_fdct_merged_islow_avx2):
         mov     rbx, JSAMPROW [rsi+4*SIZEOF_JSAMPROW]   
         mov     rdx, JSAMPROW [rsi+5*SIZEOF_JSAMPROW]       
 
-        vmovdqa    xmm8, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm8, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
         vpermq     ymm8, ymm8, 0x10
-        vmovdqa    xmm9, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm9, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
         vpermq     ymm9, ymm9, 0x10
 
         mov     rbx, JSAMPROW [rsi+6*SIZEOF_JSAMPROW]   
         mov     rdx, JSAMPROW [rsi+7*SIZEOF_JSAMPROW]   
 
-        vmovdqa    xmm10, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm10, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]       
         vpermq     ymm10, ymm10, 0x10
-        vmovdqa    xmm11, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
+        vmovdqu    xmm11, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]       
         vpermq     ymm11, ymm11, 0x10
 
         vpunpcklbw ymm8,ymm8,ymm14             
@@ -468,14 +468,14 @@ EXTN(jsimd_fdct_merged_islow_avx2):
         vperm2i128 ymm2,ymm4,ymm5,0x31
         vperm2i128 ymm3,ymm6,ymm7,0x31
 
-        vmovdqa  YMMWORD [YMMBLOCK(0,0,rdi,2*SIZEOF_DCTELEM)], ymm8
-        vmovdqa  YMMWORD [YMMBLOCK(1,0,rdi,2*SIZEOF_DCTELEM)], ymm9
-        vmovdqa  YMMWORD [YMMBLOCK(2,0,rdi,2*SIZEOF_DCTELEM)], ymm10
-        vmovdqa  YMMWORD [YMMBLOCK(3,0,rdi,2*SIZEOF_DCTELEM)], ymm11
-        vmovdqa  YMMWORD [YMMBLOCK(4,0,rdi,2*SIZEOF_DCTELEM)], ymm0
-        vmovdqa  YMMWORD [YMMBLOCK(5,0,rdi,2*SIZEOF_DCTELEM)], ymm1
-        vmovdqa  YMMWORD [YMMBLOCK(6,0,rdi,2*SIZEOF_DCTELEM)], ymm2
-        vmovdqa  YMMWORD [YMMBLOCK(7,0,rdi,2*SIZEOF_DCTELEM)], ymm3
+        vmovdqu  YMMWORD [YMMBLOCK(0,0,rdi,2*SIZEOF_DCTELEM)], ymm8
+        vmovdqu  YMMWORD [YMMBLOCK(1,0,rdi,2*SIZEOF_DCTELEM)], ymm9
+        vmovdqu  YMMWORD [YMMBLOCK(2,0,rdi,2*SIZEOF_DCTELEM)], ymm10
+        vmovdqu  YMMWORD [YMMBLOCK(3,0,rdi,2*SIZEOF_DCTELEM)], ymm11
+        vmovdqu  YMMWORD [YMMBLOCK(4,0,rdi,2*SIZEOF_DCTELEM)], ymm0
+        vmovdqu  YMMWORD [YMMBLOCK(5,0,rdi,2*SIZEOF_DCTELEM)], ymm1
+        vmovdqu  YMMWORD [YMMBLOCK(6,0,rdi,2*SIZEOF_DCTELEM)], ymm2
+        vmovdqu  YMMWORD [YMMBLOCK(7,0,rdi,2*SIZEOF_DCTELEM)], ymm3
 
 .exit:
 

--- a/simd/jidctflt-avx2-64.asm
+++ b/simd/jidctflt-avx2-64.asm
@@ -1,0 +1,441 @@
+;
+; jidctflt.asm - floating-point IDCT (64-bit AVX & AVX2)
+;
+; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2009 D. R. Commander
+; Copyright 2015 Intel Corporation.
+;
+; Based on
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; This file contains a floating-point implementation of the inverse DCT
+; (Discrete Cosine Transform). The following code is based directly on
+; the IJG's original jidctflt.c; see the jidctflt.c for more details.
+;
+; [TAB8]
+
+%include "jsimdext.inc"
+%include "jdct.inc"
+
+; --------------------------------------------------------------------------
+
+%macro  vunpcklps2 3     ; %1=(0 1 2 3) / %2=(4 5 6 7) => %1=(0 1 4 5)
+        vshufps  %1,%2,%3,0x44
+%endmacro
+
+%macro  unpckhps2 3     ; %1=(0 1 2 3) / %2=(4 5 6 7) => %1=(2 3 6 7)
+        vshufps  %1,%2,%3,0xEE
+%endmacro
+
+; --------------------------------------------------------------------------
+        SECTION SEG_CONST
+
+        alignz  32
+        global  EXTN(jconst_idct_float_avx2)
+
+EXTN(jconst_idct_float_avx2):
+
+PD_1_414        times 8 dd  1.414213562373095048801689
+PD_1_847        times 8 dd  1.847759065022573512256366
+PD_1_082        times 8 dd  1.082392200292393968799446
+PD_M2_613       times 8 dd -2.613125929752753055713286
+PD_RNDINT_MAGIC times 8 dd  100663296.0 ; (float)(0x00C00000 << 3)
+PB_CENTERJSAMP  times 32 db CENTERJSAMPLE
+
+        alignz  32
+
+; --------------------------------------------------------------------------
+        SECTION SEG_TEXT
+        BITS    64
+;
+; Perform dequantization and inverse DCT on one block of coefficients.
+;
+; GLOBAL(void)
+; jsimd_idct_float_avx2 (void * dct_table, JCOEFPTR coef_block,
+;                        JSAMPARRAY output_buf, JDIMENSION output_col)
+;
+
+; r10 = void * dct_table
+; r11 = JCOEFPTR coef_block
+; r12 = JSAMPARRAY output_buf
+; r13 = JDIMENSION output_col
+
+%define original_rbp    rbp+0
+%define wk(i)           rbp-(WK_NUM-(i))*SIZEOF_YMMWORD ; ymmword wk[WK_NUM]
+%define WK_NUM          2
+%define workspace       wk(0)-DCTSIZE2*SIZEOF_FAST_FLOAT
+                                        ; FAST_FLOAT workspace[DCTSIZE2]
+
+        align   32
+        global  EXTN(jsimd_idct_float_avx2)
+
+EXTN(jsimd_idct_float_avx2):
+        push    rbp
+        mov     rax,rsp                         ; rax = original rbp
+        sub     rsp, byte 4
+        and     rsp, byte (-SIZEOF_YMMWORD)     ; align to 128 bits
+        mov     [rsp],rax
+        mov     rbp,rsp                         ; rbp = aligned rbp
+        lea     rsp, [workspace]
+        collect_args
+        push    rbx
+
+        ; ---- Pass 1: process columns from input, store into work array.
+
+        mov     rdx, r10                ; quantptr
+        mov     rsi, r11                ; inptr
+        lea     rdi, [workspace]                        ; FAST_FLOAT * wsptr
+.columnloop:
+%ifndef NO_ZERO_COLUMN_TEST_FLOAT_AVX
+        mov     eax, DWORD [DWBLOCK(1,0,rsi,SIZEOF_JCOEF)]
+        or      eax, DWORD [DWBLOCK(2,0,rsi,SIZEOF_JCOEF)]
+        jnz     near .columnDCT
+
+        vmovdqa  xmm0, XMMWORD [XMMBLOCK(1,0,rsi,SIZEOF_JCOEF)]
+        vpor     ymm0, YMMWORD [YMMBLOCK(2,0,rsi,SIZEOF_JCOEF)]
+        vpor     ymm0, YMMWORD [YMMBLOCK(4,0,rsi,SIZEOF_JCOEF)]
+        vpor     ymm0, YMMWORD [YMMBLOCK(6,0,rsi,SIZEOF_JCOEF)]
+
+        vpacksswb ymm0,ymm0,ymm0
+        vpermq  ymm0,ymm0,0xD8 
+        vpacksswb xmm0,xmm0,xmm0
+        vpacksswb xmm0,xmm0,xmm0
+
+        vmovd    eax,xmm0
+        test    rax,rax
+        jnz     short .columnDCT
+
+        ; -- AC terms all zero
+
+        vmovdqa     xmm0, XMM_MMWORD [MMBLOCK(0,0,rsi,SIZEOF_JCOEF)]
+        vpermq      ymm0,ymm0,0x50
+
+        vpunpcklwd ymm0,ymm0,ymm0             
+        vpsrad     ymm0,(DWORD_BIT-WORD_BIT)     
+        vcvtdq2ps  ymm0,ymm0                     
+
+        vmulps   ymm0,ymm0, YMMWORD [YMMBLOCK(0,0,rdx,SIZEOF_FLOAT_MULT_TYPE)]
+
+        vperm2f128 ymm14,ymm0,ymm0,0
+        vperm2f128 ymm15,ymm0,ymm0,0x11
+
+        vshufps  ymm0,ymm14,ymm14,0x00                  
+        vshufps  ymm8,ymm14,ymm14,0x55                  
+        vshufps  ymm1,ymm14,ymm14,0xAA                  
+        vshufps  ymm9,ymm14,ymm14,0xFF                  
+
+        vshufps  ymm2,ymm15,ymm15,0x00                  
+        vshufps  ymm10,ymm15,ymm15,0x55                  
+        vshufps  ymm3,ymm15,ymm15,0xAA       
+        vshufps  ymm11,ymm15,ymm15,0xFF                 
+
+        jmp     near .nextcolumn
+%endif
+
+.columnDCT:
+
+        ; -- Even part
+
+        vmovdqa      ymm8, YMM_MMWORD [YMMBLOCK(0,0,rsi,SIZEOF_JCOEF)] 
+        vpermq       ymm0,ymm8,0x10                                   
+        vmovdqa      ymm9, YMM_MMWORD [YMMBLOCK(2,0,rsi,SIZEOF_JCOEF)] 
+        vpermq       ymm1,ymm9,0x10
+        vmovdqa      ymm10, YMM_MMWORD [YMMBLOCK(4,0,rsi,SIZEOF_JCOEF)]
+        vpermq       ymm2,ymm10,0x10
+        vmovdqa      ymm11, YMM_MMWORD [YMMBLOCK(6,0,rsi,SIZEOF_JCOEF)]
+        vpermq       ymm3,ymm11,0x10
+
+        vpunpcklwd ymm0,ymm0,ymm0             
+        vpunpcklwd ymm1,ymm1,ymm1             
+        vpsrad     ymm0,ymm0,(DWORD_BIT-WORD_BIT)     
+        vpsrad     ymm1,ymm1,(DWORD_BIT-WORD_BIT)     
+        vcvtdq2ps  ymm0,ymm0                     
+        vcvtdq2ps  ymm1,ymm1                     
+
+        vpunpcklwd ymm2,ymm2,ymm2             
+        vpunpcklwd ymm3,ymm3,ymm3             
+        vpsrad     ymm2,ymm2,(DWORD_BIT-WORD_BIT)     
+        vpsrad     ymm3,ymm3,(DWORD_BIT-WORD_BIT)     
+        vcvtdq2ps  ymm2,ymm2                     
+        vcvtdq2ps  ymm3,ymm3                     
+
+        vmulps     ymm0,ymm0, YMMWORD [YMMBLOCK(0,0,rdx,SIZEOF_FLOAT_MULT_TYPE)]
+        vmulps     ymm1,ymm1, YMMWORD [YMMBLOCK(2,0,rdx,SIZEOF_FLOAT_MULT_TYPE)]
+        vmulps     ymm2,ymm2, YMMWORD [YMMBLOCK(4,0,rdx,SIZEOF_FLOAT_MULT_TYPE)]
+        vmulps     ymm3,ymm3, YMMWORD [YMMBLOCK(6,0,rdx,SIZEOF_FLOAT_MULT_TYPE)]
+
+        vaddps   ymm4,ymm0,ymm2               
+        vaddps   ymm5,ymm1,ymm3               
+        vsubps   ymm0,ymm0,ymm2               
+        vsubps   ymm1,ymm1,ymm3
+
+        vmulps   ymm1,ymm1,[rel PD_1_414]
+        vsubps   ymm1,ymm1,ymm5               
+
+        vaddps   ymm6,ymm4,ymm5               
+        vaddps   ymm7,ymm0,ymm1               
+        vsubps   ymm4,ymm4,ymm5               
+        vsubps   ymm0,ymm0,ymm1               
+
+        vmovaps  YMMWORD [wk(1)], ymm4   
+        vmovaps  YMMWORD [wk(0)], ymm0   
+
+        ; -- Odd part
+        vpermq       ymm2,ymm8,0x32
+        vpermq       ymm3,ymm9,0x32
+        vpermq       ymm5,ymm10,0x32
+        vpermq       ymm1,ymm11,0x32
+
+        vpunpcklwd ymm2,ymm2,ymm2             
+        vpunpcklwd ymm3,ymm3,ymm3             
+        vpsrad     ymm2,ymm2,(DWORD_BIT-WORD_BIT)     
+        vpsrad     ymm3,ymm3,(DWORD_BIT-WORD_BIT)     
+        vcvtdq2ps  ymm2,ymm2                     
+        vcvtdq2ps  ymm3,ymm3                     
+
+        vpunpcklwd ymm5,ymm5,ymm5             
+        vpunpcklwd ymm1,ymm1,ymm1             
+        vpsrad     ymm5,ymm5,(DWORD_BIT-WORD_BIT)     
+        vpsrad     ymm1,ymm1,(DWORD_BIT-WORD_BIT)     
+        vcvtdq2ps  ymm5,ymm5                     
+        vcvtdq2ps  ymm1,ymm1                     
+
+        vmulps     ymm2, YMMWORD [YMMBLOCK(1,0,rdx,SIZEOF_FLOAT_MULT_TYPE)]
+        vmulps     ymm3, YMMWORD [YMMBLOCK(3,0,rdx,SIZEOF_FLOAT_MULT_TYPE)]
+        vmulps     ymm5, YMMWORD [YMMBLOCK(5,0,rdx,SIZEOF_FLOAT_MULT_TYPE)]
+        vmulps     ymm1, YMMWORD [YMMBLOCK(7,0,rdx,SIZEOF_FLOAT_MULT_TYPE)]
+
+        vsubps   ymm4,ymm2,ymm1               
+        vsubps   ymm0,ymm5,ymm3               
+        vaddps   ymm2,ymm2,ymm1               
+        vaddps   ymm5,ymm5,ymm3               
+
+        vaddps   ymm1,ymm2,ymm5               
+        vsubps   ymm2,ymm2,ymm5
+
+        vmulps   ymm2,[rel PD_1_414]     
+
+        vmulps   ymm3,ymm0,[rel PD_M2_613]    
+        vaddps   ymm0,ymm0,ymm4
+        vmulps   ymm0,[rel PD_1_847]     
+        vmulps   ymm4,[rel PD_1_082]     
+        vaddps   ymm3,ymm3,ymm0               
+        vsubps   ymm4,ymm4,ymm0               
+
+        ; -- Final output stage
+
+        vsubps   ymm3,ymm3,ymm1               
+        vaddps   ymm8,ymm6,ymm1               
+        vaddps   ymm9,ymm7,ymm3               
+        vsubps   ymm15,ymm6,ymm1               
+        vsubps   ymm14,ymm7,ymm3               
+        vsubps   ymm2,ymm2,ymm3               
+
+        vmovaps  ymm7, YMMWORD [wk(0)]   
+        vmovaps  ymm5, YMMWORD [wk(1)]   
+
+        vaddps   ymm4,ymm4,ymm2               
+        vaddps   ymm10,ymm7,ymm2               
+        vaddps   ymm12,ymm5,ymm4               
+        vsubps   ymm13,ymm7,ymm2               
+        vsubps   ymm11,ymm5,ymm4               
+
+        vunpcklps ymm2,ymm10,ymm11
+        vunpckhps ymm3,ymm10,ymm11
+        vunpcklps ymm0,ymm8,ymm9
+        vunpckhps ymm1,ymm8,ymm9
+        vunpcklpd ymm8,ymm0,ymm2
+        vunpckhpd ymm10,ymm0,ymm2
+        vunpcklpd ymm9,ymm1,ymm3
+        vunpckhpd ymm11,ymm1,ymm3
+        ;   
+
+        vunpcklps ymm6,ymm14,ymm15
+        vunpckhps ymm7,ymm14,ymm15
+        vunpcklps ymm4,ymm12,ymm13
+        vunpckhps ymm5,ymm12,ymm13
+        vunpcklpd ymm12,ymm4,ymm6
+        vunpckhpd ymm14,ymm4,ymm6
+        vunpcklpd ymm13,ymm5,ymm7
+        vunpckhpd ymm15,ymm5,ymm7
+
+        vperm2f128 ymm0,ymm8,ymm12,0x20  
+        vperm2f128 ymm2,ymm8,ymm12,0x31  
+        vperm2f128 ymm1,ymm9,ymm13,0x20  
+        vperm2f128 ymm3,ymm9,ymm13,0x31  
+        vperm2f128 ymm8,ymm10,ymm14,0x20 
+        vperm2f128 ymm10,ymm10,ymm14,0x31
+        vperm2f128 ymm9,ymm11,ymm15,0x20 
+        vperm2f128 ymm11,ymm11,ymm15,0x31
+;
+.nextcolumn:
+
+        ; -- Prefetch the next coefficient block
+        prefetchnta [rsi + (DCTSIZE2-8)*SIZEOF_JCOEF + 0*32]
+        prefetchnta [rsi + (DCTSIZE2-8)*SIZEOF_JCOEF + 1*32]
+        prefetchnta [rsi + (DCTSIZE2-8)*SIZEOF_JCOEF + 2*32]
+        prefetchnta [rsi + (DCTSIZE2-8)*SIZEOF_JCOEF + 3*32]
+
+
+        ; ---- Pass 2: process rows from work array, store into output array.
+
+        mov     rax, [original_rbp]
+        lea     rsi, [workspace]                        ; FAST_FLOAT * wsptr
+        mov     rdi, r12        ; (JSAMPROW *)
+        mov     rax, r13
+
+.rowloop:
+
+        ; -- Even part
+
+        vaddps   ymm4,ymm0,ymm2               
+        vaddps   ymm5,ymm1,ymm3               
+        vsubps   ymm0,ymm0,ymm2               
+        vsubps   ymm1,ymm1,ymm3
+
+        vmulps   ymm1,ymm1,[rel PD_1_414]
+        vsubps   ymm1,ymm1,ymm5               
+
+        vaddps   ymm6,ymm4,ymm5               
+        vaddps   ymm7,ymm0,ymm1               
+        vsubps   ymm4,ymm4,ymm5               
+        vsubps   ymm0,ymm0,ymm1               
+
+        vmovaps  YMMWORD [wk(1)], ymm4   
+        vmovaps  YMMWORD [wk(0)], ymm0   
+
+        ; -- Odd part
+
+        vmovaps ymm2,ymm8
+        vmovaps ymm3,ymm9
+        vmovaps ymm5,ymm10
+        vmovaps ymm1,ymm11
+
+        vsubps   ymm4,ymm2,ymm1               
+        vsubps   ymm0,ymm5,ymm3               
+        vaddps   ymm2,ymm2,ymm1               
+        vaddps   ymm5,ymm5,ymm3               
+
+        vaddps   ymm1,ymm2,ymm5               
+        vsubps   ymm2,ymm2,ymm5
+
+        vmulps   ymm2,ymm2,[rel PD_1_414]     
+
+        vmulps   ymm3,ymm0,[rel PD_M2_613]    
+        vaddps   ymm0,ymm0,ymm4
+        vmulps   ymm0,ymm0,[rel PD_1_847]     
+        vmulps   ymm4,ymm4,[rel PD_1_082]     
+        vaddps   ymm3,ymm3,ymm0               
+        vsubps   ymm4,ymm4,ymm0               
+
+        ; -- Final output stage
+
+        vsubps   ymm3,ymm3,ymm1               
+        vsubps   ymm5,ymm6,ymm1               
+        vsubps   ymm0,ymm7,ymm3               
+        vaddps   ymm6,ymm6,ymm1               
+        vaddps   ymm7,ymm7,ymm3               
+        vsubps   ymm2,ymm2,ymm3               
+
+        vmovaps  ymm1,[rel PD_RNDINT_MAGIC]      
+        vpcmpeqd ymm3,ymm3,ymm3
+        vpsrld   ymm3,ymm3,WORD_BIT           
+
+        vaddps   ymm6,ymm6,ymm1       
+        vaddps   ymm7,ymm7,ymm1       
+        vaddps   ymm0,ymm0,ymm1       
+        vaddps   ymm5,ymm5,ymm1       
+
+        vpand    ymm6,ymm6,ymm3               
+        vpslld   ymm7,ymm7,WORD_BIT           
+        vpand    ymm0,ymm0,ymm3               
+        vpslld   ymm5,ymm5,WORD_BIT           
+        vpor     ymm6,ymm6,ymm7               
+        vpor     ymm0,ymm0,ymm5               
+
+        vmovaps  ymm1, YMMWORD [wk(0)]   
+        vmovaps  ymm3, YMMWORD [wk(1)]   
+
+        vaddps   ymm4,ymm4,ymm2               
+        vsubps   ymm7,ymm1,ymm2             
+        vsubps   ymm5,ymm3,ymm4            
+        vaddps   ymm1,ymm1,ymm2               
+        vaddps   ymm3,ymm3,ymm4              
+
+        vmovaps  ymm2,[rel PD_RNDINT_MAGIC]      
+        vpcmpeqd ymm4,ymm4,ymm4
+        vpsrld   ymm4,ymm4,WORD_BIT           
+
+        vaddps   ymm3,ymm3,ymm2      
+        vaddps   ymm7,ymm7,ymm2     
+        vaddps   ymm1,ymm1,ymm2    
+        vaddps   ymm5,ymm5,ymm2   
+
+        vpand    ymm3,ymm3,ymm4          
+        vpslld   ymm7,ymm7,WORD_BIT     
+        vpand    ymm1,ymm1,ymm4        
+        vpslld   ymm5,ymm5,WORD_BIT   
+        vpor     ymm3,ymm3,ymm7               
+        vpor     ymm1,ymm1,ymm5               
+
+        vmovdqa    ymm2,[rel PB_CENTERJSAMP]     
+
+        vpacksswb  ymm6,ymm6,ymm3     
+        vpacksswb  ymm1,ymm1,ymm0     
+        vpaddb     ymm6,ymm6,ymm2
+        vpaddb     ymm1,ymm1,ymm2
+
+        vmovdqa    ymm4,ymm6     
+        vpunpcklwd ymm6,ymm6,ymm1     
+        vpunpckhwd ymm4,ymm4,ymm1     
+
+        vmovdqa    ymm7,ymm6     
+        vpunpckldq ymm6,ymm6,ymm4     
+        vpunpckhdq ymm7,ymm7,ymm4     
+
+        mov     rdx, JSAMPROW [rdi+0*SIZEOF_JSAMPROW]
+        mov     rbx, JSAMPROW [rdi+2*SIZEOF_JSAMPROW]
+        vmovq    XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm6;
+        vmovq    XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE], xmm7;
+
+        vpermq  ymm5,ymm6,0x01
+        vpermq  ymm3,ymm7,0x01
+        mov     rdx, JSAMPROW [rdi+1*SIZEOF_JSAMPROW]
+        mov     rbx, JSAMPROW [rdi+3*SIZEOF_JSAMPROW]
+        vmovq   XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm5
+        vmovq   XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE], xmm3
+
+        vpermq  ymm5,ymm6,0x02
+        vpermq  ymm3,ymm7,0x02
+        mov     rdx, JSAMPROW [rdi+4*SIZEOF_JSAMPROW]
+        mov     rbx, JSAMPROW [rdi+6*SIZEOF_JSAMPROW]
+        vmovq   XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm5
+        vmovq   XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE], xmm3
+
+        vpermq  ymm5,ymm6,0x03
+        vpermq  ymm3,ymm7,0x03
+        mov     rdx, JSAMPROW [rdi+5*SIZEOF_JSAMPROW]
+        mov     rbx, JSAMPROW [rdi+7*SIZEOF_JSAMPROW]
+        vmovq   XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm5
+        vmovq   XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE], xmm3
+
+.exit:
+
+        pop     rbx
+        uncollect_args
+        mov     rsp,rbp         ; rsp <- aligned rbp
+        pop     rsp             ; rsp <- original rbp
+        pop     rbp
+        ret
+
+; For some reason, the OS X linker does not honor the request to align the
+; segment unless we do this.
+        align   32

--- a/simd/jidctfst-avx2-64.asm
+++ b/simd/jidctfst-avx2-64.asm
@@ -1,0 +1,484 @@
+;
+; jidctfst.asm - fast integer IDCT (64-bit AVX2)
+;
+; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2009 D. R. Commander
+; Copyright (C) 2015, Intel Corporation
+;
+; Based on
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; This file contains a fast, not so accurate integer implementation of
+; the inverse DCT (Discrete Cosine Transform). The following code is
+; based directly on the IJG's original jidctfst.c; see the jidctfst.c
+; for more details.
+;
+; [TAB8]
+
+%include "jsimdext.inc"
+%include "jdct.inc"
+
+; --------------------------------------------------------------------------
+
+%define CONST_BITS      8       ; 14 is also OK.
+%define PASS1_BITS      2
+
+%if IFAST_SCALE_BITS != PASS1_BITS
+%error "'IFAST_SCALE_BITS' must be equal to 'PASS1_BITS'."
+%endif
+
+%if CONST_BITS == 8
+F_1_082 equ     277             ; FIX(1.082392200)
+F_1_414 equ     362             ; FIX(1.414213562)
+F_1_847 equ     473             ; FIX(1.847759065)
+F_2_613 equ     669             ; FIX(2.613125930)
+F_1_613 equ     (F_2_613 - 256) ; FIX(2.613125930) - FIX(1)
+%else
+; NASM cannot do compile-time arithmetic on floating-point constants.
+%define DESCALE(x,n)  (((x)+(1<<((n)-1)))>>(n))
+F_1_082 equ     DESCALE(1162209775,30-CONST_BITS)       ; FIX(1.082392200)
+F_1_414 equ     DESCALE(1518500249,30-CONST_BITS)       ; FIX(1.414213562)
+F_1_847 equ     DESCALE(1984016188,30-CONST_BITS)       ; FIX(1.847759065)
+F_2_613 equ     DESCALE(2805822602,30-CONST_BITS)       ; FIX(2.613125930)
+F_1_613 equ     (F_2_613 - (1 << CONST_BITS))   ; FIX(2.613125930) - FIX(1)
+%endif
+
+; --------------------------------------------------------------------------
+        SECTION SEG_CONST
+
+; PRE_MULTIPLY_SCALE_BITS <= 2 (to avoid overflow)
+; CONST_BITS + CONST_SHIFT + PRE_MULTIPLY_SCALE_BITS == 16 (for pmulhw)
+
+%define PRE_MULTIPLY_SCALE_BITS   2
+%define CONST_SHIFT     (16 - PRE_MULTIPLY_SCALE_BITS - CONST_BITS)
+
+        alignz  32
+        global  EXTN(jconst_idct_ifast_avx2)
+
+EXTN(jconst_idct_ifast_avx2):
+
+PW_F1414        times 16 dw  F_1_414 << CONST_SHIFT
+PW_F1847        times 16 dw  F_1_847 << CONST_SHIFT
+PW_MF1613       times 16 dw -F_1_613 << CONST_SHIFT
+PW_F1082        times 16 dw  F_1_082 << CONST_SHIFT
+PB_CENTERJSAMP  times 32 db CENTERJSAMPLE
+
+        alignz  32
+
+; --------------------------------------------------------------------------
+        SECTION SEG_TEXT
+        BITS    64
+;
+; Perform dequantization and inverse DCT on one block of coefficients.
+;
+; GLOBAL(void)
+; jsimd_idct_ifast_avx2 (void * dct_table, JCOEFPTR coef_block,
+;                       JSAMPARRAY output_buf, JDIMENSION output_col)
+;
+
+; r10 = jpeg_component_info * compptr
+; r11 = JCOEFPTR coef_block
+; r12 = JSAMPARRAY output_buf
+; r13 = JDIMENSION output_col
+
+%define original_rbp    rbp+0
+%define wk(i)           rbp-(WK_NUM-(i))*SIZEOF_YMMWORD ; ymmword wk[WK_NUM]
+%define WK_NUM          2
+
+        align   32
+        global  EXTN(jsimd_idct_ifast_avx2)
+
+EXTN(jsimd_idct_ifast_avx2):
+        push    rbp
+        mov     rax,rsp                         ; rax = original rbp
+        sub     rsp, byte 4
+        and     rsp, byte (-SIZEOF_YMMWORD)     ; align to 128 bits
+        mov     [rsp],rax
+        mov     rbp,rsp                         ; rbp = aligned rbp
+        lea     rsp, [wk(0)]
+        collect_args
+
+        ; ---- Pass 1: process columns from input.
+
+        mov     rdx, r10                ; quantptr
+        mov     rsi, r11                ; inptr
+
+%ifndef NO_ZERO_COLUMN_TEST_IFAST_AVX2
+        mov     eax, DWORD [DWBLOCK(1,0,rsi,SIZEOF_JCOEF)]
+        or      eax, DWORD [DWBLOCK(2,0,rsi,SIZEOF_JCOEF)]
+        or      eax, DWORD [DWBLOCK(9,0,rsi,SIZEOF_JCOEF)]
+        or      eax, DWORD [DWBLOCK(10,0,rsi,SIZEOF_JCOEF)]
+        jnz     near .columnDCT
+
+        vmovdqa  xmm0, XMMWORD [XMMBLOCK(1,0,rsi,SIZEOF_JCOEF)]
+        vmovdqa  xmm1, XMMWORD [XMMBLOCK(9,0,rsi,SIZEOF_JCOEF)]
+        vpor     ymm0, YMMWORD [YMMBLOCK(2,0,rsi,SIZEOF_JCOEF)]
+        vpor     ymm1, YMMWORD [YMMBLOCK(10,0,rsi,SIZEOF_JCOEF)]
+        vpor     ymm0, YMMWORD [YMMBLOCK(4,0,rsi,SIZEOF_JCOEF)]
+        vpor     ymm1, YMMWORD [YMMBLOCK(12,0,rsi,SIZEOF_JCOEF)]
+        vpor     ymm0, YMMWORD [YMMBLOCK(6,0,rsi,SIZEOF_JCOEF)]
+        vpor     ymm1, YMMWORD [YMMBLOCK(14,0,rsi,SIZEOF_JCOEF)]
+
+        vpor     ymm1,ymm0
+        vpacksswb ymm1,ymm1,ymm1
+        vpermq  ymm1,ymm1,0xD8 
+        vpacksswb xmm1,xmm1,xmm1
+        vpacksswb xmm1,xmm1,xmm1
+
+        vmovd    eax,xmm1
+        test    rax,rax
+        jnz     short .columnDCT
+
+        ; -- AC terms all zero
+
+        vmovdqa  xmm0, XMMWORD [XMMBLOCK(0,0,rsi,SIZEOF_JCOEF)]
+        vmovdqa  xmm1, XMMWORD [XMMBLOCK(8,0,rsi,SIZEOF_JCOEF)]
+        vperm2i128  ymm0,ymm0,ymm1,0x20
+
+        vmovdqa xmm1, XMMWORD [YMMBLOCK(0,0,rdx,SIZEOF_IFAST_MULT_TYPE)]
+        vperm2i128  ymm1,ymm1,ymm1,0
+        vpmullw  ymm0, ymm0,ymm1
+
+        vpunpckhwd ymm7,ymm0,ymm0             
+        vpunpcklwd ymm0,ymm0,ymm0             
+
+        vpshufd  ymm6,ymm0,0x00          
+        vpshufd  ymm2,ymm0,0x55          
+        vpshufd  ymm5,ymm0,0xAA          
+        vpshufd  ymm0,ymm0,0xFF          
+        vpshufd  ymm1,ymm7,0x00          
+        vpshufd  ymm4,ymm7,0x55          
+        vpshufd  ymm3,ymm7,0xAA          
+        vpshufd  ymm7,ymm7,0xFF          
+
+        vmovdqa  YMMWORD [wk(0)], ymm2   
+        vmovdqa  YMMWORD [wk(1)], ymm0   
+        jmp     near .column_end
+%endif
+.columnDCT:
+
+        ; -- Even part
+        vmovdqa  ymm14, YMMWORD [YMMBLOCK(0,0,rsi,SIZEOF_JCOEF)]
+        vmovdqa  ymm15, YMMWORD [YMMBLOCK(8,0,rsi,SIZEOF_JCOEF)]
+        vperm2i128  ymm0,ymm14,ymm15, 0x20
+        vperm2i128  ymm8,ymm14,ymm15, 0x31
+        vmovdqa  ymm14, [YMMBLOCK(0,0,rdx,SIZEOF_IFAST_MULT_TYPE)]
+        vperm2i128  ymm12,ymm14,ymm14,0x11
+        vperm2i128  ymm14,ymm14,ymm14,0
+        vpmullw ymm0,ymm0,ymm14
+
+        vmovdqa  ymm14, YMMWORD [YMMBLOCK(2,0,rsi,SIZEOF_JCOEF)]
+        vmovdqa  ymm15, YMMWORD [YMMBLOCK(10,0,rsi,SIZEOF_JCOEF)]
+        vperm2i128  ymm1,ymm14,ymm15, 0x20
+        vperm2i128  ymm9,ymm14,ymm15, 0x31
+        vmovdqa  ymm14, [YMMBLOCK(2,0,rdx,SIZEOF_IFAST_MULT_TYPE)]
+        vperm2i128  ymm13,ymm14,ymm14,0x11
+        vperm2i128  ymm14,ymm14,ymm14,0
+        vpmullw ymm1,ymm1,ymm14
+
+        vmovdqa  ymm14, YMMWORD [YMMBLOCK(4,0,rsi,SIZEOF_JCOEF)]
+        vmovdqa  ymm15, YMMWORD [YMMBLOCK(12,0,rsi,SIZEOF_JCOEF)]
+        vperm2i128  ymm2,ymm14,ymm15, 0x20
+        vperm2i128  ymm10,ymm14,ymm15, 0x31
+        vmovdqa  ymm6, [YMMBLOCK(4,0,rdx,SIZEOF_IFAST_MULT_TYPE)]
+        vperm2i128  ymm14,ymm6,ymm6,0
+        vpmullw ymm2,ymm2,ymm14
+        vperm2i128  ymm14,ymm6,ymm6,0x11
+
+        vmovdqa  ymm6, YMMWORD [YMMBLOCK(6,0,rsi,SIZEOF_JCOEF)]
+        vmovdqa  ymm7, YMMWORD [YMMBLOCK(14,0,rsi,SIZEOF_JCOEF)]
+        vperm2i128  ymm3,ymm6,ymm7, 0x20
+        vperm2i128  ymm11,ymm6,ymm7, 0x31
+        vmovdqa  ymm6, [YMMBLOCK(6,0,rdx,SIZEOF_IFAST_MULT_TYPE)]
+        vperm2i128  ymm15,ymm6,ymm6,0
+        vpmullw ymm3,ymm3,ymm15
+        vperm2i128  ymm15,ymm6,ymm6,0x11
+
+        vpaddw   ymm4,ymm0,ymm2               
+        vpaddw   ymm5,ymm1,ymm3               
+        vpsubw   ymm0,ymm0,ymm2               
+        vpsubw   ymm1,ymm1,ymm3
+
+        vpsllw   ymm1,ymm1,PRE_MULTIPLY_SCALE_BITS
+        vpmulhw  ymm1,ymm1,[rel PW_F1414]
+        vpsubw   ymm1,ymm1,ymm5               
+
+        vpaddw   ymm6,ymm4,ymm5               
+        vpaddw   ymm7,ymm0,ymm1               
+        vpsubw   ymm4,ymm4,ymm5               
+        vpsubw   ymm0,ymm0,ymm1               
+
+        vmovdqa  YMMWORD [wk(1)], ymm4   
+        vmovdqa  YMMWORD [wk(0)], ymm0   
+
+        ; -- Odd part
+
+        vpmullw ymm2, ymm8,ymm12
+        vpmullw ymm3, ymm9,ymm13
+        vpmullw ymm5, ymm10,ymm14
+        vpmullw ymm1, ymm11,ymm15
+
+        vpaddw   ymm4,ymm2,ymm1               
+        vpaddw   ymm0,ymm5,ymm3               
+        vpsubw   ymm2,ymm2,ymm1               
+        vpsubw   ymm5,ymm5,ymm3               
+
+        vmovdqa  ymm1,ymm5               
+        vpsllw   ymm2,ymm2,PRE_MULTIPLY_SCALE_BITS
+        vpsllw   ymm5,ymm5,PRE_MULTIPLY_SCALE_BITS
+
+        vpaddw   ymm3,ymm4,ymm0               
+        vpsubw   ymm4,ymm4,ymm0
+
+        vpsllw   ymm4,ymm4,PRE_MULTIPLY_SCALE_BITS
+        vpmulhw  ymm4,ymm4,[rel PW_F1414]     
+
+        ; To avoid overflow...
+        ;
+        ; (Original)
+        ; tmp12 = -2.613125930 * z10 + z5;
+        ;
+        ; (This implementation)
+        ; tmp12 = (-1.613125930 - 1) * z10 + z5;
+        ;       = -1.613125930 * z10 - z10 + z5;
+
+        vpmulhw  ymm0,ymm5,[rel PW_MF1613]
+        vpaddw   ymm5,ymm5,ymm2
+        vpmulhw  ymm5,ymm5,[rel PW_F1847]     
+        vpmulhw  ymm2,ymm2,[rel PW_F1082]
+        vpsubw   ymm0,ymm0,ymm1
+        vpsubw   ymm2,ymm2,ymm5               
+        vpaddw   ymm0,ymm0,ymm5               
+
+        ; -- Final output stage
+
+        vpsubw   ymm0,ymm0,ymm3               
+        vpsubw   ymm1,ymm6,ymm3               
+        vpsubw   ymm5,ymm7,ymm0               
+        vpaddw   ymm6,ymm6,ymm3               
+        vpaddw   ymm7,ymm7,ymm0               
+        vpsubw   ymm4,ymm4,ymm0               
+        vpunpckhwd ymm3,ymm6,ymm7             
+        vpunpcklwd ymm6,ymm6,ymm7             
+        vpunpckhwd ymm0,ymm5,ymm1             
+        vpunpcklwd ymm5,ymm5,ymm1             
+
+        vmovdqa  ymm7, YMMWORD [wk(0)]   
+        vmovdqa  ymm1, YMMWORD [wk(1)]   
+
+        vmovdqa  YMMWORD [wk(0)], ymm5   
+        vmovdqa  YMMWORD [wk(1)], ymm0   
+
+        vpaddw   ymm2,ymm2,ymm4               
+        vpsubw   ymm5,ymm7,ymm4               
+        vpaddw   ymm7,ymm7,ymm4               
+        vpsubw   ymm0,ymm1,ymm2               
+        vpaddw   ymm1,ymm1,ymm2               
+
+        vpunpckhwd ymm4,ymm7,ymm0             
+        vpunpcklwd ymm7,ymm7,ymm0             
+        vpunpckhwd ymm2,ymm1,ymm5             
+        vpunpcklwd ymm1,ymm1,ymm5             
+
+        vpunpckhdq ymm0,ymm3,ymm4             
+        vpunpckldq ymm3,ymm3,ymm4             
+        vpunpckhdq ymm5,ymm6,ymm7             
+        vpunpckldq ymm6,ymm6,ymm7             
+
+        vmovdqa  ymm4, YMMWORD [wk(0)]   
+        vmovdqa  ymm7, YMMWORD [wk(1)]   
+
+        vmovdqa  YMMWORD [wk(0)], ymm3   
+        vmovdqa  YMMWORD [wk(1)], ymm0   
+
+        vpunpckhdq ymm3,ymm1,ymm4             
+        vpunpckldq ymm1,ymm1,ymm4             
+        vpunpckhdq ymm0,ymm2,ymm7             
+        vpunpckldq ymm2,ymm2,ymm7             
+
+        vpunpckhqdq ymm4,ymm6,ymm1            
+        vpunpcklqdq ymm6,ymm6,ymm1            
+        vpunpckhqdq ymm7,ymm5,ymm3            
+        vpunpcklqdq ymm5,ymm5,ymm3            
+
+        vmovdqa  ymm1, YMMWORD [wk(0)]   
+        vmovdqa  ymm3, YMMWORD [wk(1)]   
+
+        vmovdqa  YMMWORD [wk(0)], ymm4   
+        vmovdqa  YMMWORD [wk(1)], ymm7   
+
+        vpunpckhqdq ymm4,ymm1,ymm2            
+        vpunpcklqdq ymm1,ymm1,ymm2            
+        vpunpckhqdq ymm7,ymm3,ymm0            
+        vpunpcklqdq ymm3,ymm3,ymm0            
+
+.column_end:
+
+        ; -- Prefetch the next coefficient block
+
+        prefetchnta [rsi + DCTSIZE2*SIZEOF_JCOEF + 0*32]
+        prefetchnta [rsi + DCTSIZE2*SIZEOF_JCOEF + 1*32]
+        prefetchnta [rsi + DCTSIZE2*SIZEOF_JCOEF + 2*32]
+        prefetchnta [rsi + DCTSIZE2*SIZEOF_JCOEF + 3*32]
+
+        ; ---- Pass 2: process rows from work array, store into output array.
+
+        mov     rax, [original_rbp]
+        mov     rdi, r12        ; (JSAMPROW *)
+        mov     rax, r13
+
+        ; -- Even part
+
+        vpaddw   ymm2,ymm6,ymm1               
+        vpaddw   ymm0,ymm5,ymm3               
+        vpsubw   ymm6,ymm6,ymm1               
+        vpsubw   ymm5,ymm5,ymm3
+
+        vpsllw   ymm5,ymm5,PRE_MULTIPLY_SCALE_BITS
+        vpmulhw  ymm5,ymm5,[rel PW_F1414]
+        vpsubw   ymm5,ymm5,ymm0               
+
+        vpaddw   ymm1,ymm2,ymm0               
+        vpaddw   ymm3,ymm6,ymm5               
+        vpsubw   ymm2,ymm2,ymm0               
+        vpsubw   ymm6,ymm6,ymm5               
+  
+        vmovdqa  ymm0, YMMWORD [wk(0)]   
+        vmovdqa  ymm5, YMMWORD [wk(1)]   
+
+        vmovdqa  YMMWORD [wk(0)], ymm2   
+        vmovdqa  YMMWORD [wk(1)], ymm6   
+
+        ; -- Odd part
+
+        vpaddw   ymm2,ymm0,ymm7               
+        vpaddw   ymm6,ymm4,ymm5               
+        vpsubw   ymm0,ymm0,ymm7               
+        vpsubw   ymm4,ymm4,ymm5               
+
+        vmovdqa  ymm7,ymm4               
+        vpsllw   ymm0,ymm0,PRE_MULTIPLY_SCALE_BITS
+        vpsllw   ymm4,ymm4,PRE_MULTIPLY_SCALE_BITS
+
+        vmovdqa  ymm5,ymm2
+        vpsubw   ymm2,ymm2,ymm6
+        vpaddw   ymm5,ymm5,ymm6               
+
+        vpsllw   ymm2,ymm2,PRE_MULTIPLY_SCALE_BITS
+        vpmulhw  ymm2,ymm2,[rel PW_F1414]     
+        ; To avoid overflow...
+        ;
+        ; (Original)
+        ; tmp12 = -2.613125930 * z10 + z5;
+        ;
+        ; (This implementation)
+        ; tmp12 = (-1.613125930 - 1) * z10 + z5;
+        ;       = -1.613125930 * z10 - z10 + z5;
+
+        vpmulhw  ymm6,ymm4,[rel PW_MF1613]
+        vpaddw   ymm4,ymm4,ymm0
+        vpmulhw  ymm4,ymm4,[rel PW_F1847]     
+        vpmulhw  ymm0,ymm0,[rel PW_F1082]
+        vpsubw   ymm6,ymm6,ymm7
+        vpsubw   ymm0,ymm0,ymm4               
+        vpaddw   ymm6,ymm6,ymm4               
+
+        ; -- Final output stage
+
+        vpsubw   ymm6,ymm6,ymm5               
+        vpsubw   ymm7,ymm1,ymm5               
+        vpsubw   ymm4,ymm3,ymm6               
+        vpaddw   ymm1,ymm1,ymm5               
+        vpaddw   ymm3,ymm3,ymm6               
+        vpsraw   ymm1,ymm1,(PASS1_BITS+3)     
+        vpsraw   ymm3,ymm3,(PASS1_BITS+3)     
+        vpsraw   ymm7,ymm7,(PASS1_BITS+3)     
+        vpsraw   ymm4,ymm4,(PASS1_BITS+3)     
+        vpsubw   ymm2,ymm2,ymm6               
+
+        vpacksswb  ymm1,ymm1,ymm4     
+        vpacksswb  ymm3,ymm3,ymm7     
+
+        vmovdqa  ymm5, YMMWORD [wk(1)]   
+        vmovdqa  ymm6, YMMWORD [wk(0)]   
+
+        vpaddw   ymm0,ymm0,ymm2               
+        vpsubw   ymm7,ymm6,ymm0               
+        vpsubw   ymm4,ymm5,ymm2               
+        vpaddw   ymm5,ymm5,ymm2               
+        vpaddw   ymm6,ymm6,ymm0               
+        vpsraw   ymm5,ymm5,(PASS1_BITS+3)     
+        vpsraw   ymm6,ymm6,(PASS1_BITS+3)     
+        vpsraw   ymm4,ymm4,(PASS1_BITS+3)     
+        vpsraw   ymm7,ymm7,(PASS1_BITS+3)     
+
+        vmovdqa    ymm2,[rel PB_CENTERJSAMP]     
+
+        vpacksswb  ymm5,ymm5,ymm6     
+        vpacksswb  ymm7,ymm7,ymm4     
+
+        vpaddb     ymm1,ymm1,ymm2
+        vpaddb     ymm3,ymm3,ymm2
+        vpaddb     ymm5,ymm5,ymm2
+        vpaddb     ymm7,ymm7,ymm2
+
+        vpunpckhbw ymm0,ymm1,ymm3     
+        vpunpcklbw ymm1,ymm1,ymm3     
+        vpunpckhbw ymm6,ymm5,ymm7     
+        vpunpcklbw ymm5,ymm5,ymm7     
+
+        vpunpckhwd ymm4,ymm1,ymm5     
+        vpunpcklwd ymm1,ymm1,ymm5     
+        vpunpckhwd ymm2,ymm6,ymm0     
+        vpunpcklwd ymm6,ymm6,ymm0     
+
+        vpunpckhdq ymm3,ymm1,ymm6     
+        vpunpckldq ymm1,ymm1,ymm6     
+        vpunpckhdq ymm7,ymm4,ymm2     
+        vpunpckldq ymm4,ymm4,ymm2     
+
+        vpermq  ymm5,ymm1,0xd8      
+        vperm2i128 ymm1,ymm5,ymm5,1 
+        vpermq  ymm0,ymm3,0xd8      
+        vperm2i128 ymm3,ymm0,ymm0,1 
+        vpermq  ymm6,ymm4,0xd8      
+        vperm2i128 ymm4,ymm6,ymm6,1 
+        vpermq  ymm2,ymm7,0xd8      
+        vperm2i128 ymm7,ymm2,ymm2,1 
+
+        mov     rdx, JSAMPROW [rdi+0*SIZEOF_JSAMPROW]
+        mov     rsi, JSAMPROW [rdi+2*SIZEOF_JSAMPROW]
+        vmovdqu    XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm5
+        vmovdqu    XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE], xmm0
+        mov     rdx, JSAMPROW [rdi+4*SIZEOF_JSAMPROW]
+        mov     rsi, JSAMPROW [rdi+6*SIZEOF_JSAMPROW]
+        vmovdqu    XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm6
+        vmovdqu    XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE], xmm2
+
+        mov     rdx, JSAMPROW [rdi+1*SIZEOF_JSAMPROW]
+        mov     rsi, JSAMPROW [rdi+3*SIZEOF_JSAMPROW]
+        vmovdqu    XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm1
+        vmovdqu    XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE], xmm3
+        mov     rdx, JSAMPROW [rdi+5*SIZEOF_JSAMPROW]
+        mov     rsi, JSAMPROW [rdi+7*SIZEOF_JSAMPROW]
+        vmovdqu    XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm4
+        vmovdqu    XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE], xmm7
+
+        uncollect_args
+        mov     rsp,rbp         ; rsp <- aligned rbp
+        pop     rsp             ; rsp <- original rbp
+        pop     rbp
+        ret
+        ret
+
+; For some reason, the OS X linker does not honor the request to align the
+; segment unless we do this.
+        align   32

--- a/simd/jidctint-avx2-64.asm
+++ b/simd/jidctint-avx2-64.asm
@@ -1,0 +1,800 @@
+;
+; jidctint.asm - accurate integer IDCT (64-bit AVX2)
+;
+; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2009 D. R. Commander
+; Copyright 2015 Intel Corporation
+;
+; Based on
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; This file contains a slow-but-accurate integer implementation of the
+; inverse DCT (Discrete Cosine Transform). The following code is based
+; directly on the IJG's original jidctint.c; see the jidctint.c for
+; more details.
+;
+; [TAB8]
+
+%include "jsimdext.inc"
+%include "jdct.inc"
+
+; --------------------------------------------------------------------------
+
+%define CONST_BITS      13
+%define PASS1_BITS      2
+
+%define DESCALE_P1      (CONST_BITS-PASS1_BITS)
+%define DESCALE_P2      (CONST_BITS+PASS1_BITS+3)
+
+%if CONST_BITS == 13
+F_0_298 equ      2446           ; FIX(0.298631336)
+F_0_390 equ      3196           ; FIX(0.390180644)
+F_0_541 equ      4433           ; FIX(0.541196100)
+F_0_765 equ      6270           ; FIX(0.765366865)
+F_0_899 equ      7373           ; FIX(0.899976223)
+F_1_175 equ      9633           ; FIX(1.175875602)
+F_1_501 equ     12299           ; FIX(1.501321110)
+F_1_847 equ     15137           ; FIX(1.847759065)
+F_1_961 equ     16069           ; FIX(1.961570560)
+F_2_053 equ     16819           ; FIX(2.053119869)
+F_2_562 equ     20995           ; FIX(2.562915447)
+F_3_072 equ     25172           ; FIX(3.072711026)
+%else
+; NASM cannot do compile-time arithmetic on floating-point constants.
+%define DESCALE(x,n)  (((x)+(1<<((n)-1)))>>(n))
+F_0_298 equ     DESCALE( 320652955,30-CONST_BITS)       ; FIX(0.298631336)
+F_0_390 equ     DESCALE( 418953276,30-CONST_BITS)       ; FIX(0.390180644)
+F_0_541 equ     DESCALE( 581104887,30-CONST_BITS)       ; FIX(0.541196100)
+F_0_765 equ     DESCALE( 821806413,30-CONST_BITS)       ; FIX(0.765366865)
+F_0_899 equ     DESCALE( 966342111,30-CONST_BITS)       ; FIX(0.899976223)
+F_1_175 equ     DESCALE(1262586813,30-CONST_BITS)       ; FIX(1.175875602)
+F_1_501 equ     DESCALE(1612031267,30-CONST_BITS)       ; FIX(1.501321110)
+F_1_847 equ     DESCALE(1984016188,30-CONST_BITS)       ; FIX(1.847759065)
+F_1_961 equ     DESCALE(2106220350,30-CONST_BITS)       ; FIX(1.961570560)
+F_2_053 equ     DESCALE(2204520673,30-CONST_BITS)       ; FIX(2.053119869)
+F_2_562 equ     DESCALE(2751909506,30-CONST_BITS)       ; FIX(2.562915447)
+F_3_072 equ     DESCALE(3299298341,30-CONST_BITS)       ; FIX(3.072711026)
+%endif
+
+; --------------------------------------------------------------------------
+        SECTION SEG_CONST
+
+        alignz  32
+        global  EXTN(jconst_idct_islow_avx2)
+
+EXTN(jconst_idct_islow_avx2):
+
+PW_F130_F054    times 8 dw  (F_0_541+F_0_765), F_0_541
+PW_F054_MF130   times 8 dw  F_0_541, (F_0_541-F_1_847)
+PW_MF078_F117   times 8 dw  (F_1_175-F_1_961), F_1_175
+PW_F117_F078    times 8 dw  F_1_175, (F_1_175-F_0_390)
+PW_MF060_MF089  times 8 dw  (F_0_298-F_0_899),-F_0_899
+PW_MF089_F060   times 8 dw -F_0_899, (F_1_501-F_0_899)
+PW_MF050_MF256  times 8 dw  (F_2_053-F_2_562),-F_2_562
+PW_MF256_F050   times 8 dw -F_2_562, (F_3_072-F_2_562)
+PD_DESCALE_P1   times 8 dd  1 << (DESCALE_P1-1)
+PD_DESCALE_P2   times 8 dd  1 << (DESCALE_P2-1)
+PB_CENTERJSAMP  times 32 db CENTERJSAMPLE
+
+        alignz  32
+
+; --------------------------------------------------------------------------
+        SECTION SEG_TEXT
+        BITS    64
+;
+; Perform dequantization and inverse DCT on one block of coefficients.
+;
+; GLOBAL(void)
+; jsimd_idct_islow_avx2 (void * dct_table, JCOEFPTR coef_block,
+;                        JSAMPARRAY output_buf, JDIMENSION output_col)
+;
+
+; r10 = jpeg_component_info * compptr
+; r11 = JCOEFPTR coef_block
+; r12 = JSAMPARRAY output_buf
+; r13 = JDIMENSION output_col
+
+%define original_rbp    rbp+0
+%define wk(i)           rbp-(WK_NUM-(i))*SIZEOF_YMMWORD 
+%define WK_NUM          12
+
+        align   32
+        global  EXTN(jsimd_idct_islow_avx2)
+
+EXTN(jsimd_idct_islow_avx2):
+        push    rbp
+        mov     rax,rsp                         ; rax = original rbp
+        sub     rsp, byte 4
+        and     rsp, byte (-SIZEOF_YMMWORD)     ; align to 256 bits
+        mov     [rsp],rax
+        mov     rbp,rsp                         ; rbp = aligned rbp
+        lea     rsp, [wk(0)]
+        collect_args
+
+        ; ---- Pass 1: process columns from input.
+
+        mov     rdx, r10                ; quantptr
+        mov     rsi, r11                ; inptr
+
+%ifndef NO_ZERO_COLUMN_TEST_ISLOW_AVX2
+        mov     eax, DWORD [DWBLOCK(1,0,rsi,SIZEOF_JCOEF)]
+        or      eax, DWORD [DWBLOCK(2,0,rsi,SIZEOF_JCOEF)]
+        ;next MCUBUffer is located at DWBLOCK(8,0,rsi,SIZEOF_JCOEF)
+        ; or DWBLOCK(4,0,rsi,2*SIZEOF_JCOEF)
+        or      eax, DWORD [DWBLOCK(9,0,rsi,SIZEOF_JCOEF)]
+        or      eax, DWORD [DWBLOCK(10,0,rsi,SIZEOF_JCOEF)]
+        jnz     near .columnDCT
+
+        vmovdqa  xmm0, XMMWORD [XMMBLOCK(1,0,rsi,SIZEOF_JCOEF)]
+        vmovdqa  xmm1, XMMWORD [XMMBLOCK(9,0,rsi,SIZEOF_JCOEF)]
+        vpor     ymm0, YMMWORD [YMMBLOCK(2,0,rsi,SIZEOF_JCOEF)]
+        vpor     ymm1, YMMWORD [YMMBLOCK(10,0,rsi,SIZEOF_JCOEF)]
+        vpor     ymm0, YMMWORD [YMMBLOCK(4,0,rsi,SIZEOF_JCOEF)]
+        vpor     ymm1, YMMWORD [YMMBLOCK(12,0,rsi,SIZEOF_JCOEF)]
+        vpor     ymm0, YMMWORD [YMMBLOCK(6,0,rsi,SIZEOF_JCOEF)]
+        vpor     ymm1, YMMWORD [YMMBLOCK(14,0,rsi,SIZEOF_JCOEF)]
+
+        vpor     ymm1,ymm0
+        vpacksswb ymm1,ymm1,ymm1
+        vpermq  ymm1,ymm1,0xD8 
+        vpacksswb xmm1,xmm1,xmm1
+        vpacksswb xmm1,xmm1,xmm1
+
+        vmovd    eax,xmm1
+        test    rax,rax
+        jnz     short .columnDCT
+
+        ; -- AC terms all zero
+        vmovdqa  xmm0, XMMWORD [XMMBLOCK(0,0,rsi,SIZEOF_JCOEF)]
+        vmovdqa  xmm1, XMMWORD [XMMBLOCK(8,0,rsi,SIZEOF_JCOEF)]
+        vperm2i128  ymm0,ymm0,ymm1,0x20
+
+        vmovdqa xmm1, XMMWORD [YMMBLOCK(0,0,rdx,SIZEOF_IFAST_MULT_TYPE)]
+        vperm2i128  ymm1,ymm1,ymm1,0
+        vpmullw  ymm5, ymm0,ymm1
+
+        vpsllw   ymm5,ymm5,PASS1_BITS
+
+        vpunpckhwd ymm4,ymm5,ymm5             
+        vpunpcklwd ymm5,ymm5,ymm5             
+
+        vpshufd  ymm7,ymm5,0x00          
+        vpshufd  ymm6,ymm5,0x55          
+        vpshufd  ymm1,ymm5,0xAA          
+        vpshufd  ymm5,ymm5,0xFF          
+        vpshufd  ymm0,ymm4,0x00          
+        vpshufd  ymm3,ymm4,0x55          
+        vpshufd  ymm2,ymm4,0xAA          
+        vpshufd  ymm4,ymm4,0xFF          
+
+        vmovdqa  YMMWORD [wk(8)], ymm6   
+        vmovdqa  YMMWORD [wk(9)], ymm5   
+        vmovdqa  YMMWORD [wk(10)], ymm3  
+        vmovdqa  YMMWORD [wk(11)], ymm4  
+        jmp     near .column_end
+%endif
+.columnDCT:
+
+        ; -- Even part
+        vmovdqa  ymm14, YMMWORD [YMMBLOCK(0,0,rsi,SIZEOF_JCOEF)]
+        vmovdqa  ymm15, YMMWORD [YMMBLOCK(8,0,rsi,SIZEOF_JCOEF)]
+        vperm2i128  ymm0,ymm14,ymm15, 0x20
+        vperm2i128  ymm8,ymm14,ymm15, 0x31
+        vmovdqa  ymm14, [YMMBLOCK(0,0,rdx,SIZEOF_IFAST_MULT_TYPE)]
+        vperm2i128  ymm12,ymm14,ymm14,0x11
+        vperm2i128  ymm14,ymm14,ymm14,0
+        vpmullw ymm0,ymm0,ymm14
+
+        vmovdqa  ymm14, YMMWORD [YMMBLOCK(2,0,rsi,SIZEOF_JCOEF)]
+        vmovdqa  ymm15, YMMWORD [YMMBLOCK(10,0,rsi,SIZEOF_JCOEF)]
+        vperm2i128  ymm1,ymm14,ymm15, 0x20
+        vperm2i128  ymm9,ymm14,ymm15, 0x31
+        vmovdqa  ymm14, [YMMBLOCK(2,0,rdx,SIZEOF_IFAST_MULT_TYPE)]
+        vperm2i128  ymm13,ymm14,ymm14,0x11
+        vperm2i128  ymm14,ymm14,ymm14,0
+        vpmullw ymm1,ymm1,ymm14
+
+        vmovdqa  ymm14, YMMWORD [YMMBLOCK(4,0,rsi,SIZEOF_JCOEF)]
+        vmovdqa  ymm15, YMMWORD [YMMBLOCK(12,0,rsi,SIZEOF_JCOEF)]
+        vperm2i128  ymm2,ymm14,ymm15, 0x20
+        vperm2i128  ymm10,ymm14,ymm15, 0x31
+        vmovdqa  ymm6, [YMMBLOCK(4,0,rdx,SIZEOF_IFAST_MULT_TYPE)]
+        vperm2i128  ymm14,ymm6,ymm6,0
+        vpmullw ymm2,ymm2,ymm14
+        vperm2i128  ymm14,ymm6,ymm6,0x11
+
+        vmovdqa  ymm6, YMMWORD [YMMBLOCK(6,0,rsi,SIZEOF_JCOEF)]
+        vmovdqa  ymm7, YMMWORD [YMMBLOCK(14,0,rsi,SIZEOF_JCOEF)]
+        vperm2i128  ymm3,ymm6,ymm7, 0x20
+        vperm2i128  ymm11,ymm6,ymm7, 0x31
+        vmovdqa  ymm6, [YMMBLOCK(6,0,rdx,SIZEOF_IFAST_MULT_TYPE)]
+        vperm2i128  ymm15,ymm6,ymm6,0
+        vpmullw ymm3,ymm3,ymm15
+        vperm2i128  ymm15,ymm6,ymm6,0x11
+        ; (Original)
+        ; z1 = (z2 + z3) * 0.541196100;
+        ; tmp2 = z1 + z3 * -1.847759065;
+        ; tmp3 = z1 + z2 * 0.765366865;
+        ;
+        ; (This implementation)
+        ; tmp2 = z2 * 0.541196100 + z3 * (0.541196100 - 1.847759065);
+        ; tmp3 = z2 * (0.541196100 + 0.765366865) + z3 * 0.541196100;
+
+        vpunpcklwd ymm4,ymm1,ymm3             
+        vpunpckhwd ymm5,ymm1,ymm3
+        vpmaddwd   ymm1,ymm4,[rel PW_F054_MF130]      
+        vpmaddwd   ymm3,ymm5,[rel PW_F054_MF130]      
+        vpmaddwd   ymm4,ymm4,[rel PW_F130_F054]       
+        vpmaddwd   ymm5,ymm5,[rel PW_F130_F054]       
+
+        vpsubw     ymm6,ymm0,ymm2             
+        vpaddw     ymm0,ymm0,ymm2             
+
+        vpxor      ymm2,ymm2,ymm2
+        vpunpcklwd ymm7,ymm2,ymm0             
+        vpunpckhwd ymm2,ymm2,ymm0             
+        vpsrad     ymm7,ymm7,(16-CONST_BITS)  
+        vpsrad     ymm2,ymm2,(16-CONST_BITS)  
+
+        vpsubd   ymm0,ymm7,ymm4               
+        vpaddd   ymm7,ymm7,ymm4               
+        vpsubd   ymm4,ymm2,ymm5               
+        vpaddd   ymm2,ymm2,ymm5               
+
+        vmovdqa  YMMWORD [wk(0)], ymm7   
+        vmovdqa  YMMWORD [wk(1)], ymm2   
+        vmovdqa  YMMWORD [wk(2)], ymm0   
+        vmovdqa  YMMWORD [wk(3)], ymm4   
+
+        vpxor      ymm7,ymm7
+        vpunpcklwd ymm5,ymm7,ymm6             
+        vpunpckhwd ymm7,ymm7,ymm6             
+        vpsrad     ymm5,ymm5,(16-CONST_BITS)  
+        vpsrad     ymm7,ymm7,(16-CONST_BITS)  
+
+        vpsubd   ymm2,ymm5,ymm1               
+        vpaddd   ymm5,ymm5,ymm1               
+        vpsubd   ymm0,ymm7,ymm3               
+        vpaddd   ymm7,ymm7,ymm3               
+
+        vmovdqa  YMMWORD [wk(4)], ymm5   
+        vmovdqa  YMMWORD [wk(5)], ymm7   
+        vmovdqa  YMMWORD [wk(6)], ymm2   
+        vmovdqa  YMMWORD [wk(7)], ymm0   
+
+        ; -- Odd part
+
+        vpmullw ymm4, ymm8,ymm12
+        vpmullw ymm6, ymm9,ymm13
+        vpmullw ymm1, ymm10,ymm14
+        vpmullw ymm3, ymm11,ymm15
+        vpaddw   ymm5,ymm6,ymm3               
+        vpaddw   ymm7,ymm4,ymm1               
+
+        ; (Original)
+        ; z5 = (z3 + z4) * 1.175875602;
+        ; z3 = z3 * -1.961570560;  z4 = z4 * -0.390180644;
+        ; z3 += z5;  z4 += z5;
+        ;
+        ; (This implementation)
+        ; z3 = z3 * (1.175875602 - 1.961570560) + z4 * 1.175875602;
+        ; z4 = z3 * 1.175875602 + z4 * (1.175875602 - 0.390180644);
+
+        vpunpcklwd ymm2,ymm5,ymm7
+        vpunpckhwd ymm0,ymm5,ymm7
+        vpmaddwd   ymm5,ymm2,[rel PW_F117_F078]       
+        vpmaddwd   ymm7,ymm0,[rel PW_F117_F078]       
+        vpmaddwd   ymm2,ymm2,[rel PW_MF078_F117]      
+        vpmaddwd   ymm0,ymm0,[rel PW_MF078_F117]      
+        vmovdqa  YMMWORD [wk(10)], ymm2  
+        vmovdqa  YMMWORD [wk(11)], ymm0  
+
+        ; (Original)
+        ; z1 = tmp0 + tmp3;  z2 = tmp1 + tmp2;
+        ; tmp0 = tmp0 * 0.298631336;  tmp1 = tmp1 * 2.053119869;
+        ; tmp2 = tmp2 * 3.072711026;  tmp3 = tmp3 * 1.501321110;
+        ; z1 = z1 * -0.899976223;  z2 = z2 * -2.562915447;
+        ; tmp0 += z1 + z3;  tmp1 += z2 + z4;
+        ; tmp2 += z2 + z3;  tmp3 += z1 + z4;
+        ;
+        ; (This implementation)
+        ; tmp0 = tmp0 * (0.298631336 - 0.899976223) + tmp3 * -0.899976223;
+        ; tmp1 = tmp1 * (2.053119869 - 2.562915447) + tmp2 * -2.562915447;
+        ; tmp2 = tmp1 * -2.562915447 + tmp2 * (3.072711026 - 2.562915447);
+        ; tmp3 = tmp0 * -0.899976223 + tmp3 * (1.501321110 - 0.899976223);
+        ; tmp0 += z3;  tmp1 += z4;
+        ; tmp2 += z3;  tmp3 += z4;
+
+        vpunpcklwd ymm2,ymm3,ymm4
+        vpunpckhwd ymm0,ymm3,ymm4
+        vpmaddwd   ymm3,ymm2,[rel PW_MF089_F060]      
+        vpmaddwd   ymm4,ymm0,[rel PW_MF089_F060]      
+        vpmaddwd   ymm2,ymm2,[rel PW_MF060_MF089]     
+        vpmaddwd   ymm0,ymm0,[rel PW_MF060_MF089]     
+
+        vpaddd   ymm2,ymm2, YMMWORD [wk(10)]  
+        vpaddd   ymm0,ymm0, YMMWORD [wk(11)]  
+        vpaddd   ymm3,ymm3,ymm5               
+        vpaddd   ymm4,ymm4,ymm7               
+
+        vmovdqa  YMMWORD [wk(8)], ymm2   
+        vmovdqa  YMMWORD [wk(9)], ymm0   
+
+        vpunpcklwd ymm2,ymm1,ymm6
+        vpunpckhwd ymm0,ymm1,ymm6
+        vpmaddwd   ymm1,ymm2,[rel PW_MF256_F050]      
+        vpmaddwd   ymm6,ymm0,[rel PW_MF256_F050]      
+        vpmaddwd   ymm2,ymm2,[rel PW_MF050_MF256]     
+        vpmaddwd   ymm0,ymm0,[rel PW_MF050_MF256]     
+        
+        vpaddd   ymm2,ymm2,ymm5               
+        vpaddd   ymm0,ymm0,ymm7               
+        vpaddd   ymm1,ymm1, YMMWORD [wk(10)]  
+        vpaddd   ymm6,ymm6, YMMWORD [wk(11)]  
+
+        vmovdqa  YMMWORD [wk(10)], ymm2  
+        vmovdqa  YMMWORD [wk(11)], ymm0  
+
+        ; -- Final output stage
+
+        vmovdqa  ymm5, YMMWORD [wk(0)]   
+        vmovdqa  ymm7, YMMWORD [wk(1)]   
+
+        vpsubd   ymm2,ymm5,ymm3               
+        vpsubd   ymm0,ymm7,ymm4               
+        vpaddd   ymm5,ymm5,ymm3               
+        vpaddd   ymm7,ymm7,ymm4               
+
+        vmovdqa  ymm3,[rel PD_DESCALE_P1]        
+
+        vpaddd   ymm5,ymm5,ymm3
+        vpaddd   ymm7,ymm7,ymm3
+        vpsrad   ymm5,ymm5,DESCALE_P1
+        vpsrad   ymm7,ymm7,DESCALE_P1
+        vpaddd   ymm2,ymm2,ymm3
+        vpaddd   ymm0,ymm0,ymm3
+        vpsrad   ymm2,ymm2,DESCALE_P1
+        vpsrad   ymm0,ymm0,DESCALE_P1
+
+        vpackssdw  ymm5,ymm5,ymm7             
+        vpackssdw  ymm2,ymm2,ymm0             
+
+        vmovdqa  ymm4, YMMWORD [wk(4)]   
+        vmovdqa  ymm3, YMMWORD [wk(5)]   
+
+        vpsubd   ymm7,ymm4,ymm1               
+        vpsubd   ymm0,ymm3,ymm6               
+        vpaddd   ymm4,ymm4,ymm1               
+        vpaddd   ymm3,ymm3,ymm6               
+
+        vmovdqa  ymm1,[rel PD_DESCALE_P1]        
+
+        vpaddd   ymm4,ymm4,ymm1
+        vpaddd   ymm3,ymm3,ymm1
+        vpsrad   ymm4,ymm4,DESCALE_P1
+        vpsrad   ymm3,ymm3,DESCALE_P1
+        vpaddd   ymm7,ymm7,ymm1
+        vpaddd   ymm0,ymm0,ymm1
+        vpsrad   ymm7,ymm7,DESCALE_P1
+        vpsrad   ymm0,ymm0,DESCALE_P1
+
+        vpackssdw  ymm4,ymm4,ymm3             
+        vpackssdw  ymm7,ymm7,ymm0             
+
+        vpunpckhwd ymm6,ymm5,ymm4             
+        vpunpcklwd ymm5,ymm5,ymm4             
+        vpunpckhwd ymm1,ymm7,ymm2             
+        vpunpcklwd ymm7,ymm7,ymm2             
+
+        vmovdqa  ymm3, YMMWORD [wk(6)]   
+        vmovdqa  ymm0, YMMWORD [wk(7)]   
+        vmovdqa  ymm4, YMMWORD [wk(10)]  
+        vmovdqa  ymm2, YMMWORD [wk(11)]  
+
+        vmovdqa  YMMWORD [wk(0)], ymm5   
+        vmovdqa  YMMWORD [wk(1)], ymm6   
+        vmovdqa  YMMWORD [wk(4)], ymm7   
+        vmovdqa  YMMWORD [wk(5)], ymm1   
+
+        vpsubd   ymm5,ymm3,ymm4               
+        vpsubd   ymm6,ymm0,ymm2               
+        vpaddd   ymm3,ymm3,ymm4               
+        vpaddd   ymm0,ymm0,ymm2               
+
+        vmovdqa  ymm7,[rel PD_DESCALE_P1]        
+
+        vpaddd   ymm3,ymm3,ymm7
+        vpaddd   ymm0,ymm0,ymm7
+        vpsrad   ymm3,ymm3,DESCALE_P1
+        vpsrad   ymm0,ymm0,DESCALE_P1
+        vpaddd   ymm5,ymm5,ymm7
+        vpaddd   ymm6,ymm6,ymm7
+        vpsrad   ymm5,ymm5,DESCALE_P1
+        vpsrad   ymm6,ymm6,DESCALE_P1
+
+        vpackssdw  ymm3,ymm3,ymm0             
+        vpackssdw  ymm5,ymm5,ymm6             
+
+        vmovdqa  ymm1, YMMWORD [wk(2)]   
+        vmovdqa  ymm4, YMMWORD [wk(3)]   
+        vmovdqa  ymm2, YMMWORD [wk(8)]   
+        vmovdqa  ymm7, YMMWORD [wk(9)]   
+
+        vpsubd   ymm0,ymm1,ymm2               
+        vpsubd   ymm6,ymm4,ymm7               
+        vpaddd   ymm1,ymm1,ymm2               
+        vpaddd   ymm4,ymm4,ymm7               
+
+        vmovdqa  ymm2,[rel PD_DESCALE_P1]        
+
+        vpaddd   ymm1,ymm1,ymm2
+        vpaddd   ymm4,ymm4,ymm2
+        vpsrad   ymm1,ymm1,DESCALE_P1
+        vpsrad   ymm4,ymm4,DESCALE_P1
+        vpaddd   ymm0,ymm0,ymm2
+        vpaddd   ymm6,ymm6,ymm2
+        vpsrad   ymm0,ymm0,DESCALE_P1
+        vpsrad   ymm6,ymm6,DESCALE_P1
+
+        vpackssdw  ymm1,ymm1,ymm4             
+        vpackssdw  ymm0,ymm0,ymm6             
+
+        vmovdqa  ymm7, YMMWORD [wk(0)]   
+        vmovdqa  ymm2, YMMWORD [wk(1)]   
+
+        vpunpckhwd ymm4,ymm3,ymm1             
+        vpunpcklwd ymm3,ymm3,ymm1             
+        vpunpckhwd ymm6,ymm0,ymm5             
+        vpunpcklwd ymm0,ymm0,ymm5             
+
+        vpunpckhdq ymm1,ymm7,ymm3             
+        vpunpckldq ymm7,ymm7,ymm3             
+        vpunpckhdq ymm5,ymm2,ymm4             
+        vpunpckldq ymm2,ymm2,ymm4             
+
+        vmovdqa  ymm3, YMMWORD [wk(4)]   
+        vmovdqa  ymm4, YMMWORD [wk(5)]   
+
+        vmovdqa  YMMWORD [wk(6)], ymm2   
+        vmovdqa  YMMWORD [wk(7)], ymm5   
+
+        vpunpckhdq ymm2,ymm0,ymm3             
+        vpunpckldq ymm0,ymm0,ymm3             
+        vpunpckhdq ymm5,ymm6,ymm4             
+        vpunpckldq ymm6,ymm6,ymm4             
+
+        vpunpckhqdq ymm3,ymm7,ymm0            
+        vpunpcklqdq ymm7,ymm7,ymm0            
+        vpunpckhqdq ymm4,ymm1,ymm2            
+        vpunpcklqdq ymm1,ymm1,ymm2            
+
+        vmovdqa  ymm0, YMMWORD [wk(6)]   
+        vmovdqa  ymm2, YMMWORD [wk(7)]   
+
+        vmovdqa  YMMWORD [wk(8)], ymm3   
+        vmovdqa  YMMWORD [wk(9)], ymm4   
+
+        vpunpckhqdq ymm3,ymm0,ymm6            
+        vpunpcklqdq ymm0,ymm0,ymm6            
+        vpunpckhqdq ymm4,ymm2,ymm5            
+        vpunpcklqdq ymm2,ymm2,ymm5            
+
+        vmovdqa  YMMWORD [wk(10)], ymm3  
+        vmovdqa  YMMWORD [wk(11)], ymm4  
+
+.column_end:
+
+        ; -- Prefetch the next coefficient block
+
+        prefetchnta [rsi + DCTSIZE2*SIZEOF_JCOEF + 0*32]
+        prefetchnta [rsi + DCTSIZE2*SIZEOF_JCOEF + 1*32]
+        prefetchnta [rsi + DCTSIZE2*SIZEOF_JCOEF + 2*32]
+        prefetchnta [rsi + DCTSIZE2*SIZEOF_JCOEF + 3*32]
+
+        ; ---- Pass 2: process rows from work array, store into output array.
+
+        mov     rax, [original_rbp]
+        mov     rdi, r12        ; (JSAMPROW *)
+        mov     rax, r13
+
+        ; -- Even part
+
+        ; ymm7=col0, ymm1=col2, ymm0=col4, xmm2=col6
+
+        ; (Original)
+        ; z1 = (z2 + z3) * 0.541196100;
+        ; tmp2 = z1 + z3 * -1.847759065;
+        ; tmp3 = z1 + z2 * 0.765366865;
+        ;
+        ; (This implementation)
+        ; tmp2 = z2 * 0.541196100 + z3 * (0.541196100 - 1.847759065);
+        ; tmp3 = z2 * (0.541196100 + 0.765366865) + z3 * 0.541196100;
+
+        vpunpckhwd ymm5,ymm1,ymm2
+        vpunpcklwd ymm6,ymm1,ymm2             
+        vpmaddwd   ymm1,ymm6,[rel PW_F054_MF130]      
+        vpmaddwd   ymm2,ymm5,[rel PW_F054_MF130]      
+        vpmaddwd   ymm6,ymm6,[rel PW_F130_F054]       
+        vpmaddwd   ymm5,ymm5,[rel PW_F130_F054]       
+
+        vpsubw     ymm3,ymm7,ymm0             
+        vpaddw     ymm7,ymm7,ymm0             
+
+        vpxor      ymm0,ymm0,ymm0
+        vpunpcklwd ymm4,ymm0,ymm7             
+        vpunpckhwd ymm0,ymm0,ymm7             
+        vpsrad     ymm4,ymm4,(16-CONST_BITS)  
+        vpsrad     ymm0,ymm0,(16-CONST_BITS)  
+
+        vpsubd   ymm7,ymm4,ymm6               
+        vpaddd   ymm4,ymm4,ymm6               
+        vpsubd   ymm6,ymm0,ymm5               
+        vpaddd   ymm0,ymm0,ymm5               
+
+        vmovdqa  YMMWORD [wk(0)], ymm4   
+        vmovdqa  YMMWORD [wk(1)], ymm0   
+        vmovdqa  YMMWORD [wk(2)], ymm7   
+        vmovdqa  YMMWORD [wk(3)], ymm6   
+
+        vpxor      ymm4,ymm4,ymm4
+        vpunpcklwd ymm5,ymm4,ymm3             
+        vpunpckhwd ymm4,ymm4,ymm3             
+        vpsrad     ymm5,ymm5,(16-CONST_BITS)  
+        vpsrad     ymm4,ymm4,(16-CONST_BITS)  
+
+        vpsubd   ymm0,ymm5,ymm1               
+        vpaddd   ymm5,ymm5,ymm1               
+        vpsubd   ymm7,ymm4,ymm2               
+        vpaddd   ymm4,ymm4,ymm2               
+
+        vmovdqa  YMMWORD [wk(4)], ymm5   
+        vmovdqa  YMMWORD [wk(5)], ymm4   
+        vmovdqa  YMMWORD [wk(6)], ymm0   
+        vmovdqa  YMMWORD [wk(7)], ymm7   
+
+        ; -- Odd part
+
+        vmovdqa  ymm6, YMMWORD [wk(9)]   
+        vmovdqa  ymm3, YMMWORD [wk(8)]   
+        vmovdqa  ymm1, YMMWORD [wk(11)]  
+        vmovdqa  ymm2, YMMWORD [wk(10)]  
+
+        vpaddw   ymm5,ymm6,ymm1               
+        vpaddw   ymm4,ymm3,ymm2               
+
+        ; (Original)
+        ; z5 = (z3 + z4) * 1.175875602;
+        ; z3 = z3 * -1.961570560;  z4 = z4 * -0.390180644;
+        ; z3 += z5;  z4 += z5;
+        ;
+        ; (This implementation)
+        ; z3 = z3 * (1.175875602 - 1.961570560) + z4 * 1.175875602;
+        ; z4 = z3 * 1.175875602 + z4 * (1.175875602 - 0.390180644);
+
+        vpunpckhwd ymm7,ymm5,ymm4
+        vpunpcklwd ymm0,ymm5,ymm4
+        vpmaddwd   ymm5,ymm0,[rel PW_F117_F078]       
+        vpmaddwd   ymm4,ymm7,[rel PW_F117_F078]       
+        vpmaddwd   ymm0,ymm0,[rel PW_MF078_F117]      
+        vpmaddwd   ymm7,ymm7,[rel PW_MF078_F117]      
+
+        vmovdqa  YMMWORD [wk(10)], ymm0  
+        vmovdqa  YMMWORD [wk(11)], ymm7  
+
+        ; (Original)
+        ; z1 = tmp0 + tmp3;  z2 = tmp1 + tmp2;
+        ; tmp0 = tmp0 * 0.298631336;  tmp1 = tmp1 * 2.053119869;
+        ; tmp2 = tmp2 * 3.072711026;  tmp3 = tmp3 * 1.501321110;
+        ; z1 = z1 * -0.899976223;  z2 = z2 * -2.562915447;
+        ; tmp0 += z1 + z3;  tmp1 += z2 + z4;
+        ; tmp2 += z2 + z3;  tmp3 += z1 + z4;
+        ;
+        ; (This implementation)
+        ; tmp0 = tmp0 * (0.298631336 - 0.899976223) + tmp3 * -0.899976223;
+        ; tmp1 = tmp1 * (2.053119869 - 2.562915447) + tmp2 * -2.562915447;
+        ; tmp2 = tmp1 * -2.562915447 + tmp2 * (3.072711026 - 2.562915447);
+        ; tmp3 = tmp0 * -0.899976223 + tmp3 * (1.501321110 - 0.899976223);
+        ; tmp0 += z3;  tmp1 += z4;
+        ; tmp2 += z3;  tmp3 += z4;
+
+        vpunpcklwd ymm0,ymm1,ymm3
+        vpunpckhwd ymm7,ymm1,ymm3
+        vpmaddwd   ymm1,ymm0,[rel PW_MF089_F060]      
+        vpmaddwd   ymm3,ymm7,[rel PW_MF089_F060]      
+        vpmaddwd   ymm0,ymm0,[rel PW_MF060_MF089]     
+        vpmaddwd   ymm7,ymm7,[rel PW_MF060_MF089]     
+
+        vpaddd   ymm0,ymm0, YMMWORD [wk(10)]  
+        vpaddd   ymm7,ymm7, YMMWORD [wk(11)]  
+        vpaddd   ymm1,ymm1,ymm5               
+        vpaddd   ymm3,ymm3,ymm4               
+
+        vmovdqa  YMMWORD [wk(8)], ymm0   
+        vmovdqa  YMMWORD [wk(9)], ymm7   
+
+        vpunpcklwd ymm0,ymm2,ymm6
+        vpunpckhwd ymm7,ymm2,ymm6
+        vpmaddwd   ymm2,ymm0,[rel PW_MF256_F050]      
+        vpmaddwd   ymm6,ymm7,[rel PW_MF256_F050]      
+        vpmaddwd   ymm0,ymm0,[rel PW_MF050_MF256]     
+        vpmaddwd   ymm7,ymm7,[rel PW_MF050_MF256]     
+        
+        vpaddd   ymm0,ymm0,ymm5               
+        vpaddd   ymm7,ymm7,ymm4               
+        vpaddd   ymm2,ymm2, YMMWORD [wk(10)]  
+        vpaddd   ymm6,ymm6, YMMWORD [wk(11)]  
+
+        vmovdqa  YMMWORD [wk(10)], ymm0  
+        vmovdqa  YMMWORD [wk(11)], ymm7  
+
+        ; -- Final output stage
+
+        vmovdqa  ymm5, YMMWORD [wk(0)]   
+        vmovdqa  ymm4, YMMWORD [wk(1)]   
+
+        vpsubd   ymm0,ymm5,ymm1               
+        vpsubd   ymm7,ymm4,ymm3               
+        vpaddd   ymm5,ymm5,ymm1               
+        vpaddd   ymm4,ymm4,ymm3               
+
+        vmovdqa  ymm1,[rel PD_DESCALE_P2]        
+
+        vpaddd   ymm5,ymm5,ymm1
+        vpaddd   ymm4,ymm4,ymm1
+        vpsrad   ymm5,ymm5,DESCALE_P2
+        vpsrad   ymm4,ymm4,DESCALE_P2
+        vpaddd   ymm0,ymm0,ymm1
+        vpaddd   ymm7,ymm7,ymm1
+        vpsrad   ymm0,ymm0,DESCALE_P2
+        vpsrad   ymm7,ymm7,DESCALE_P2
+
+        vpackssdw  ymm5,ymm5,ymm4             
+        vpackssdw  ymm0,ymm0,ymm7             
+        vmovdqa  ymm3, YMMWORD [wk(4)]   
+        vmovdqa  ymm1, YMMWORD [wk(5)]   
+
+        vpsubd   ymm4,ymm3,ymm2               
+        vpsubd   ymm7,ymm1,ymm6               
+        vpaddd   ymm3,ymm3,ymm2               
+        vpaddd   ymm1,ymm1,ymm6               
+        
+        vmovdqa  ymm2,[rel PD_DESCALE_P2]        
+
+        vpaddd   ymm3,ymm3,ymm2
+        vpaddd   ymm1,ymm1,ymm2
+        vpsrad   ymm3,ymm3,DESCALE_P2
+        vpsrad   ymm1,ymm1,DESCALE_P2
+        vpaddd   ymm4,ymm4,ymm2
+        vpaddd   ymm7,ymm7,ymm2
+        vpsrad   ymm4,ymm4,DESCALE_P2
+        vpsrad   ymm7,ymm7,DESCALE_P2
+
+        vpackssdw  ymm3,ymm3,ymm1             
+        vpackssdw  ymm4,ymm4,ymm7             
+
+        vpacksswb  ymm5,ymm5,ymm4             
+        vpacksswb  ymm3,ymm3,ymm0             
+
+        vmovdqa  ymm6, YMMWORD [wk(6)]   
+        vmovdqa  ymm2, YMMWORD [wk(7)]   
+        vmovdqa  ymm1, YMMWORD [wk(10)]  
+        vmovdqa  ymm7, YMMWORD [wk(11)]  
+
+        vmovdqa  YMMWORD [wk(0)], ymm5   
+        vmovdqa  YMMWORD [wk(1)], ymm3   
+
+        vpsubd   ymm4,ymm6,ymm1               
+        vpsubd   ymm0,ymm2,ymm7               
+        vpaddd   ymm6,ymm6,ymm1               
+        vpaddd   ymm2,ymm2,ymm7               
+        
+        vmovdqa  ymm5,[rel PD_DESCALE_P2]        
+
+        vpaddd   ymm6,ymm6,ymm5
+        vpaddd   ymm2,ymm2,ymm5
+        vpsrad   ymm6,ymm6,DESCALE_P2
+        vpsrad   ymm2,ymm2,DESCALE_P2
+        vpaddd   ymm4,ymm4,ymm5
+        vpaddd   ymm0,ymm0,ymm5
+        vpsrad   ymm4,ymm4,DESCALE_P2
+        vpsrad   ymm0,ymm0,DESCALE_P2
+
+        vpackssdw  ymm6,ymm6,ymm2             
+        vpackssdw  ymm4,ymm4,ymm0             
+
+        vmovdqa  ymm3, YMMWORD [wk(2)]   
+        vmovdqa  ymm1, YMMWORD [wk(3)]   
+        vmovdqa  ymm7, YMMWORD [wk(8)]   
+        vmovdqa  ymm5, YMMWORD [wk(9)]   
+
+        vpsubd   ymm2,ymm3,ymm7               
+        vpsubd   ymm0,ymm1,ymm5               
+        vpaddd   ymm3,ymm3,ymm7               
+        vpaddd   ymm1,ymm1,ymm5               
+        
+        vmovdqa  ymm7,[rel PD_DESCALE_P2]        
+
+        vpaddd   ymm3,ymm3,ymm7
+        vpaddd   ymm1,ymm1,ymm7
+        vpsrad   ymm3,ymm3,DESCALE_P2
+        vpsrad   ymm1,ymm1,DESCALE_P2
+        vpaddd   ymm2,ymm2,ymm7
+        vpaddd   ymm0,ymm0,ymm7
+        vpsrad   ymm2,ymm2,DESCALE_P2
+        vpsrad   ymm0,ymm0,DESCALE_P2
+
+        vmovdqa    ymm5,[rel PB_CENTERJSAMP]     
+
+        vpackssdw  ymm3,ymm3,ymm1             
+        vpackssdw  ymm2,ymm2,ymm0             
+
+        vmovdqa    ymm7, YMMWORD [wk(0)] 
+        vmovdqa    ymm1, YMMWORD [wk(1)] 
+
+        vpacksswb  ymm6,ymm6,ymm2             
+        vpacksswb  ymm3,ymm3,ymm4             
+
+        vpaddb     ymm7,ymm7,ymm5
+        vpaddb     ymm1,ymm1,ymm5
+        vpaddb     ymm6,ymm6,ymm5
+        vpaddb     ymm3,ymm3,ymm5
+
+        vpunpckhbw ymm0,ymm7,ymm1     
+        vpunpcklbw ymm7,ymm7,ymm1     
+        vpunpckhbw ymm2,ymm6,ymm3     
+        vpunpcklbw ymm6,ymm6,ymm3     
+
+        vpunpckhwd ymm4,ymm7,ymm6     
+        vpunpcklwd ymm7,ymm7,ymm6     
+        vpunpckhwd ymm5,ymm2,ymm0     
+        vpunpcklwd ymm2,ymm2,ymm0     
+
+        vpunpckhdq ymm1,ymm7,ymm2     
+        vpunpckldq ymm7,ymm7,ymm2     
+        vpunpckhdq ymm3,ymm4,ymm5     
+        vpunpckldq ymm4,ymm4,ymm5     
+
+        vpermq  ymm7,ymm7,0xd8      
+        vperm2i128 ymm2,ymm7,ymm7,1 
+        vpermq  ymm1,ymm1,0xd8      
+        vperm2i128 ymm0,ymm1,ymm1,1 
+        vpermq  ymm4,ymm4,0xd8      
+        vperm2i128 ymm6,ymm4,ymm4,1 
+        vpermq  ymm3,ymm3,0xd8      
+        vperm2i128 ymm5,ymm3,ymm3,1 
+
+        mov     rdx, JSAMPROW [rdi+0*SIZEOF_JSAMPROW]
+        mov     rsi, JSAMPROW [rdi+2*SIZEOF_JSAMPROW]
+        vmovdqu    XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm7
+        vmovdqu    XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE], xmm1
+        mov     rdx, JSAMPROW [rdi+4*SIZEOF_JSAMPROW]
+        mov     rsi, JSAMPROW [rdi+6*SIZEOF_JSAMPROW]
+        vmovdqu    XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm4
+        vmovdqu    XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE], xmm3
+
+        mov     rdx, JSAMPROW [rdi+1*SIZEOF_JSAMPROW]
+        mov     rsi, JSAMPROW [rdi+3*SIZEOF_JSAMPROW]
+        vmovdqu    XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm2
+        vmovdqu    XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE], xmm0
+        mov     rdx, JSAMPROW [rdi+5*SIZEOF_JSAMPROW]
+        mov     rsi, JSAMPROW [rdi+7*SIZEOF_JSAMPROW]
+        vmovdqu    XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm6
+        vmovdqu    XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE], xmm5
+
+        uncollect_args
+        mov     rsp,rbp         ; rsp <- aligned rbp
+        pop     rsp             ; rsp <- original rbp
+        pop     rbp
+        ret
+
+; For some reason, the OS X linker does not honor the request to align the
+; segment unless we do this.
+        align   32

--- a/simd/jquantf-avx2-64.asm
+++ b/simd/jquantf-avx2-64.asm
@@ -1,0 +1,235 @@
+;
+; jquantf.asm - sample data conversion and quantization (64-bit AVX & AVX2) ;
+; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2009 D. R. Commander
+; Copyright 2015 Intel Corporation
+;
+; Based on
+; x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; [TAB8]
+
+%include "jsimdext.inc"
+%include "jdct.inc"
+
+; --------------------------------------------------------------------------
+        SECTION SEG_TEXT
+        BITS    64
+;
+; Load data into workspace, applying unsigned->signed conversion
+;
+; GLOBAL(void)
+; jsimd_convsamp_float_avx2 (JSAMPARRAY sample_data, JDIMENSION start_col,
+;                            FAST_FLOAT * workspace);
+;
+
+; r10 = JSAMPARRAY sample_data
+; r11 = JDIMENSION start_col
+; r12 = FAST_FLOAT * workspace
+
+        align   32
+        global  EXTN(jsimd_convsamp_float_avx2)
+
+EXTN(jsimd_convsamp_float_avx2):
+        push    rbp
+        mov     rax,rsp
+        mov     rbp,rsp
+        collect_args
+        push    rbx
+
+
+        vpcmpeqw  ymm15,ymm15,ymm15
+        vpsllw    ymm15,ymm15,7
+        vpacksswb ymm15,ymm15,ymm15              
+
+        mov rsi, r10
+        mov     rax, r11
+        mov rdi, r12
+.convloop:
+        mov     rbx, JSAMPROW [rsi+0*SIZEOF_JSAMPROW]   
+        mov rdx, JSAMPROW [rsi+1*SIZEOF_JSAMPROW]       
+
+        vmovq    xmm0, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]
+        vmovq    xmm1, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]
+
+        vperm2i128 ymm9, ymm0,ymm1,0x20
+        vpsubb ymm0,ymm9,ymm15
+
+        vpunpcklbw ymm1,ymm0,ymm0 
+        vpermq ymm8,ymm1,0xd8
+        vpunpcklwd ymm0,ymm1,ymm8 
+        vpunpckhwd ymm1,ymm9,ymm8 
+        
+        vpsrad ymm8,ymm0,(DWORD_BIT-BYTE_BIT) 
+        vpsrad ymm9,ymm1,(DWORD_BIT-BYTE_BIT)
+        vcvtdq2ps ymm0,ymm8
+        vcvtdq2ps ymm1,ymm9
+
+        mov     rbx, JSAMPROW [rsi+2*SIZEOF_JSAMPROW]   
+        mov rdx, JSAMPROW [rsi+3*SIZEOF_JSAMPROW]       
+
+        vmovq    xmm2, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]
+        vmovq    xmm3, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]
+
+        vperm2i128 ymm11, ymm2,ymm3,0x20
+        vpsubb ymm2,ymm11,ymm15
+
+        vpunpcklbw ymm3,ymm2,ymm2 
+        vpermq ymm10,ymm3,0xd8
+        vpunpcklwd ymm2,ymm3,ymm10 
+        vpunpckhwd ymm3,ymm11,ymm10 
+        
+        vpsrad ymm10,ymm2,(DWORD_BIT-BYTE_BIT) 
+        vpsrad ymm11,ymm3,(DWORD_BIT-BYTE_BIT)
+        vcvtdq2ps ymm2,ymm10
+        vcvtdq2ps ymm3,ymm11
+
+        mov     rbx, JSAMPROW [rsi+4*SIZEOF_JSAMPROW]   
+        mov rdx, JSAMPROW [rsi+5*SIZEOF_JSAMPROW]       
+
+        vmovq    xmm4, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]
+        vmovq    xmm5, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]
+
+        vperm2i128 ymm13, ymm4,ymm5,0x20
+        vpsubb ymm4,ymm13,ymm15
+
+        vpunpcklbw ymm5,ymm4,ymm4
+        vpermq ymm12,ymm5,0xd8
+        vpunpcklwd ymm4,ymm5,ymm12 
+        vpunpckhwd ymm5,ymm13,ymm12 
+        
+        vpsrad ymm12,ymm4,(DWORD_BIT-BYTE_BIT) 
+        vpsrad ymm13,ymm5,(DWORD_BIT-BYTE_BIT)
+        vcvtdq2ps ymm4,ymm12
+        vcvtdq2ps ymm5,ymm13
+
+        mov     rbx, JSAMPROW [rsi+6*SIZEOF_JSAMPROW]   
+        mov rdx, JSAMPROW [rsi+7*SIZEOF_JSAMPROW]       
+
+        vmovq    xmm6, XMM_MMWORD [rbx+rax*SIZEOF_JSAMPLE]
+        vmovq    xmm7, XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE]
+
+        vperm2i128 ymm9, ymm6,ymm7,0x20
+        vpsubb ymm6,ymm9,ymm15
+
+        vpunpcklbw ymm7,ymm6,ymm6 
+        vpermq ymm14,ymm7,0xd8
+        vpunpcklwd ymm6,ymm7,ymm14 
+        vpunpckhwd ymm7,ymm9,ymm14 
+        
+        vpsrad ymm14,ymm6,(DWORD_BIT-BYTE_BIT) 
+        vpsrad ymm9,ymm7,(DWORD_BIT-BYTE_BIT)
+        vcvtdq2ps ymm6,ymm14
+        vcvtdq2ps ymm7,ymm9
+
+
+        vmovaps  YMMWORD [YMMBLOCK(0,0,rdi,SIZEOF_FAST_FLOAT)], ymm0
+        vmovaps  YMMWORD [YMMBLOCK(1,0,rdi,SIZEOF_FAST_FLOAT)], ymm1
+
+        vmovaps  YMMWORD [YMMBLOCK(2,0,rdi,SIZEOF_FAST_FLOAT)], ymm2
+        vmovaps  YMMWORD [YMMBLOCK(3,0,rdi,SIZEOF_FAST_FLOAT)], ymm3
+
+        vmovaps  YMMWORD [YMMBLOCK(4,0,rdi,SIZEOF_FAST_FLOAT)], ymm4
+        vmovaps  YMMWORD [YMMBLOCK(5,0,rdi,SIZEOF_FAST_FLOAT)], ymm5
+
+        vmovaps  YMMWORD [YMMBLOCK(6,0,rdi,SIZEOF_FAST_FLOAT)], ymm6
+        vmovaps  YMMWORD [YMMBLOCK(7,0,rdi,SIZEOF_FAST_FLOAT)], ymm7
+
+        pop     rbx
+        uncollect_args
+        pop     rbp
+        ret
+
+
+; --------------------------------------------------------------------------
+;
+; Quantize/descale the coefficients, and store into coef_block
+;
+; GLOBAL(void)
+; jsimd_quantize_float_avx2 (JCOEFPTR coef_block, FAST_FLOAT * divisors,
+;                         FAST_FLOAT * workspace);
+;
+
+; r10 = JCOEFPTR coef_block
+; r11 = FAST_FLOAT * divisors
+; r12 = FAST_FLOAT * workspace
+
+        align   32
+        global  EXTN(jsimd_quantize_float_avx2)
+
+EXTN(jsimd_quantize_float_avx2):
+        push    rbp
+        mov     rax,rsp
+        mov     rbp,rsp
+        collect_args
+
+        mov rsi, r12
+        mov rdx, r11
+        mov rdi, r10
+.quantloop:
+            vmovaps  ymm0, YMMWORD [YMMBLOCK(0,0,rsi,SIZEOF_FAST_FLOAT)]
+        vmulps   ymm0,ymm0, YMMWORD [YMMBLOCK(0,0,rdx,SIZEOF_FAST_FLOAT)]
+        vmovaps  ymm1, YMMWORD [YMMBLOCK(1,0,rsi,SIZEOF_FAST_FLOAT)]
+        vmulps   ymm1,ymm1, YMMWORD [YMMBLOCK(1,0,rdx,SIZEOF_FAST_FLOAT)]
+
+        vcvtps2dq ymm0,ymm0
+        vcvtps2dq ymm1,ymm1
+
+        vpackssdw ymm1,ymm0,ymm1
+        vpermq ymm0,ymm1,0xD8
+
+        vmovdqa  YMMWORD [YMMBLOCK(0,0,rdi,2*SIZEOF_JCOEF)], ymm0
+        vmovaps  ymm2, YMMWORD [YMMBLOCK(2,0,rsi,SIZEOF_FAST_FLOAT)]
+        vmulps   ymm2,ymm2, YMMWORD [YMMBLOCK(2,0,rdx,SIZEOF_FAST_FLOAT)]
+        vmovaps  ymm3, YMMWORD [YMMBLOCK(3,0,rsi,SIZEOF_FAST_FLOAT)]
+        vmulps   ymm3,ymm3, YMMWORD [YMMBLOCK(3,0,rdx,SIZEOF_FAST_FLOAT)]
+
+        vcvtps2dq ymm2,ymm2
+        vcvtps2dq ymm3,ymm3
+
+        vpackssdw ymm3,ymm2,ymm3
+        vpermq ymm2,ymm3,0xD8
+
+        vmovdqa  YMMWORD [YMMBLOCK(1,0,rdi,2*SIZEOF_JCOEF)], ymm2
+
+
+        vmovaps  ymm4, YMMWORD [YMMBLOCK(4,0,rsi,SIZEOF_FAST_FLOAT)]
+        vmulps   ymm4,ymm4, YMMWORD [YMMBLOCK(4,0,rdx,SIZEOF_FAST_FLOAT)]
+        vmovaps  ymm5, YMMWORD [YMMBLOCK(5,0,rsi,SIZEOF_FAST_FLOAT)]
+        vmulps   ymm5,ymm5, YMMWORD [YMMBLOCK(5,0,rdx,SIZEOF_FAST_FLOAT)]
+
+        vcvtps2dq ymm4,ymm4
+        vcvtps2dq ymm5,ymm5
+
+        vpackssdw ymm5,ymm4,ymm5
+        vpermq ymm4,ymm5,0xD8
+
+        vmovdqa  YMMWORD [YMMBLOCK(2,0,rdi,2*SIZEOF_JCOEF)], ymm4
+        vmovaps  ymm6, YMMWORD [YMMBLOCK(6,0,rsi,SIZEOF_FAST_FLOAT)]
+        vmulps   ymm6,ymm6, YMMWORD [YMMBLOCK(6,0,rdx,SIZEOF_FAST_FLOAT)]
+        vmovaps  ymm7, YMMWORD [YMMBLOCK(7,0,rsi,SIZEOF_FAST_FLOAT)]
+        vmulps   ymm7,ymm7, YMMWORD [YMMBLOCK(7,0,rdx,SIZEOF_FAST_FLOAT)]
+
+        vcvtps2dq ymm6,ymm6
+        vcvtps2dq ymm7,ymm7
+
+        vpackssdw ymm7,ymm6,ymm7
+        vpermq ymm6,ymm7,0xD8
+
+        vmovdqa  YMMWORD [YMMBLOCK(3,0,rdi,2*SIZEOF_JCOEF)], ymm6
+
+        uncollect_args
+        pop     rbp
+        ret
+
+; For some reason, the OS X linker does not honor the request to align the
+; segment unless we do this.
+        align   32

--- a/simd/jsimd.h
+++ b/simd/jsimd.h
@@ -5,6 +5,7 @@
  * Copyright (C) 2011, 2014-2015 D. R. Commander
  * Copyright (C) 2013-2014, MIPS Technologies, Inc., California
  * Copyright (C) 2014 Linaro Limited
+ * Copyright (C) 2015, Intel Corporation
  *
  * Based on the x86 SIMD extension for IJG JPEG library,
  * Copyright (C) 1999-2006, MIYASAKA Masaru.
@@ -22,6 +23,7 @@
 #define JSIMD_ARM_NEON   0x10
 #define JSIMD_MIPS_DSPR2 0x20
 #define JSIMD_ALTIVEC    0x40
+#define JSIMD_AVX2		   0x80
 
 /* SIMD Ext: retrieve SIMD/CPU information */
 EXTERN(unsigned int) jpeg_simd_cpu_support (void);
@@ -69,6 +71,29 @@ EXTERN(void) jsimd_extxbgr_ycc_convert_sse2
         (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
          JDIMENSION output_row, int num_rows);
 EXTERN(void) jsimd_extxrgb_ycc_convert_sse2
+        (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+         JDIMENSION output_row, int num_rows);
+
+extern const int jconst_rgb_ycc_convert_avx2[];
+EXTERN(void) jsimd_rgb_ycc_convert_avx2
+        (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+         JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extrgb_ycc_convert_avx2
+        (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+         JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extrgbx_ycc_convert_avx2
+        (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+         JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extbgr_ycc_convert_avx2
+        (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+         JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extbgrx_ycc_convert_avx2
+        (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+         JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extxbgr_ycc_convert_avx2
+        (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+         JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extxrgb_ycc_convert_avx2
         (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
          JDIMENSION output_row, int num_rows);
 
@@ -161,6 +186,29 @@ EXTERN(void) jsimd_extxrgb_gray_convert_mmx
         (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
          JDIMENSION output_row, int num_rows);
 
+extern const int jconst_rgb_gray_convert_avx2[];
+EXTERN(void) jsimd_rgb_gray_convert_avx2
+        (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+         JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extrgb_gray_convert_avx2
+        (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+         JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extrgbx_gray_convert_avx2
+        (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+         JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extbgr_gray_convert_avx2
+        (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+         JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extbgrx_gray_convert_avx2
+        (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+         JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extxbgr_gray_convert_avx2
+        (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+         JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extxrgb_gray_convert_avx2
+        (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+         JDIMENSION output_row, int num_rows);
+
 extern const int jconst_rgb_gray_convert_sse2[];
 EXTERN(void) jsimd_rgb_gray_convert_sse2
         (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
@@ -250,6 +298,29 @@ EXTERN(void) jsimd_ycc_extxbgr_convert_mmx
 EXTERN(void) jsimd_ycc_extxrgb_convert_mmx
         (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
          JSAMPARRAY output_buf, int num_rows);
+
+extern const int jconst_ycc_rgb_convert_avx2[];
+EXTERN(void) jsimd_ycc_rgb_convert_avx2
+        (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
+		JSAMPARRAY output_buf, int num_rows);
+EXTERN(void) jsimd_ycc_extrgb_convert_avx2
+        (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
+		JSAMPARRAY output_buf, int num_rows);
+EXTERN(void) jsimd_ycc_extrgbx_convert_avx2
+        (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
+		JSAMPARRAY output_buf, int num_rows);
+EXTERN(void) jsimd_ycc_extbgr_convert_avx2
+        (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
+		JSAMPARRAY output_buf, int num_rows);
+EXTERN(void) jsimd_ycc_extbgrx_convert_avx2
+        (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
+		JSAMPARRAY output_buf, int num_rows);
+EXTERN(void) jsimd_ycc_extxbgr_convert_avx2
+        (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
+		JSAMPARRAY output_buf, int num_rows);
+EXTERN(void) jsimd_ycc_extxrgb_convert_avx2
+        (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
+	    JSAMPARRAY output_buf, int num_rows);
 
 extern const int jconst_ycc_rgb_convert_sse2[];
 EXTERN(void) jsimd_ycc_rgb_convert_sse2
@@ -359,6 +430,11 @@ EXTERN(void) jsimd_h2v1_downsample_sse2
          JDIMENSION v_samp_factor, JDIMENSION width_blocks,
          JSAMPARRAY input_data, JSAMPARRAY output_data);
 
+EXTERN(void) jsimd_h2v1_downsample_avx2
+        (JDIMENSION image_width, int max_v_samp_factor,
+         JDIMENSION v_samp_factor, JDIMENSION width_blocks,
+         JSAMPARRAY input_data, JSAMPARRAY output_data);
+
 EXTERN(void) jsimd_h2v1_downsample_mips_dspr2
         (JDIMENSION image_width, int max_v_samp_factor,
          JDIMENSION v_samp_factor, JDIMENSION width_blocks,
@@ -376,6 +452,11 @@ EXTERN(void) jsimd_h2v2_downsample_mmx
          JSAMPARRAY input_data, JSAMPARRAY output_data);
 
 EXTERN(void) jsimd_h2v2_downsample_sse2
+        (JDIMENSION image_width, int max_v_samp_factor,
+         JDIMENSION v_samp_factor, JDIMENSION width_blocks,
+         JSAMPARRAY input_data, JSAMPARRAY output_data);
+
+EXTERN(void) jsimd_h2v2_downsample_avx2
         (JDIMENSION image_width, int max_v_samp_factor,
          JDIMENSION v_samp_factor, JDIMENSION width_blocks,
          JSAMPARRAY input_data, JSAMPARRAY output_data);
@@ -409,7 +490,16 @@ EXTERN(void) jsimd_h2v2_upsample_mmx
 EXTERN(void) jsimd_h2v1_upsample_sse2
         (int max_v_samp_factor, JDIMENSION output_width, JSAMPARRAY input_data,
          JSAMPARRAY * output_data_ptr);
+
+EXTERN(void) jsimd_h2v1_upsample_avx2
+        (int max_v_samp_factor, JDIMENSION output_width, JSAMPARRAY input_data,
+         JSAMPARRAY * output_data_ptr);
+
 EXTERN(void) jsimd_h2v2_upsample_sse2
+        (int max_v_samp_factor, JDIMENSION output_width, JSAMPARRAY input_data,
+         JSAMPARRAY * output_data_ptr);
+
+EXTERN(void) jsimd_h2v2_upsample_avx2
         (int max_v_samp_factor, JDIMENSION output_width, JSAMPARRAY input_data,
          JSAMPARRAY * output_data_ptr);
 
@@ -444,6 +534,15 @@ extern const int jconst_fancy_upsample_sse2[];
 EXTERN(void) jsimd_h2v1_fancy_upsample_sse2
         (int max_v_samp_factor, JDIMENSION downsampled_width,
          JSAMPARRAY input_data, JSAMPARRAY * output_data_ptr);
+extern const int jconst_fancy_upsample_avx2[];
+EXTERN(void) jsimd_h2v1_fancy_upsample_avx2
+        (int max_v_samp_factor, JDIMENSION downsampled_width,
+         JSAMPARRAY input_data, JSAMPARRAY * output_data_ptr);
+
+EXTERN(void) jsimd_h2v2_fancy_upsample_avx2
+        (int max_v_samp_factor, JDIMENSION downsampled_width,
+         JSAMPARRAY input_data, JSAMPARRAY * output_data_ptr);
+
 EXTERN(void) jsimd_h2v2_fancy_upsample_sse2
         (int max_v_samp_factor, JDIMENSION downsampled_width,
          JSAMPARRAY input_data, JSAMPARRAY * output_data_ptr);
@@ -553,6 +652,51 @@ EXTERN(void) jsimd_h2v2_extxbgr_merged_upsample_sse2
         (JDIMENSION output_width, JSAMPIMAGE input_buf,
          JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
 EXTERN(void) jsimd_h2v2_extxrgb_merged_upsample_sse2
+        (JDIMENSION output_width, JSAMPIMAGE input_buf,
+         JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+
+extern const int jconst_merged_upsample_avx2[];
+EXTERN(void) jsimd_h2v1_merged_upsample_avx2
+        (JDIMENSION output_width, JSAMPIMAGE input_buf,
+         JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v1_extrgb_merged_upsample_avx2
+        (JDIMENSION output_width, JSAMPIMAGE input_buf,
+         JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v1_extrgbx_merged_upsample_avx2
+        (JDIMENSION output_width, JSAMPIMAGE input_buf,
+         JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v1_extbgr_merged_upsample_avx2
+        (JDIMENSION output_width, JSAMPIMAGE input_buf,
+         JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v1_extbgrx_merged_upsample_avx2
+        (JDIMENSION output_width, JSAMPIMAGE input_buf,
+         JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v1_extxbgr_merged_upsample_avx2
+        (JDIMENSION output_width, JSAMPIMAGE input_buf,
+         JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v1_extxrgb_merged_upsample_avx2
+        (JDIMENSION output_width, JSAMPIMAGE input_buf,
+         JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+
+EXTERN(void) jsimd_h2v2_merged_upsample_avx2
+        (JDIMENSION output_width, JSAMPIMAGE input_buf,
+         JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v2_extrgb_merged_upsample_avx2
+        (JDIMENSION output_width, JSAMPIMAGE input_buf,
+         JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v2_extrgbx_merged_upsample_avx2
+        (JDIMENSION output_width, JSAMPIMAGE input_buf,
+         JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v2_extbgr_merged_upsample_avx2
+        (JDIMENSION output_width, JSAMPIMAGE input_buf,
+         JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v2_extbgrx_merged_upsample_avx2
+        (JDIMENSION output_width, JSAMPIMAGE input_buf,
+         JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v2_extxbgr_merged_upsample_avx2
+        (JDIMENSION output_width, JSAMPIMAGE input_buf,
+         JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v2_extxrgb_merged_upsample_avx2
         (JDIMENSION output_width, JSAMPIMAGE input_buf,
          JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
 
@@ -670,6 +814,9 @@ EXTERN(void) jsimd_convsamp_float_sse
 EXTERN(void) jsimd_convsamp_float_sse2
         (JSAMPARRAY sample_data, JDIMENSION start_col, FAST_FLOAT * workspace);
 
+EXTERN(void) jsimd_convsamp_float_avx2
+        (JSAMPARRAY sample_data, JDIMENSION start_col, FAST_FLOAT * workspace);
+
 EXTERN(void) jsimd_convsamp_float_mips_dspr2
         (JSAMPARRAY sample_data, JDIMENSION start_col, FAST_FLOAT * workspace);
 
@@ -683,6 +830,9 @@ EXTERN(void) jsimd_fdct_islow_mips_dspr2 (DCTELEM * data);
 
 EXTERN(void) jsimd_fdct_islow_altivec (DCTELEM * data);
 
+EXTERN(void) jsimd_fdct_merged_islow_avx2 (JSAMPARRAY sample, 
+    JDIMENSION start_col, JCOEFPTR coef_block, DCTELEM* divisors);
+
 /* Fast Integer Forward DCT */
 EXTERN(void) jsimd_fdct_ifast_mmx (DCTELEM * data);
 
@@ -695,11 +845,19 @@ EXTERN(void) jsimd_fdct_ifast_mips_dspr2 (DCTELEM * data);
 
 EXTERN(void) jsimd_fdct_ifast_altivec (DCTELEM * data);
 
+EXTERN(void) jsimd_fdct_merged_ifast_avx2 (JSAMPARRAY sample, 
+    JDIMENSION start_col, JCOEFPTR coef_block, DCTELEM* divisors);
+
 /* Floating Point Forward DCT */
 EXTERN(void) jsimd_fdct_float_3dnow (FAST_FLOAT * data);
 
 extern const int jconst_fdct_float_sse[];
 EXTERN(void) jsimd_fdct_float_sse (FAST_FLOAT * data);
+
+EXTERN(void) jsimd_fdct_merged_float_avx2 (JSAMPARRAY sample_data, 
+   JDIMENSION start_col,JCOEFPTR coef_block, FAST_FLOAT * divisors);
+
+EXTERN(void) jsimd_fdct_float_avx2 (FAST_FLOAT * data);
 
 /* Quantization */
 EXTERN(void) jsimd_quantize_mmx
@@ -725,6 +883,12 @@ EXTERN(void) jsimd_quantize_float_sse
         (JCOEFPTR coef_block, FAST_FLOAT * divisors, FAST_FLOAT * workspace);
 
 EXTERN(void) jsimd_quantize_float_sse2
+        (JCOEFPTR coef_block, FAST_FLOAT * divisors, FAST_FLOAT * workspace);
+
+EXTERN(void) jsimd_quantize_float_avx2
+        (JCOEFPTR coef_block, FAST_FLOAT * divisors, FAST_FLOAT * workspace);
+
+EXTERN(void) jsimd_quantize_float_avx2
         (JCOEFPTR coef_block, FAST_FLOAT * divisors, FAST_FLOAT * workspace);
 
 EXTERN(void) jsimd_quantize_float_mips_dspr2
@@ -777,6 +941,10 @@ EXTERN(void) jsimd_idct_islow_sse2
         (void * dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
          JDIMENSION output_col);
 
+EXTERN(void) jsimd_idct_islow_avx2
+        (void * dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
+         JDIMENSION output_col);
+
 EXTERN(void) jsimd_idct_islow_neon
         (void * dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
          JDIMENSION output_col);
@@ -796,6 +964,10 @@ EXTERN(void) jsimd_idct_ifast_mmx
 
 extern const int jconst_idct_ifast_sse2[];
 EXTERN(void) jsimd_idct_ifast_sse2
+        (void * dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
+         JDIMENSION output_col);
+
+EXTERN(void) jsimd_idct_ifast_avx2
         (void * dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
          JDIMENSION output_col);
 
@@ -826,5 +998,9 @@ EXTERN(void) jsimd_idct_float_sse
 
 extern const int jconst_idct_float_sse2[];
 EXTERN(void) jsimd_idct_float_sse2
+        (void * dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
+         JDIMENSION output_col);
+
+EXTERN(void) jsimd_idct_float_avx2
         (void * dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
          JDIMENSION output_col);

--- a/simd/jsimd_x86_64.c
+++ b/simd/jsimd_x86_64.c
@@ -67,7 +67,6 @@ init_simd (void)
 	if ((env != NULL) && (strcmp(env, "1") == 0))
 		simd_support = 0;
 
-	printf("simd_support = %x\n",simd_support);
   if(simd_support & JSIMD_AVX2)
 		putenv("JSIMD_LENGTH_256=1");
   else

--- a/simd/jsimd_x86_64.c
+++ b/simd/jsimd_x86_64.c
@@ -3,6 +3,7 @@
  *
  * Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
  * Copyright 2009-2011, 2014 D. R. Commander
+ * Copyright 2015, Intel Corporation
  *
  * Based on the x86 SIMD extension for IJG JPEG library,
  * Copyright (C) 1999-2006, MIYASAKA Masaru.
@@ -29,6 +30,50 @@
 
 #define IS_ALIGNED_SSE(ptr) (IS_ALIGNED(ptr, 4)) /* 16 byte alignment */
 
+static unsigned int simd_support = ~0;
+
+/*
+ * Check what SIMD accelerations are supported.
+ *
+ * FIXME: This code is racy under a multi-threaded environment.
+ */
+LOCAL(void)
+init_simd (void)
+{
+	char *env = NULL;
+
+	if (simd_support != ~0U)
+		return;
+
+	simd_support = jpeg_simd_cpu_support();
+
+	/* Force different settings through environment variables */
+	env = getenv("JSIMD_FORCEMMX");
+	if ((env != NULL) && (strcmp(env, "1") == 0))
+		simd_support &= JSIMD_MMX;
+	env = getenv("JSIMD_FORCE3DNOW");
+	if ((env != NULL) && (strcmp(env, "1") == 0))
+		simd_support &= JSIMD_3DNOW|JSIMD_MMX;
+	env = getenv("JSIMD_FORCESSE");
+	if ((env != NULL) && (strcmp(env, "1") == 0))
+		simd_support &= JSIMD_SSE|JSIMD_MMX;
+	env = getenv("JSIMD_FORCESSE2");
+	if ((env != NULL) && (strcmp(env, "1") == 0))
+		simd_support &= JSIMD_SSE2;
+	env = getenv("JSIMD_FORCEAVX2");
+	if ((env != NULL) && (strcmp(env, "1") == 0))
+		simd_support &= JSIMD_AVX2;
+	env = getenv("JSIMD_FORCENONE");
+	if ((env != NULL) && (strcmp(env, "1") == 0))
+		simd_support = 0;
+
+	printf("simd_support = %x\n",simd_support);
+  if(simd_support & JSIMD_AVX2)
+		putenv("JSIMD_LENGTH_256=1");
+  else
+		putenv("JSIMD_LENGTH_256=0");
+}
+
 GLOBAL(int)
 jsimd_can_rgb_ycc (void)
 {
@@ -40,10 +85,14 @@ jsimd_can_rgb_ycc (void)
   if ((RGB_PIXELSIZE != 3) && (RGB_PIXELSIZE != 4))
     return 0;
 
-  if (!IS_ALIGNED_SSE(jconst_rgb_ycc_convert_sse2))
-    return 0;
+  init_simd();
+  if (simd_support & JSIMD_SSE2) 
+	  return 1;
 
-  return 1;
+  if (simd_support & JSIMD_AVX2) 
+	  return 1;
+
+  return 0;
 }
 
 GLOBAL(int)
@@ -57,10 +106,13 @@ jsimd_can_rgb_gray (void)
   if ((RGB_PIXELSIZE != 3) && (RGB_PIXELSIZE != 4))
     return 0;
 
-  if (!IS_ALIGNED_SSE(jconst_rgb_gray_convert_sse2))
-    return 0;
+  init_simd();
+  if (simd_support & JSIMD_SSE2) 
+    return 1;
+  if ((simd_support & JSIMD_AVX2))
+    return 1;
 
-  return 1;
+  return 0;
 }
 
 GLOBAL(int)
@@ -74,10 +126,13 @@ jsimd_can_ycc_rgb (void)
   if ((RGB_PIXELSIZE != 3) && (RGB_PIXELSIZE != 4))
     return 0;
 
-  if (!IS_ALIGNED_SSE(jconst_ycc_rgb_convert_sse2))
-    return 0;
+  init_simd();
+  if (simd_support & JSIMD_SSE2) 
+    return 1;
+  if ((simd_support & JSIMD_AVX2))
+    return 1;
 
-  return 1;
+  return 0;
 }
 
 GLOBAL(int)
@@ -92,36 +147,47 @@ jsimd_rgb_ycc_convert (j_compress_ptr cinfo,
                        JDIMENSION output_row, int num_rows)
 {
   void (*sse2fct)(JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
+  void (*avx2fct)(JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
 
   switch(cinfo->in_color_space) {
     case JCS_EXT_RGB:
       sse2fct=jsimd_extrgb_ycc_convert_sse2;
+      avx2fct=jsimd_extrgb_ycc_convert_avx2;
       break;
     case JCS_EXT_RGBX:
     case JCS_EXT_RGBA:
       sse2fct=jsimd_extrgbx_ycc_convert_sse2;
+      avx2fct=jsimd_extrgbx_ycc_convert_avx2;
       break;
     case JCS_EXT_BGR:
       sse2fct=jsimd_extbgr_ycc_convert_sse2;
+      avx2fct=jsimd_extbgr_ycc_convert_avx2;
       break;
     case JCS_EXT_BGRX:
     case JCS_EXT_BGRA:
       sse2fct=jsimd_extbgrx_ycc_convert_sse2;
+      avx2fct=jsimd_extbgrx_ycc_convert_avx2;
       break;
     case JCS_EXT_XBGR:
     case JCS_EXT_ABGR:
       sse2fct=jsimd_extxbgr_ycc_convert_sse2;
+      avx2fct=jsimd_extxbgr_ycc_convert_avx2;
       break;
     case JCS_EXT_XRGB:
     case JCS_EXT_ARGB:
       sse2fct=jsimd_extxrgb_ycc_convert_sse2;
+      avx2fct=jsimd_extxrgb_ycc_convert_avx2;
       break;
     default:
       sse2fct=jsimd_rgb_ycc_convert_sse2;
+      avx2fct=jsimd_rgb_ycc_convert_avx2;
       break;
   }
 
-  sse2fct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
+  if (simd_support & JSIMD_AVX2)
+    avx2fct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
+  else if (simd_support & JSIMD_SSE2)
+    sse2fct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
 }
 
 GLOBAL(void)
@@ -130,36 +196,47 @@ jsimd_rgb_gray_convert (j_compress_ptr cinfo,
                         JDIMENSION output_row, int num_rows)
 {
   void (*sse2fct)(JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
+  void (*avx2fct)(JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
 
   switch(cinfo->in_color_space) {
     case JCS_EXT_RGB:
       sse2fct=jsimd_extrgb_gray_convert_sse2;
+      avx2fct=jsimd_extrgb_gray_convert_avx2;
       break;
     case JCS_EXT_RGBX:
     case JCS_EXT_RGBA:
       sse2fct=jsimd_extrgbx_gray_convert_sse2;
+      avx2fct=jsimd_extrgbx_gray_convert_avx2;
       break;
     case JCS_EXT_BGR:
       sse2fct=jsimd_extbgr_gray_convert_sse2;
+      avx2fct=jsimd_extbgr_gray_convert_avx2;
       break;
     case JCS_EXT_BGRX:
     case JCS_EXT_BGRA:
       sse2fct=jsimd_extbgrx_gray_convert_sse2;
+      avx2fct=jsimd_extbgrx_gray_convert_avx2;
       break;
     case JCS_EXT_XBGR:
     case JCS_EXT_ABGR:
       sse2fct=jsimd_extxbgr_gray_convert_sse2;
+      avx2fct=jsimd_extxbgr_gray_convert_avx2;
       break;
     case JCS_EXT_XRGB:
     case JCS_EXT_ARGB:
       sse2fct=jsimd_extxrgb_gray_convert_sse2;
+      avx2fct=jsimd_extxrgb_gray_convert_avx2;
       break;
     default:
       sse2fct=jsimd_rgb_gray_convert_sse2;
+      avx2fct=jsimd_rgb_gray_convert_avx2;
       break;
   }
 
-  sse2fct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
+  if (simd_support & JSIMD_AVX2)
+  	avx2fct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
+  else if (simd_support & JSIMD_SSE2)
+    sse2fct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
 }
 
 GLOBAL(void)
@@ -168,36 +245,47 @@ jsimd_ycc_rgb_convert (j_decompress_ptr cinfo,
                        JSAMPARRAY output_buf, int num_rows)
 {
   void (*sse2fct)(JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY, int);
+  void (*avx2fct)(JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY, int);
 
   switch(cinfo->out_color_space) {
     case JCS_EXT_RGB:
       sse2fct=jsimd_ycc_extrgb_convert_sse2;
+      avx2fct=jsimd_ycc_extrgb_convert_avx2;
       break;
     case JCS_EXT_RGBX:
     case JCS_EXT_RGBA:
       sse2fct=jsimd_ycc_extrgbx_convert_sse2;
+      avx2fct=jsimd_ycc_extrgbx_convert_avx2;
       break;
     case JCS_EXT_BGR:
       sse2fct=jsimd_ycc_extbgr_convert_sse2;
+      avx2fct=jsimd_ycc_extbgr_convert_avx2;
       break;
     case JCS_EXT_BGRX:
     case JCS_EXT_BGRA:
       sse2fct=jsimd_ycc_extbgrx_convert_sse2;
+      avx2fct=jsimd_ycc_extbgrx_convert_avx2;
       break;
     case JCS_EXT_XBGR:
     case JCS_EXT_ABGR:
       sse2fct=jsimd_ycc_extxbgr_convert_sse2;
+      avx2fct=jsimd_ycc_extxbgr_convert_avx2;
       break;
     case JCS_EXT_XRGB:
     case JCS_EXT_ARGB:
       sse2fct=jsimd_ycc_extxrgb_convert_sse2;
+      avx2fct=jsimd_ycc_extxrgb_convert_avx2;
       break;
     default:
       sse2fct=jsimd_ycc_rgb_convert_sse2;
+      avx2fct=jsimd_ycc_rgb_convert_avx2;
       break;
   }
 
-  sse2fct(cinfo->output_width, input_buf, input_row, output_buf, num_rows);
+  if (simd_support & JSIMD_AVX2)
+	  avx2fct(cinfo->output_width, input_buf, input_row, output_buf, num_rows);
+  else if (simd_support & JSIMD_SSE2)
+	  sse2fct(cinfo->output_width, input_buf, input_row, output_buf, num_rows);
 }
 
 GLOBAL(void)
@@ -216,7 +304,13 @@ jsimd_can_h2v2_downsample (void)
   if (sizeof(JDIMENSION) != 4)
     return 0;
 
-  return 1;
+  init_simd();
+   if (simd_support & JSIMD_SSE2)
+    return 1;
+  if (simd_support & JSIMD_AVX2)
+	  return 1;
+
+  return 0;
 }
 
 GLOBAL(int)
@@ -228,25 +322,44 @@ jsimd_can_h2v1_downsample (void)
   if (sizeof(JDIMENSION) != 4)
     return 0;
 
-  return 1;
+  init_simd();
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  if (simd_support & JSIMD_AVX2)
+    return 1;
+
+  return 0;
+
 }
 
 GLOBAL(void)
 jsimd_h2v2_downsample (j_compress_ptr cinfo, jpeg_component_info * compptr,
                        JSAMPARRAY input_data, JSAMPARRAY output_data)
 {
-  jsimd_h2v2_downsample_sse2(cinfo->image_width, cinfo->max_v_samp_factor,
-                             compptr->v_samp_factor, compptr->width_in_blocks,
-                             input_data, output_data);
+  	if (simd_support & JSIMD_AVX2) 
+		jsimd_h2v2_downsample_avx2(cinfo->image_width, cinfo->max_v_samp_factor,
+				compptr->v_samp_factor, compptr->width_in_blocks,
+				input_data, output_data);
+	else if ( simd_support & JSIMD_SSE2)
+		jsimd_h2v2_downsample_sse2(cinfo->image_width, cinfo->max_v_samp_factor,
+				compptr->v_samp_factor, compptr->width_in_blocks,
+				input_data, output_data);
 }
 
 GLOBAL(void)
 jsimd_h2v1_downsample (j_compress_ptr cinfo, jpeg_component_info * compptr,
                        JSAMPARRAY input_data, JSAMPARRAY output_data)
 {
-  jsimd_h2v1_downsample_sse2(cinfo->image_width, cinfo->max_v_samp_factor,
-                             compptr->v_samp_factor, compptr->width_in_blocks,
-                             input_data, output_data);
+	if (simd_support & JSIMD_AVX2) 
+		jsimd_h2v1_downsample_avx2(cinfo->image_width, cinfo->max_v_samp_factor,
+				compptr->v_samp_factor, compptr->width_in_blocks,
+				input_data, output_data);
+	else if ( simd_support & JSIMD_SSE2)
+		jsimd_h2v1_downsample_sse2(cinfo->image_width, cinfo->max_v_samp_factor,
+				compptr->v_samp_factor, compptr->width_in_blocks,
+				input_data, output_data);
 }
 
 GLOBAL(int)
@@ -258,7 +371,14 @@ jsimd_can_h2v2_upsample (void)
   if (sizeof(JDIMENSION) != 4)
     return 0;
 
-  return 1;
+	init_simd();
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+  if (simd_support & JSIMD_AVX2)
+	  return 1;
+
+  return 0;
 }
 
 GLOBAL(int)
@@ -270,7 +390,14 @@ jsimd_can_h2v1_upsample (void)
   if (sizeof(JDIMENSION) != 4)
     return 0;
 
-  return 1;
+  init_simd();
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+  if (simd_support & JSIMD_AVX2)
+	  return 1;
+
+  return 0;
+
 }
 
 GLOBAL(void)
@@ -279,8 +406,12 @@ jsimd_h2v2_upsample (j_decompress_ptr cinfo,
                      JSAMPARRAY input_data,
                      JSAMPARRAY * output_data_ptr)
 {
-  jsimd_h2v2_upsample_sse2(cinfo->max_v_samp_factor, cinfo->output_width,
-                           input_data, output_data_ptr);
+	if (simd_support & JSIMD_AVX2)
+		jsimd_h2v2_upsample_avx2(cinfo->max_v_samp_factor, cinfo->output_width,
+				input_data, output_data_ptr);
+	else if (simd_support & JSIMD_SSE2)
+		jsimd_h2v2_upsample_sse2(cinfo->max_v_samp_factor, cinfo->output_width,
+				input_data, output_data_ptr);
 }
 
 GLOBAL(void)
@@ -289,8 +420,12 @@ jsimd_h2v1_upsample (j_decompress_ptr cinfo,
                      JSAMPARRAY input_data,
                      JSAMPARRAY * output_data_ptr)
 {
-  jsimd_h2v1_upsample_sse2(cinfo->max_v_samp_factor, cinfo->output_width,
-                           input_data, output_data_ptr);
+	if (simd_support & JSIMD_AVX2)
+		jsimd_h2v1_upsample_avx2(cinfo->max_v_samp_factor, cinfo->output_width,
+				input_data, output_data_ptr);
+	else if (simd_support & JSIMD_SSE2)
+		jsimd_h2v1_upsample_sse2(cinfo->max_v_samp_factor, cinfo->output_width,
+				input_data, output_data_ptr);
 }
 
 GLOBAL(int)
@@ -302,10 +437,13 @@ jsimd_can_h2v2_fancy_upsample (void)
   if (sizeof(JDIMENSION) != 4)
     return 0;
 
-  if (!IS_ALIGNED_SSE(jconst_fancy_upsample_sse2))
-    return 0;
+  init_simd();
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+  if (simd_support & JSIMD_AVX2)
+	  return 1;
 
-  return 1;
+  return 0;
 }
 
 GLOBAL(int)
@@ -317,10 +455,13 @@ jsimd_can_h2v1_fancy_upsample (void)
   if (sizeof(JDIMENSION) != 4)
     return 0;
 
-  if (!IS_ALIGNED_SSE(jconst_fancy_upsample_sse2))
-    return 0;
+  init_simd();
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+  if (simd_support & JSIMD_AVX2)
+	  return 1;
 
-  return 1;
+  return 0;
 }
 
 GLOBAL(void)
@@ -329,9 +470,16 @@ jsimd_h2v2_fancy_upsample (j_decompress_ptr cinfo,
                            JSAMPARRAY input_data,
                            JSAMPARRAY * output_data_ptr)
 {
-  jsimd_h2v2_fancy_upsample_sse2(cinfo->max_v_samp_factor,
-                                 compptr->downsampled_width, input_data,
-                                 output_data_ptr);
+	if(simd_support & JSIMD_AVX2)
+		jsimd_h2v2_fancy_upsample_avx2(cinfo->max_v_samp_factor,
+				compptr->downsampled_width, input_data,
+				output_data_ptr);
+
+	else if(simd_support & JSIMD_SSE2)
+		jsimd_h2v2_fancy_upsample_sse2(cinfo->max_v_samp_factor,
+				compptr->downsampled_width, input_data,
+				output_data_ptr);
+
 }
 
 GLOBAL(void)
@@ -340,9 +488,15 @@ jsimd_h2v1_fancy_upsample (j_decompress_ptr cinfo,
                            JSAMPARRAY input_data,
                            JSAMPARRAY * output_data_ptr)
 {
-  jsimd_h2v1_fancy_upsample_sse2(cinfo->max_v_samp_factor,
-                                 compptr->downsampled_width, input_data,
-                                 output_data_ptr);
+	if(simd_support & JSIMD_AVX2)
+		jsimd_h2v1_fancy_upsample_avx2(cinfo->max_v_samp_factor,
+				compptr->downsampled_width, input_data,
+				output_data_ptr);
+
+	else if(simd_support & JSIMD_SSE2)
+		jsimd_h2v1_fancy_upsample_sse2(cinfo->max_v_samp_factor,
+				compptr->downsampled_width, input_data,
+				output_data_ptr);
 }
 
 GLOBAL(int)
@@ -354,10 +508,15 @@ jsimd_can_h2v2_merged_upsample (void)
   if (sizeof(JDIMENSION) != 4)
     return 0;
 
-  if (!IS_ALIGNED_SSE(jconst_merged_upsample_sse2))
-    return 0;
+  init_simd();
 
-  return 1;
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  if (simd_support & JSIMD_AVX2)
+    return 1;
+
+  return 0;
 }
 
 GLOBAL(int)
@@ -369,10 +528,14 @@ jsimd_can_h2v1_merged_upsample (void)
   if (sizeof(JDIMENSION) != 4)
     return 0;
 
-  if (!IS_ALIGNED_SSE(jconst_merged_upsample_sse2))
-    return 0;
+  init_simd();
+  if (simd_support&JSIMD_SSE2)
+    return 1;
 
-  return 1;
+  if (simd_support & JSIMD_AVX2)
+    return 1;
+
+  return 0;
 }
 
 GLOBAL(void)
@@ -382,36 +545,47 @@ jsimd_h2v2_merged_upsample (j_decompress_ptr cinfo,
                             JSAMPARRAY output_buf)
 {
   void (*sse2fct)(JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
+  void (*avx2fct)(JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
 
   switch(cinfo->out_color_space) {
     case JCS_EXT_RGB:
       sse2fct=jsimd_h2v2_extrgb_merged_upsample_sse2;
+      avx2fct=jsimd_h2v2_extrgb_merged_upsample_avx2;
       break;
     case JCS_EXT_RGBX:
     case JCS_EXT_RGBA:
       sse2fct=jsimd_h2v2_extrgbx_merged_upsample_sse2;
+      avx2fct=jsimd_h2v2_extrgbx_merged_upsample_avx2;
       break;
     case JCS_EXT_BGR:
       sse2fct=jsimd_h2v2_extbgr_merged_upsample_sse2;
+      avx2fct=jsimd_h2v2_extbgr_merged_upsample_avx2;
       break;
     case JCS_EXT_BGRX:
     case JCS_EXT_BGRA:
       sse2fct=jsimd_h2v2_extbgrx_merged_upsample_sse2;
+      avx2fct=jsimd_h2v2_extbgrx_merged_upsample_avx2;
       break;
     case JCS_EXT_XBGR:
     case JCS_EXT_ABGR:
       sse2fct=jsimd_h2v2_extxbgr_merged_upsample_sse2;
+      avx2fct=jsimd_h2v2_extxbgr_merged_upsample_avx2;
       break;
     case JCS_EXT_XRGB:
     case JCS_EXT_ARGB:
       sse2fct=jsimd_h2v2_extxrgb_merged_upsample_sse2;
+      avx2fct=jsimd_h2v2_extxrgb_merged_upsample_avx2;
       break;
     default:
       sse2fct=jsimd_h2v2_merged_upsample_sse2;
+      avx2fct=jsimd_h2v2_merged_upsample_avx2;
       break;
   }
 
-  sse2fct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
+  if (simd_support & JSIMD_AVX2)
+	  avx2fct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
+  else if (simd_support & JSIMD_SSE2)
+	  sse2fct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
 }
 
 GLOBAL(void)
@@ -421,36 +595,46 @@ jsimd_h2v1_merged_upsample (j_decompress_ptr cinfo,
                             JSAMPARRAY output_buf)
 {
   void (*sse2fct)(JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
+  void (*avx2fct)(JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
 
   switch(cinfo->out_color_space) {
     case JCS_EXT_RGB:
       sse2fct=jsimd_h2v1_extrgb_merged_upsample_sse2;
+      avx2fct=jsimd_h2v1_extrgb_merged_upsample_avx2;
       break;
     case JCS_EXT_RGBX:
     case JCS_EXT_RGBA:
       sse2fct=jsimd_h2v1_extrgbx_merged_upsample_sse2;
+      avx2fct=jsimd_h2v1_extrgbx_merged_upsample_avx2;
       break;
     case JCS_EXT_BGR:
       sse2fct=jsimd_h2v1_extbgr_merged_upsample_sse2;
+      avx2fct=jsimd_h2v1_extbgr_merged_upsample_avx2;
       break;
     case JCS_EXT_BGRX:
     case JCS_EXT_BGRA:
       sse2fct=jsimd_h2v1_extbgrx_merged_upsample_sse2;
+      avx2fct=jsimd_h2v1_extbgrx_merged_upsample_avx2;
       break;
     case JCS_EXT_XBGR:
     case JCS_EXT_ABGR:
       sse2fct=jsimd_h2v1_extxbgr_merged_upsample_sse2;
+      avx2fct=jsimd_h2v1_extxbgr_merged_upsample_avx2;
       break;
     case JCS_EXT_XRGB:
     case JCS_EXT_ARGB:
       sse2fct=jsimd_h2v1_extxrgb_merged_upsample_sse2;
+      avx2fct=jsimd_h2v1_extxrgb_merged_upsample_avx2;
       break;
     default:
       sse2fct=jsimd_h2v1_merged_upsample_sse2;
+      avx2fct=jsimd_h2v1_merged_upsample_avx2;
       break;
   }
-
-  sse2fct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
+  if (simd_support & JSIMD_AVX2)
+	  avx2fct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
+  else if (simd_support & JSIMD_SSE2)
+	  sse2fct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
 }
 
 GLOBAL(int)
@@ -466,7 +650,14 @@ jsimd_can_convsamp (void)
   if (sizeof(DCTELEM) != 2)
     return 0;
 
-  return 1;
+  init_simd();
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+  if (simd_support & JSIMD_AVX2)
+    return 1;
+
+
+  return 0;
 }
 
 GLOBAL(int)
@@ -482,7 +673,30 @@ jsimd_can_convsamp_float (void)
   if (sizeof(FAST_FLOAT) != 4)
     return 0;
 
-  return 1;
+  init_simd();
+  if (simd_support & JSIMD_SSE2) 
+    return 1;
+  if ((simd_support & JSIMD_AVX2))
+    return 1;
+
+  return 0;
+
+}
+
+GLOBAL(void)
+jsimd_fdct_merged_ifast
+(JSAMPARRAY sample_data, JDIMENSION start_col,JCOEFPTR coef_block, DCTELEM * divisors)
+{
+	DCTELEM * divisors_avx = divisors + 4*DCTSIZE2;
+	jsimd_fdct_merged_ifast_avx2(sample_data,start_col,coef_block,divisors_avx);
+}
+
+GLOBAL(void)
+jsimd_fdct_merged_islow
+(JSAMPARRAY sample_data, JDIMENSION start_col,JCOEFPTR coef_block, DCTELEM* divisors)
+{
+	DCTELEM * divisors_avx = divisors + 4*DCTSIZE2;
+	jsimd_fdct_merged_islow_avx2(sample_data,start_col,coef_block,divisors_avx);
 }
 
 GLOBAL(void)
@@ -496,7 +710,10 @@ GLOBAL(void)
 jsimd_convsamp_float (JSAMPARRAY sample_data, JDIMENSION start_col,
                       FAST_FLOAT * workspace)
 {
-  jsimd_convsamp_float_sse2(sample_data, start_col, workspace);
+	if (simd_support & JSIMD_AVX2)
+		jsimd_convsamp_float_avx2(sample_data, start_col, workspace);
+	else if (simd_support & JSIMD_SSE2)
+		jsimd_convsamp_float_sse2(sample_data, start_col, workspace);
 }
 
 GLOBAL(int)
@@ -508,10 +725,13 @@ jsimd_can_fdct_islow (void)
   if (sizeof(DCTELEM) != 2)
     return 0;
 
-  if (!IS_ALIGNED_SSE(jconst_fdct_islow_sse2))
-    return 0;
+  init_simd();
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+  if (simd_support & JSIMD_AVX2)
+    return 1;
 
-  return 1;
+  return 0;
 }
 
 GLOBAL(int)
@@ -523,10 +743,14 @@ jsimd_can_fdct_ifast (void)
   if (sizeof(DCTELEM) != 2)
     return 0;
 
-  if (!IS_ALIGNED_SSE(jconst_fdct_ifast_sse2))
-    return 0;
+  init_simd();
+  if (simd_support & JSIMD_AVX2) 
+	  return 1;
 
-  return 1;
+  if (simd_support & JSIMD_SSE2)
+	  return 1;
+
+  return 0;
 }
 
 GLOBAL(int)
@@ -538,10 +762,14 @@ jsimd_can_fdct_float (void)
   if (sizeof(FAST_FLOAT) != 4)
     return 0;
 
-  if (!IS_ALIGNED_SSE(jconst_fdct_float_sse))
-    return 0;
+  init_simd();
+  if (simd_support & JSIMD_AVX2) 
+	  return 1;
 
-  return 1;
+  if (simd_support & JSIMD_SSE2)
+	  return 1;
+
+  return 0;
 }
 
 GLOBAL(void)
@@ -559,7 +787,17 @@ jsimd_fdct_ifast (DCTELEM * data)
 GLOBAL(void)
 jsimd_fdct_float (FAST_FLOAT * data)
 {
-  jsimd_fdct_float_sse(data);
+  if ((simd_support & JSIMD_AVX2))
+    jsimd_fdct_float_sse(data);
+  else
+    jsimd_fdct_float_sse(data);
+}
+
+GLOBAL(void)
+jsimd_fdct_merged_float
+(JSAMPARRAY sample_data, JDIMENSION start_col,JCOEFPTR coef_block, FAST_FLOAT * divisors)
+{
+  jsimd_fdct_merged_float_avx2(sample_data,start_col,coef_block,divisors);
 }
 
 GLOBAL(int)
@@ -573,7 +811,13 @@ jsimd_can_quantize (void)
   if (sizeof(DCTELEM) != 2)
     return 0;
 
-  return 1;
+ init_simd();
+  if (simd_support & JSIMD_AVX2) 
+	  return 1;
+  if (simd_support & JSIMD_SSE2)
+	  return 1;
+
+  return 0;
 }
 
 GLOBAL(int)
@@ -587,7 +831,13 @@ jsimd_can_quantize_float (void)
   if (sizeof(FAST_FLOAT) != 4)
     return 0;
 
-  return 1;
+  init_simd();
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+  if (simd_support & JSIMD_AVX2)
+    return 1;
+ 
+  return 0;
 }
 
 GLOBAL(void)
@@ -601,7 +851,10 @@ GLOBAL(void)
 jsimd_quantize_float (JCOEFPTR coef_block, FAST_FLOAT * divisors,
                       FAST_FLOAT * workspace)
 {
-  jsimd_quantize_float_sse2(coef_block, divisors, workspace);
+	if (simd_support & JSIMD_AVX2)
+		jsimd_quantize_float_avx2(coef_block, divisors, workspace);
+	else if (simd_support & JSIMD_SSE2)
+		jsimd_quantize_float_sse2(coef_block, divisors, workspace);
 }
 
 GLOBAL(int)
@@ -619,10 +872,13 @@ jsimd_can_idct_2x2 (void)
   if (sizeof(ISLOW_MULT_TYPE) != 2)
     return 0;
 
-  if (!IS_ALIGNED_SSE(jconst_idct_red_sse2))
-    return 0;
+  init_simd();
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+  if (simd_support & JSIMD_AVX2)
+    return 1;
 
-  return 1;
+  return 0;
 }
 
 GLOBAL(int)
@@ -640,10 +896,13 @@ jsimd_can_idct_4x4 (void)
   if (sizeof(ISLOW_MULT_TYPE) != 2)
     return 0;
 
-  if (!IS_ALIGNED_SSE(jconst_idct_red_sse2))
-    return 0;
+  init_simd();
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+  if (simd_support & JSIMD_AVX2)
+    return 1;
 
-  return 1;
+  return 0;
 }
 
 GLOBAL(void)
@@ -677,10 +936,13 @@ jsimd_can_idct_islow (void)
   if (sizeof(ISLOW_MULT_TYPE) != 2)
     return 0;
 
-  if (!IS_ALIGNED_SSE(jconst_idct_islow_sse2))
-    return 0;
+  init_simd();
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+  if (simd_support & JSIMD_AVX2)
+    return 1;
 
-  return 1;
+  return 0;
 }
 
 GLOBAL(int)
@@ -700,10 +962,13 @@ jsimd_can_idct_ifast (void)
   if (IFAST_SCALE_BITS != 2)
     return 0;
 
-  if (!IS_ALIGNED_SSE(jconst_idct_ifast_sse2))
-    return 0;
+  init_simd();
+  if (simd_support & JSIMD_SSE2)
+	  return 1;
+  if (simd_support & JSIMD_AVX2)
+	  return 1;
 
-  return 1;
+    return 0;
 }
 
 GLOBAL(int)
@@ -722,10 +987,13 @@ jsimd_can_idct_float (void)
   if (sizeof(FLOAT_MULT_TYPE) != 4)
     return 0;
 
-  if (!IS_ALIGNED_SSE(jconst_idct_float_sse2))
-    return 0;
+  init_simd();
+  if (simd_support & JSIMD_AVX2) 
+	  return 1;
+  if (simd_support & JSIMD_SSE2)
+	  return 1;
 
-  return 1;
+  return 0;
 }
 
 GLOBAL(void)
@@ -747,11 +1015,51 @@ jsimd_idct_ifast (j_decompress_ptr cinfo, jpeg_component_info * compptr,
 }
 
 GLOBAL(void)
+jsimd_simd256_idct_islow (j_decompress_ptr cinfo, jpeg_component_info * compptr,
+                  JCOEFPTR coef_block, JSAMPARRAY output_buf,
+                  JDIMENSION output_col)
+{
+	/*
+   * bit 0 of output_col isnot used in standard IDCT processing, 
+	 * I use it for indicating single block IDCT transform
+   * */
+#define IDCT_IFAST_MAGIC_BIT 1
+	if((output_col & IDCT_IFAST_MAGIC_BIT) == 0)
+		jsimd_idct_islow_avx2(compptr->dct_table, coef_block, output_buf,
+				output_col);
+	else
+		jsimd_idct_islow_sse2(compptr->dct_table, coef_block, output_buf,
+				output_col&(JDIMENSION)(-2));
+}
+
+GLOBAL(void)
+jsimd_simd256_idct_ifast (j_decompress_ptr cinfo, jpeg_component_info * compptr,
+                  JCOEFPTR coef_block, JSAMPARRAY output_buf,
+                  JDIMENSION output_col)
+{
+	/*
+   * bit 0 of output_col isnot used in standard IDCT processing, 
+	 * I use it for indicating single block IDCT transform
+   * */
+#define IDCT_IFAST_MAGIC_BIT 1
+  if((output_col & IDCT_IFAST_MAGIC_BIT) == 0)
+    jsimd_idct_ifast_avx2(compptr->dct_table, coef_block, output_buf,
+        output_col);
+  else
+    jsimd_idct_ifast_sse2(compptr->dct_table, coef_block, output_buf,
+        output_col&(JDIMENSION)(-2));
+}
+
+  GLOBAL(void)
 jsimd_idct_float (j_decompress_ptr cinfo, jpeg_component_info * compptr,
                   JCOEFPTR coef_block, JSAMPARRAY output_buf,
                   JDIMENSION output_col)
 {
-  jsimd_idct_float_sse2(compptr->dct_table, coef_block, output_buf,
-                        output_col);
+	if(simd_support & JSIMD_AVX2)
+		jsimd_idct_float_avx2(compptr->dct_table, coef_block, output_buf,
+				output_col);
+	else if (simd_support & JSIMD_SSE2)
+		jsimd_idct_float_sse2(compptr->dct_table, coef_block, output_buf,
+				output_col);
 }
 

--- a/simd/jsimdcfg.inc.h
+++ b/simd/jsimdcfg.inc.h
@@ -128,3 +128,4 @@
 %define _cpp_protection_JSIMD_3DNOW JSIMD_3DNOW
 %define _cpp_protection_JSIMD_SSE JSIMD_SSE
 %define _cpp_protection_JSIMD_SSE2 JSIMD_SSE2
+%define _cpp_protection_JSIMD_AVX2 JSIMD_AVX2

--- a/simd/jsimdcpu.asm
+++ b/simd/jsimdcpu.asm
@@ -2,6 +2,7 @@
 ; jsimdcpu.asm - SIMD instruction support check
 ;
 ; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright 2015 Intel Corporation
 ;
 ; Based on
 ; x86 SIMD extension for IJG JPEG library
@@ -57,8 +58,7 @@ EXTN(jpeg_simd_cpu_support):
         test    eax,eax
         jz      short .return
 
-        xor     eax,eax
-        inc     eax
+		    mov		eax,1
         cpuid
         mov     eax,edx                 ; eax = Standard feature flags
 
@@ -74,6 +74,14 @@ EXTN(jpeg_simd_cpu_support):
         jz      short .no_sse2
         or      edi, byte JSIMD_SSE2
 .no_sse2:
+		mov eax, 7
+		mov ecx, 0
+		cpuid
+		and ebx, 0x20
+		test ebx, 0x20
+		jz  short .no_avx2
+		or  edi, byte JSIMD_AVX2
+.no_avx2:
 
         ; Check for 3DNow! instruction support
         mov     eax, 0x80000000

--- a/simd/jsimdext.inc
+++ b/simd/jsimdext.inc
@@ -3,6 +3,7 @@
 ;
 ; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
 ; Copyright 2010 D. R. Commander
+; Copyright 2015 Intel Corporation
 ;
 ; Based on
 ; x86 SIMD extension for IJG JPEG library - version 1.02
@@ -158,6 +159,12 @@ section .note.GNU-stack noalloc noexec nowrite progbits
 %define XMMWORD                                 ; int128 (SSE register)
 %define SIZEOF_XMMWORD          SIZEOF_OWORD    ; sizeof(XMMWORD)
 %define XMMWORD_BIT             OWORD_BIT       ; sizeof(XMMWORD)*BYTE_BIT
+
+; For AVX/AVX2 instructions
+%define YMMWORD           			
+%define YMM_MMWORD           			
+%define SIZEOF_YMMWORD         	32 
+%define YMMWORD_BIT             256 
 
 ; Similar hacks for when we load a dword or MMWORD into an xmm# register
 %define XMM_DWORD

--- a/tjunittest.c
+++ b/tjunittest.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (C)2009-2014 D. R. Commander.  All Rights Reserved.
- * Copyright (C)2015, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -302,7 +301,7 @@ int checkBufYUV(unsigned char *buf, int w, int h, int subsamp,
 	int hsf=tjMCUWidth[subsamp]/8, vsf=tjMCUHeight[subsamp]/8;
 	int pw=PAD(w, hsf), ph=PAD(h, vsf);
 	int cw=pw/hsf, ch=ph/vsf;
-	int ypitch=PAD(PAD(pw, pad),16), uvpitch=PAD(PAD(cw, pad),16);
+	int ypitch=PAD(pw, pad), uvpitch=PAD(cw, pad);
 	int retval=1;
 	int halfway=16*sf.num/sf.denom;
 	int blocksize=8*sf.num/sf.denom;

--- a/tjunittest.c
+++ b/tjunittest.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C)2009-2014 D. R. Commander.  All Rights Reserved.
+ * Copyright (C)2015, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -301,7 +302,7 @@ int checkBufYUV(unsigned char *buf, int w, int h, int subsamp,
 	int hsf=tjMCUWidth[subsamp]/8, vsf=tjMCUHeight[subsamp]/8;
 	int pw=PAD(w, hsf), ph=PAD(h, vsf);
 	int cw=pw/hsf, ch=ph/vsf;
-	int ypitch=PAD(pw, pad), uvpitch=PAD(cw, pad);
+	int ypitch=PAD(PAD(pw, pad),16), uvpitch=PAD(PAD(cw, pad),16);
 	int retval=1;
 	int halfway=16*sf.num/sf.denom;
 	int blocksize=8*sf.num/sf.denom;

--- a/turbojpeg.c
+++ b/turbojpeg.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C)2009-2015 D. R. Commander.  All Rights Reserved.
+ * Copyright (C)2015, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -621,7 +622,7 @@ DLLEXPORT unsigned long DLLCALL TJBUFSIZE(int width, int height)
 	/* This allows for rare corner cases in which a JPEG image can actually be
 	   larger than the uncompressed input (we wouldn't mention it if it hadn't
 	   happened before.) */
-	retval=PAD(width, 16) * PAD(height, 16) * 6 + 2048;
+	retval=PAD(width, 32) * PAD(height, 32) * 6 + 2048;
 
 	bailout:
 	return retval;
@@ -640,7 +641,7 @@ DLLEXPORT unsigned long DLLCALL tjBufSizeYUV2(int width, int pad, int height,
 	for(i=0; i<nc; i++)
 	{
 		int pw=tjPlaneWidth(i, width, subsamp);
-		int stride=PAD(pw, pad);
+		int stride=PAD(PAD(pw, pad),16);
 		int ph=tjPlaneHeight(i, height, subsamp);
 		if(pw<0 || ph<0) return -1;
 		else retval+=stride*ph;
@@ -921,29 +922,29 @@ DLLEXPORT int DLLCALL tjEncodeYUVPlanes(tjhandle handle, unsigned char *srcBuf,
 		compptr=&cinfo->comp_info[i];
 		_tmpbuf[i]=(JSAMPLE *)malloc(
 			PAD((compptr->width_in_blocks*cinfo->max_h_samp_factor*DCTSIZE)
-				/compptr->h_samp_factor, 16) * cinfo->max_v_samp_factor + 16);
+				/compptr->h_samp_factor, 32) * cinfo->max_v_samp_factor + 32);
 		if(!_tmpbuf[i]) _throw("tjEncodeYUVPlanes(): Memory allocation failure");
 		tmpbuf[i]=(JSAMPROW *)malloc(sizeof(JSAMPROW)*cinfo->max_v_samp_factor);
 		if(!tmpbuf[i]) _throw("tjEncodeYUVPlanes(): Memory allocation failure");
 		for(row=0; row<cinfo->max_v_samp_factor; row++)
 		{
 			unsigned char *_tmpbuf_aligned=
-				(unsigned char *)PAD((size_t)_tmpbuf[i], 16);
+				(unsigned char *)PAD((size_t)_tmpbuf[i], 32);
 			tmpbuf[i][row]=&_tmpbuf_aligned[
 				PAD((compptr->width_in_blocks*cinfo->max_h_samp_factor*DCTSIZE)
-					/compptr->h_samp_factor, 16) * row];
+					/compptr->h_samp_factor, 32) * row];
 		}
-		_tmpbuf2[i]=(JSAMPLE *)malloc(PAD(compptr->width_in_blocks*DCTSIZE, 16)
-			* compptr->v_samp_factor + 16);
+		_tmpbuf2[i]=(JSAMPLE *)malloc(PAD(compptr->width_in_blocks*DCTSIZE, 32)
+			* compptr->v_samp_factor + 32);
 		if(!_tmpbuf2[i]) _throw("tjEncodeYUVPlanes(): Memory allocation failure");
 		tmpbuf2[i]=(JSAMPROW *)malloc(sizeof(JSAMPROW)*compptr->v_samp_factor);
 		if(!tmpbuf2[i]) _throw("tjEncodeYUVPlanes(): Memory allocation failure");
 		for(row=0; row<compptr->v_samp_factor; row++)
 		{
 			unsigned char *_tmpbuf2_aligned=
-				(unsigned char *)PAD((size_t)_tmpbuf2[i], 16);
+				(unsigned char *)PAD((size_t)_tmpbuf2[i], 32);
 			tmpbuf2[i][row]=&_tmpbuf2_aligned[
-				PAD(compptr->width_in_blocks*DCTSIZE, 16) * row];
+				PAD(compptr->width_in_blocks*DCTSIZE, 32) * row];
 		}
 		pw[i]=pw0*compptr->h_samp_factor/cinfo->max_h_samp_factor;
 		ph[i]=ph0*compptr->v_samp_factor/cinfo->max_v_samp_factor;
@@ -953,7 +954,7 @@ DLLEXPORT int DLLCALL tjEncodeYUVPlanes(tjhandle handle, unsigned char *srcBuf,
 		for(row=0; row<ph[i]; row++)
 		{
 			outbuf[i][row]=ptr;
-			ptr+=(strides && strides[i]!=0)? strides[i]:pw[i];
+			ptr+=(strides && strides[i]!=0)? strides[i]:PAD(pw[i],16);
 		}
 	}
 
@@ -1002,7 +1003,7 @@ DLLEXPORT int DLLCALL tjEncodeYUV3(tjhandle handle, unsigned char *srcBuf,
 	pw0=tjPlaneWidth(0, width, subsamp);
 	ph0=tjPlaneHeight(0, height, subsamp);
 	dstPlanes[0]=dstBuf;
-	strides[0]=PAD(pw0, pad);
+	strides[0]=PAD(PAD(pw0, pad),16);
 	if(subsamp==TJSAMP_GRAY)
 	{
 		strides[1]=strides[2]=0;
@@ -1012,7 +1013,7 @@ DLLEXPORT int DLLCALL tjEncodeYUV3(tjhandle handle, unsigned char *srcBuf,
 	{
 		int pw1=tjPlaneWidth(1, width, subsamp);
 		int ph1=tjPlaneHeight(1, height, subsamp);
-		strides[1]=strides[2]=PAD(pw1, pad);
+		strides[1]=strides[2]=PAD(PAD(pw1, pad),16);
 		dstPlanes[1]=dstPlanes[0]+strides[0]*ph0;
 		dstPlanes[2]=dstPlanes[1]+strides[1]*ph1;
 	}
@@ -1073,7 +1074,7 @@ DLLEXPORT int DLLCALL tjCompressFromYUVPlanes(tjhandle handle,
 		retval=-1;
 		goto bailout;
 	}
-
+	
 	cinfo->image_width=width;
 	cinfo->image_height=height;
 
@@ -1103,14 +1104,14 @@ DLLEXPORT int DLLCALL tjCompressFromYUVPlanes(tjhandle handle,
 			*compptr->v_samp_factor/cinfo->max_v_samp_factor;
 		if(iw[i]!=pw[i] || ih!=ph[i]) usetmpbuf=1;
 		th[i]=compptr->v_samp_factor*DCTSIZE;
-		tmpbufsize+=iw[i]*th[i];
+		tmpbufsize+=PAD(iw[i],32)*th[i];
 		if((inbuf[i]=(JSAMPROW *)malloc(sizeof(JSAMPROW)*ph[i]))==NULL)
 			_throw("tjCompressFromYUVPlanes(): Memory allocation failure");
 		ptr=srcPlanes[i];
 		for(row=0; row<ph[i]; row++)
 		{
 			inbuf[i][row]=ptr;
-			ptr+=(strides && strides[i]!=0)? strides[i]:pw[i];
+			ptr+=(strides && strides[i]!=0)? strides[i]:PAD(pw[i],16);
 		}
 	}
 	if(usetmpbuf)
@@ -1125,7 +1126,7 @@ DLLEXPORT int DLLCALL tjCompressFromYUVPlanes(tjhandle handle,
 			for(row=0; row<th[i]; row++)
 			{
 				tmpbuf[i][row]=ptr;
-				ptr+=iw[i];
+				ptr+=PAD(iw[i],32);
 			}
 		}
 	}
@@ -1186,7 +1187,7 @@ DLLEXPORT int DLLCALL tjCompressFromYUV(tjhandle handle, unsigned char *srcBuf,
 	pw0=tjPlaneWidth(0, width, subsamp);
 	ph0=tjPlaneHeight(0, height, subsamp);
 	srcPlanes[0]=srcBuf;
-	strides[0]=PAD(pw0, pad);
+	strides[0]=PAD(PAD(pw0, pad),16);
 	if(subsamp==TJSAMP_GRAY)
 	{
 		strides[1]=strides[2]=0;
@@ -1196,7 +1197,7 @@ DLLEXPORT int DLLCALL tjCompressFromYUV(tjhandle handle, unsigned char *srcBuf,
 	{
 		int pw1=tjPlaneWidth(1, width, subsamp);
 		int ph1=tjPlaneHeight(1, height, subsamp);
-		strides[1]=strides[2]=PAD(pw1, pad);
+		strides[1]=strides[2]=PAD(PAD(pw1, pad),16);
 		srcPlanes[1]=srcPlanes[0]+strides[0]*ph0;
 		srcPlanes[2]=srcPlanes[1]+strides[1]*ph1;
 	}
@@ -1604,17 +1605,17 @@ DLLEXPORT int DLLCALL tjDecodeYUVPlanes(tjhandle handle,
 	for(i=0; i<dinfo->num_components; i++)
 	{
 		compptr=&dinfo->comp_info[i];
-		_tmpbuf[i]=(JSAMPLE *)malloc(PAD(compptr->width_in_blocks*DCTSIZE, 16)
-			* compptr->v_samp_factor + 16);
+		_tmpbuf[i]=(JSAMPLE *)malloc(PAD(compptr->width_in_blocks*DCTSIZE, 32)
+			* compptr->v_samp_factor + 32);
 		if(!_tmpbuf[i]) _throw("tjDecodeYUVPlanes(): Memory allocation failure");
 		tmpbuf[i]=(JSAMPROW *)malloc(sizeof(JSAMPROW)*compptr->v_samp_factor);
 		if(!tmpbuf[i]) _throw("tjDecodeYUVPlanes(): Memory allocation failure");
 		for(row=0; row<compptr->v_samp_factor; row++)
 		{
 			unsigned char *_tmpbuf_aligned=
-				(unsigned char *)PAD((size_t)_tmpbuf[i], 16);
+				(unsigned char *)PAD((size_t)_tmpbuf[i], 32);
 			tmpbuf[i][row]=&_tmpbuf_aligned[
-				PAD(compptr->width_in_blocks*DCTSIZE, 16) * row];
+				PAD(compptr->width_in_blocks*DCTSIZE, 32) * row];
 		}
 		pw[i]=pw0*compptr->h_samp_factor/dinfo->max_h_samp_factor;
 		ph[i]=ph0*compptr->v_samp_factor/dinfo->max_v_samp_factor;
@@ -1624,7 +1625,7 @@ DLLEXPORT int DLLCALL tjDecodeYUVPlanes(tjhandle handle,
 		for(row=0; row<ph[i]; row++)
 		{
 			inbuf[i][row]=ptr;
-			ptr+=(strides && strides[i]!=0)? strides[i]:pw[i];
+			ptr+=(strides && strides[i]!=0)? strides[i]:PAD(pw[i],16);
 		}
 	}
 
@@ -1675,7 +1676,7 @@ DLLEXPORT int DLLCALL tjDecodeYUV(tjhandle handle, unsigned char *srcBuf,
 	pw0=tjPlaneWidth(0, width, subsamp);
 	ph0=tjPlaneHeight(0, height, subsamp);
 	srcPlanes[0]=srcBuf;
-	strides[0]=PAD(pw0, pad);
+	strides[0]=PAD(PAD(pw0, pad),16);
 	if(subsamp==TJSAMP_GRAY)
 	{
 		strides[1]=strides[2]=0;
@@ -1685,7 +1686,7 @@ DLLEXPORT int DLLCALL tjDecodeYUV(tjhandle handle, unsigned char *srcBuf,
 	{
 		int pw1=tjPlaneWidth(1, width, subsamp);
 		int ph1=tjPlaneHeight(1, height, subsamp);
-		strides[1]=strides[2]=PAD(pw1, pad);
+		strides[1]=strides[2]=PAD(PAD(pw1, pad),16);
 		srcPlanes[1]=srcPlanes[0]+strides[0]*ph0;
 		srcPlanes[2]=srcPlanes[1]+strides[1]*ph1;
 	}
@@ -1695,8 +1696,7 @@ DLLEXPORT int DLLCALL tjDecodeYUV(tjhandle handle, unsigned char *srcBuf,
 
 	bailout:
 	return retval;
-}
-
+} 
 DLLEXPORT int DLLCALL tjDecompressToYUVPlanes(tjhandle handle,
 	unsigned char *jpegBuf, unsigned long jpegSize, unsigned char **dstPlanes,
 	int width, int *strides, int height, int flags)
@@ -1781,14 +1781,14 @@ DLLEXPORT int DLLCALL tjDecompressToYUVPlanes(tjhandle handle,
 			*compptr->v_samp_factor/dinfo->max_v_samp_factor;
 		if(iw[i]!=pw[i] || ih!=ph[i]) usetmpbuf=1;
 		th[i]=compptr->v_samp_factor*dctsize;
-		tmpbufsize+=iw[i]*th[i];
+		tmpbufsize+=PAD(iw[i],32)*th[i];
 		if((outbuf[i]=(JSAMPROW *)malloc(sizeof(JSAMPROW)*ph[i]))==NULL)
 			_throw("tjDecompressToYUVPlanes(): Memory allocation failure");
 		ptr=dstPlanes[i];
 		for(row=0; row<ph[i]; row++)
 		{
 			outbuf[i][row]=ptr;
-			ptr+=(strides && strides[i]!=0)? strides[i]:pw[i];
+			ptr+=(strides && strides[i]!=0)? strides[i]:PAD(pw[i],16);
 		}
 	}
 	if(usetmpbuf)
@@ -1803,7 +1803,7 @@ DLLEXPORT int DLLCALL tjDecompressToYUVPlanes(tjhandle handle,
 			for(row=0; row<th[i]; row++)
 			{
 				tmpbuf[i][row]=ptr;
-				ptr+=iw[i];
+				ptr+=PAD(iw[i],32);
 			}
 		}
 	}
@@ -1908,7 +1908,7 @@ DLLEXPORT int DLLCALL tjDecompressToYUV2(tjhandle handle,
 	pw0=tjPlaneWidth(0, width, jpegSubsamp);
 	ph0=tjPlaneHeight(0, height, jpegSubsamp);
 	dstPlanes[0]=dstBuf;
-	strides[0]=PAD(pw0, pad);
+	strides[0]=PAD(PAD(pw0, pad),16);
 	if(jpegSubsamp==TJSAMP_GRAY)
 	{
 		strides[1]=strides[2]=0;
@@ -1918,7 +1918,7 @@ DLLEXPORT int DLLCALL tjDecompressToYUV2(tjhandle handle,
 	{
 		int pw1=tjPlaneWidth(1, width, jpegSubsamp);
 		int ph1=tjPlaneHeight(1, height, jpegSubsamp);
-		strides[1]=strides[2]=PAD(pw1, pad);
+		strides[1]=strides[2]=PAD(PAD(pw1, pad),16);
 		dstPlanes[1]=dstPlanes[0]+strides[0]*ph0;
 		dstPlanes[2]=dstPlanes[1]+strides[1]*ph1;
 	}


### PR DESCRIPTION
This is a big patch. AVX/AVX2 extensions now  are broadly used in new CPUs such as the HASWELL, BROADWEL  as well as the upcoming generations.  In this patch it takes advantage of AVX2 SIMD extensions to accelerate the JPEG encode/decode performance by 20%-60% according to different CPU types.
With this patch it will detect the CPU feature automatically, if CPU supports AVX2 extension it will execute the AVX2 routines at the first choice, otherwise it will select SSE2 or normal C routines. Just like the mechanism implemented in jsimd_i386.c, user can also 'downgrade' to SSE2 or C routines  by defining  the system environment of JSMID_FORCESSE2=1 or JSIMD_FORCENONE=1. 
This patch only enables AVX2 extension for 64bit CPU mode.
