### PR TITLE
Fix clang compatibility of jsimd_arm_neon.S

### DIFF
--- a/simd/jsimd_arm_neon.S
+++ b/simd/jsimd_arm_neon.S
@@ -2457,7 +2457,11 @@ asm_function jsimd_h2v1_fancy_upsample_neon
     strb            \TMP, [\BUFFER, #1]!
     cmp             \TMP, #0xff
     /*it eq*/
+#if defined(__clang__)
+    strbeq          \ZERO, [\BUFFER, #1]!
+#else
     streqb          \ZERO, [\BUFFER, #1]!
+#endif
 .endm
 
 .macro put_bits PUT_BUFFER, PUT_BITS, CODE, SIZE


### PR DESCRIPTION
Clang only supports Unified Assembler Language (and not pre-UAL syntax).  This is intentional.
https://llvm.org/bugs/show_bug.cgi?id=23507
http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0473c/BABJIHGJ.html

This means clang expects "strbeq" here.  Unfortunately, it seems that my version of gcc only supports "streqb".  So I think we need both variations here.