### PR TITLE
Adds missing includes for stddef.h and stdio.h

### DIFF
--- a/jpeglib.h
+++ b/jpeglib.h
@@ -30,6 +30,8 @@
 #endif
 #include "jmorecfg.h"           /* seldom changed options */
 
+#include <stdio.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 #ifndef DONT_USE_EXTERN_C


### PR DESCRIPTION
This file uses `FILE*` and `size_t`