### PR TITLE
Fix various compile issues with CMake on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -895,8 +895,8 @@ if(WITH_TURBOJPEG)
   if(ENABLE_STATIC)
     install(TARGETS turbojpeg-static ARCHIVE DESTINATION lib)
     if(NOT ENABLE_SHARED)
-      install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/tjbench-static.exe
-        DESTINATION bin RENAME tjbench.exe)
+      install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/tjbench-static${CMAKE_EXECUTABLE_SUFFIX}
+        DESTINATION bin RENAME tjbench${CMAKE_EXECUTABLE_SUFFIX})
     endif()
   endif()
   install(FILES ${CMAKE_SOURCE_DIR}/turbojpeg.h DESTINATION include)
@@ -905,12 +905,12 @@ endif()
 if(ENABLE_STATIC)
   install(TARGETS jpeg-static ARCHIVE DESTINATION lib)
   if(NOT ENABLE_SHARED)
-    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/cjpeg-static.exe
-      DESTINATION bin RENAME cjpeg.exe)
-    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/djpeg-static.exe
-      DESTINATION bin RENAME djpeg.exe)
-    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/jpegtran-static.exe
-      DESTINATION bin RENAME jpegtran.exe)
+    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/cjpeg-static${CMAKE_EXECUTABLE_SUFFIX}
+      DESTINATION bin RENAME cjpeg${CMAKE_EXECUTABLE_SUFFIX})
+    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/djpeg-static${CMAKE_EXECUTABLE_SUFFIX}
+      DESTINATION bin RENAME djpeg${CMAKE_EXECUTABLE_SUFFIX})
+    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/jpegtran-static${CMAKE_EXECUTABLE_SUFFIX}
+      DESTINATION bin RENAME jpegtran${CMAKE_EXECUTABLE_SUFFIX})
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,9 @@ endif()
 
 message(STATUS "Install directory = ${CMAKE_INSTALL_PREFIX}")
 
+include(CheckTypeSize)
+check_type_size(size_t SIZEOF_SIZE_T)
+
 configure_file(win/jconfig.h.in jconfig.h)
 configure_file(win/jconfigint.h.in jconfigint.h)
 
@@ -296,11 +299,15 @@ if(WITH_TURBOJPEG)
 endif()
 
 if(WITH_12BIT)
-  set(COMPILE_FLAGS "-DGIF_SUPPORTED -DPPM_SUPPORTED -DUSE_SETMODE")
+  set(COMPILE_FLAGS "-DGIF_SUPPORTED -DPPM_SUPPORTED")
 else()
-  set(COMPILE_FLAGS "-DBMP_SUPPORTED -DGIF_SUPPORTED -DPPM_SUPPORTED -DTARGA_SUPPORTED -DUSE_SETMODE")
+  set(COMPILE_FLAGS "-DBMP_SUPPORTED -DGIF_SUPPORTED -DPPM_SUPPORTED -DTARGA_SUPPORTED")
   set(CJPEG_BMP_SOURCES rdbmp.c rdtarga.c)
   set(DJPEG_BMP_SOURCES wrbmp.c wrtarga.c)
+endif()
+
+if(WIN32)
+  add_definitions(-DUSE_SETMODE)
 endif()
 
 if(ENABLE_STATIC)
@@ -316,7 +323,7 @@ if(ENABLE_STATIC)
 
   add_executable(jpegtran-static jpegtran.c cdjpeg.c rdswitch.c transupp.c)
   target_link_libraries(jpegtran-static jpeg-static)
-  set_property(TARGET jpegtran-static PROPERTY COMPILE_FLAGS "-DUSE_SETMODE")
+  set_property(TARGET jpegtran-static PROPERTY COMPILE_FLAGS "")
 endif()
 
 add_executable(rdjpgcom rdjpgcom.c)

--- a/sharedlib/CMakeLists.txt
+++ b/sharedlib/CMakeLists.txt
@@ -43,11 +43,15 @@ if(WITH_SIMD)
 endif()
 
 if(WITH_12BIT)
-  set(COMPILE_FLAGS "-DGIF_SUPPORTED -DPPM_SUPPORTED -DUSE_SETMODE")
+  set(COMPILE_FLAGS "-DGIF_SUPPORTED -DPPM_SUPPORTED")
 else()
-  set(COMPILE_FLAGS "-DBMP_SUPPORTED -DGIF_SUPPORTED -DPPM_SUPPORTED -DTARGA_SUPPORTED -DUSE_SETMODE")
+  set(COMPILE_FLAGS "-DBMP_SUPPORTED -DGIF_SUPPORTED -DPPM_SUPPORTED -DTARGA_SUPPORTED")
 	set(CJPEG_BMP_SOURCES ../rdbmp.c ../rdtarga.c)
 	set(DJPEG_BMP_SOURCES ../wrbmp.c ../wrtarga.c)
+endif()
+
+if(WIN32)
+  add_definitions(-DUSE_SETMODE)
 endif()
 
 add_executable(cjpeg ../cjpeg.c ../cdjpeg.c ../rdgif.c ../rdppm.c
@@ -62,7 +66,7 @@ target_link_libraries(djpeg jpeg)
 
 add_executable(jpegtran ../jpegtran.c ../cdjpeg.c ../rdswitch.c ../transupp.c)
 target_link_libraries(jpegtran jpeg)
-set_property(TARGET jpegtran PROPERTY COMPILE_FLAGS "-DUSE_SETMODE")
+set_property(TARGET jpegtran PROPERTY COMPILE_FLAGS "")
 
 add_executable(jcstest ../jcstest.c)
 target_link_libraries(jcstest jpeg)

--- a/win/jconfigint.h.in
+++ b/win/jconfigint.h.in
@@ -11,3 +11,6 @@
 #define INLINE
 #endif
 #endif
+
+/* The size of `size_t', as computed by sizeof. */
+#define SIZEOF_SIZE_T @SIZEOF_SIZE_T@


### PR DESCRIPTION
This makes the CMake build work on Linux.  It includes the following changes:
* Compute and write SIZEOF_SIZE_T to the config.h file.
* Define the USE_SETMODE preprocessor definition only on Windows.
* Use CMAKE_EXECUTABLE_SUFFIX instead of hardcoding .exe.

Thanks!