### PR TITLE
Fix memleak in tjunittest.c

### DIFF
--- a/tjunittest.c
+++ b/tjunittest.c
@@ -638,7 +638,7 @@ void bufSizeTest(void)
 						&dstSize, subsamp, 100, alloc? 0:TJFLAG_NOREALLOC));
 				}
 				free(srcBuf);  srcBuf=NULL;
-				if(!alloc)
+				if(!alloc || doyuv)
 				{
 					tjFree(dstBuf);  dstBuf=NULL;
 				}
@@ -670,7 +670,7 @@ void bufSizeTest(void)
 						&dstSize, subsamp, 100, alloc? 0:TJFLAG_NOREALLOC));
 				}
 				free(srcBuf);  srcBuf=NULL;
-				if(!alloc)
+				if(!alloc || doyuv)
 				{
 					tjFree(dstBuf);  dstBuf=NULL;
 				}


### PR DESCRIPTION
While running tests under [ASan](https://github.com/google/sanitizers/wiki/AddressSanitizer), I ran into a memleak in `tjunittest.c`.

@dcommander, in order to test some of my modifications, I'm setting up CI on my repo ([travis-ci](https://travis-ci.org/mayeut/libjpeg-turbo/) for now). I don't know if you're using something on your end or if that's something you'd be interested in, in which case I'd be happy to make a PR to add the proper config file.