### PR TITLE
Demo implementation for #63 - downscale in linear light

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,7 @@ set(JPEG_SOURCES jcapimin.c jcapistd.c jccoefct.c jccolor.c jcdctmgr.c jchuff.c
   jcprepct.c jcsample.c jctrans.c jdapimin.c jdapistd.c jdatadst.c jdatasrc.c
   jdcoefct.c jdcolor.c jddctmgr.c jdhuff.c jdinput.c jdmainct.c jdmarker.c
   jdmaster.c jdmerge.c jdphuff.c jdpostct.c jdsample.c jdtrans.c jerror.c
-  jfdctflt.c jfdctfst.c jfdctint.c jidctflt.c jidctfst.c jidctint.c jidctred.c
+  jfdctflt.c jfdctfst.c jfdctint.c jidctflt.c jidctfst.c jidctint.c jidctred.c  
   jquant1.c jquant2.c jutils.c jmemmgr.c jmemnobs.c)
 
 if(WITH_ARITH_ENC OR WITH_ARITH_DEC)

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@ libjpeg_la_SOURCES = $(HDRS) jcapimin.c jcapistd.c jccoefct.c jccolor.c \
 	jddctmgr.c jdhuff.c jdinput.c jdmainct.c jdmarker.c jdmaster.c \
 	jdmerge.c jdphuff.c jdpostct.c jdsample.c jdtrans.c jerror.c \
 	jfdctflt.c jfdctfst.c jfdctint.c jidctflt.c jidctfst.c jidctint.c \
-	jidctred.c jquant1.c jquant2.c jutils.c jmemmgr.c jmemnobs.c
+	jidctred.c jquant1.c jquant2.c jutils.c jmemmgr.c jmemnobs.c 
 
 if WITH_ARITH
 libjpeg_la_SOURCES += jaricom.c

--- a/jddctmgr.c
+++ b/jddctmgr.c
@@ -86,6 +86,10 @@ typedef union {
 #endif
 #endif
 
+EXTERN(void) jpeg_set_idct_method_selector (j_decompress_ptr cinfo, jpeg_idct_method_selector selector){
+  cinfo->custom_idct_selector = selector;
+}
+
 
 /*
  * Prepare for an output pass.
@@ -225,6 +229,11 @@ start_pass (j_decompress_ptr cinfo)
       ERREXIT1(cinfo, JERR_BAD_DCTSIZE, compptr->_DCT_scaled_size);
       break;
     }
+    //Let selector override
+    if (cinfo->custom_idct_selector != NULL){
+      cinfo->custom_idct_selector(cinfo, compptr, &method_ptr, &method);
+    }
+
     idct->pub.inverse_DCT[ci] = method_ptr;
     /* Create multiplier table from quant table.
      * However, we can skip this if the component is uninteresting

--- a/jpeglib.h
+++ b/jpeglib.h
@@ -466,6 +466,8 @@ struct jpeg_compress_struct {
   int script_space_size;
 };
 
+typedef void (*jpeg_idct_method) (j_decompress_ptr cinfo, jpeg_component_info *compptr, JCOEFPTR coef_block, JSAMPARRAY output_buf, JDIMENSION output_col);
+typedef void (*jpeg_idct_method_selector) (j_decompress_ptr cinfo, jpeg_component_info *compptr, jpeg_idct_method * set_idct_method, int * set_idct_category);
 
 /* Master record for a decompression instance */
 
@@ -704,6 +706,11 @@ struct jpeg_decompress_struct {
   struct jpeg_upsampler *upsample;
   struct jpeg_color_deconverter *cconvert;
   struct jpeg_color_quantizer *cquantize;
+
+  /*
+   * Permit users to replace the IDCT method
+  */
+  jpeg_idct_method_selector custom_idct_selector;
 };
 
 
@@ -1056,6 +1063,10 @@ EXTERN(void) jpeg_destroy (j_common_ptr cinfo);
 
 /* Default restart-marker-resync procedure for use by data source modules */
 EXTERN(boolean) jpeg_resync_to_restart (j_decompress_ptr cinfo, int desired);
+
+
+
+EXTERN(void) jpeg_set_idct_method_selector (j_decompress_ptr cinfo, jpeg_idct_method_selector selector);
 
 
 /* These marker codes are exported since applications and data source modules


### PR DESCRIPTION
Sample implementation of https://github.com/libjpeg-turbo/libjpeg-turbo/issues/63

1/2, 1/4, 1/8 are supported. 

The performance is very good when a fast pow approximation is used. There are excellent opportunities for SIMD and vectorization here, although the perf hit is < 25% anyway. 

@jcupitt - This should let vipsthumbnail --linear go from 1.3 seconds down to <400ms on large jpegs. 

This PR does not
1. Have test coverage and validate floating-point accuracy. We need to round-trip blocks with Y values 0..255 and verify no precision loss occurs. We should also validate that averaging happens correctly, with linear behavior. 
2. Investigate the 10% over/undershoot coming out of the floating-point IDCT phase. We clamp these values, but perhaps we can do better?
3. Establish any flags or configurations to enable the feature. It's just on, always, for 1/2, 1/4, 1/8.

Downscaling in the sRGB space is mathematically incorrect, and always produces the wrong result. - my brief analysis seems to indicate that this has lead to reduced usage of the downscaling API over time. I think an improved implementation which assumes an sRGB-adjacent gamma would be acceptable for accelerating many applications (such as web browsers, thumbnail generation, etc). 

While averaging is not the ideal downscaling filter, the largest speed gains in most algorithms are found by reducing the quantity of active bytes in the CPU cache. By providing an image that is 2.1x wider than the display target (vs potentially 20x larger), the sampling window can easily fit in the cache and the algorithms are much more performant. I'm not aware of an instance where this would result in less than a 200% application speedup. For a properly tuned application, a 3-4x speedup is easily achieved. 