### PR TITLE
Find nasm or yasm instead of hard coded as nasm.

### DIFF
--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOT DEFINED NASM)
-  set(NASM nasm CACHE FILEPATH "Path to NASM/YASM executable")
+  find_program(NASM NAMES nasm yasm DOC "Path to NASM/YASM executable")
 endif()
 
 if(SIMD_X86_64)


### PR DESCRIPTION
This is usefull if user has yasm installed and they don't need to specify NASM.

The original CMakeLists.txt will not use yasm if user not sepcified -DNASM=path/to/yasm.