### PR TITLE
Display default compression ratio in usage output

### DIFF
--- a/cjpeg.c
+++ b/cjpeg.c
@@ -155,7 +155,7 @@ usage (void)
 #endif
 
   fprintf(stderr, "Switches (names may be abbreviated):\n");
-  fprintf(stderr, "  -quality N[,...]   Compression quality (0..100; 5-95 is useful range)\n");
+  fprintf(stderr, "  -quality N[,...]   Compression quality (0..100; 5-95 is useful range, 75 is default)\n");
   fprintf(stderr, "  -grayscale     Create monochrome JPEG file\n");
   fprintf(stderr, "  -rgb           Create RGB JPEG file\n");
 #ifdef ENTROPY_OPT_SUPPORTED


### PR DESCRIPTION
Although usage.txt specifies the default quality, users will just look at the output of `--help` and expect it there.