### PR TITLE
Generate pkg-config file as part of build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,6 +10,8 @@ endif
 
 nodist_include_HEADERS = jconfig.h
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = pkgscripts/libjpeg.pc pkgscripts/libturbojpeg.pc
 
 HDRS = jchuff.h jdct.h jdhuff.h jerror.h jinclude.h jmemsys.h jmorecfg.h \
 	jpegint.h jpeglib.h jversion.h jsimd.h jsimddct.h jpegcomp.h \

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,8 @@ AC_ARG_WITH([build-date], [Use custom build string to enable reproducible builds
   [BUILD="$with_build_date"],
   [BUILD=`date +%Y%m%d`])
 
+PKG_PROG_PKG_CONFIG
+
 # When the prefix is /opt/libjpeg-turbo, we assume that an "official" binary is
 # being created, and thus we install things into specific locations.
 
@@ -576,6 +578,8 @@ AC_CONFIG_FILES([pkgscripts/makecygwinpkg.tmpl:release/makecygwinpkg.in])
 AC_CONFIG_FILES([pkgscripts/makedpkg.tmpl:release/makedpkg.in])
 AC_CONFIG_FILES([pkgscripts/makemacpkg.tmpl:release/makemacpkg.in])
 AC_CONFIG_FILES([pkgscripts/uninstall.tmpl:release/uninstall.in])
+AC_CONFIG_FILES([pkgscripts/libjpeg.pc:release/libjpeg.pc.in])
+AC_CONFIG_FILES([pkgscripts/libturbojpeg.pc:release/libturbojpeg.pc.in])
 if test "x$with_turbojpeg" != "xno"; then
   AC_CONFIG_FILES([tjbenchtest])
 fi

--- a/release/libjpeg.pc.in
+++ b/release/libjpeg.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+ 
+Name: @PACKAGE_NAME@
+Description: A SIMD-accelerated JPEG codec that provides the libjpeg APIs
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -ljpeg
+Cflags: -I${includedir}

--- a/release/libturbojpeg.pc.in
+++ b/release/libturbojpeg.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+ 
+Name: @PACKAGE_NAME@
+Description: A SIMD-accelerated JPEG codec
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lturbojpeg
+Cflags: -I${includedir}


### PR DESCRIPTION
This will help Linux users link with libjpeg-turbo more easily, and will fix bugs like https://bugs.launchpad.net/ubuntu/+source/libjpeg-turbo/+bug/1056566