### PR TITLE
Return if a custom exit function does not terminate the process

### DIFF
--- a/jdapistd.c
+++ b/jdapistd.c
@@ -161,8 +161,10 @@ jpeg_crop_scanline (j_decompress_ptr cinfo, JDIMENSION *xoffset,
   if (cinfo->global_state != DSTATE_SCANNING || cinfo->output_scanline != 0)
     ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
 
-  if (!xoffset || !width)
+  if (!xoffset || !width) {
     ERREXIT(cinfo, JERR_BAD_CROP_SPEC);
+    return;
+  }
 
   /* xoffset and width must fall within the output image dimensions. */
   if (*width == 0 || *xoffset + *width > cinfo->output_width)


### PR DESCRIPTION
If a custom exit function does not terminate the process or raise an exception (in C++), the
dereferenced xoffset or width will crash in the next few lines.

This bug was found by Clang Static Analyzer.