### PR TITLE
Add detection of Altivec for AmigaOS4

### DIFF
--- a/simd/jsimd_powerpc.c
+++ b/simd/jsimd_powerpc.c
@@ -14,6 +14,10 @@
  * PowerPC architecture.
  */
 
+#ifdef __amigaos4__
+#include <proto/exec.h>
+#endif
+
 #define JPEG_INTERNALS
 #include "../jinclude.h"
 #include "../jpeglib.h"
@@ -25,10 +29,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
-
-#ifdef __amigaos4__
-#include <proto/exec.h>
-#endif
 
 static unsigned int simd_support = ~0;
 
@@ -122,7 +122,7 @@ init_simd (void)
   }
 #elif defined(__amigaos4__)
   uint32 altivec = 0;
-  GetCPUInfoTags(GCIT_VectorUnit, &altivec, TAG_DONE);
+  IExec->GetCPUInfoTags(GCIT_VectorUnit, &altivec, TAG_DONE);
   if(altivec == VECTORTYPE_ALTIVEC)
     simd_support |= JSIMD_ALTIVEC;
 #endif

--- a/simd/jsimd_powerpc.c
+++ b/simd/jsimd_powerpc.c
@@ -15,6 +15,7 @@
  */
 
 #ifdef __amigaos4__
+/* This must be defined first as it re-defines GLOBAL otherwise */
 #include <proto/exec.h>
 #endif
 

--- a/simd/jsimd_powerpc.c
+++ b/simd/jsimd_powerpc.c
@@ -26,6 +26,10 @@
 #include <string.h>
 #include <ctype.h>
 
+#ifdef __amigaos4__
+#include <proto/exec.h>
+#endif
+
 static unsigned int simd_support = ~0;
 
 #if defined(__linux__) || defined(ANDROID) || defined(__ANDROID__)
@@ -116,6 +120,11 @@ init_simd (void)
     if (bufsize > SOMEWHAT_SANE_PROC_CPUINFO_SIZE_LIMIT)
       break;
   }
+#elif defined(__amigaos4__)
+  uint32 altivec = 0;
+  GetCPUInfoTags(GCIT_VectorUnit, &altivec, TAG_DONE);
+  if(altivec == VECTORTYPE_ALTIVEC)
+    simd_support |= JSIMD_ALTIVEC;
 #endif
 
   /* Force different settings through environment variables */


### PR DESCRIPTION
This patch adds detection of Altivec on the AmigaOS 4 (PowerPC) operating system.