### PR TITLE
Detect AltiVec support on OpenBSD

### DIFF
--- a/simd/jsimd_powerpc.c
+++ b/simd/jsimd_powerpc.c
@@ -31,6 +31,12 @@
 #include <string.h>
 #include <ctype.h>
 
+#if defined(__OpenBSD__)
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#include <machine/cpu.h>
+#endif
+
 static unsigned int simd_support = ~0;
 
 #if defined(__linux__) || defined(ANDROID) || defined(__ANDROID__)
@@ -125,6 +131,12 @@ init_simd (void)
   uint32 altivec = 0;
   IExec->GetCPUInfoTags(GCIT_VectorUnit, &altivec, TAG_DONE);
   if(altivec == VECTORTYPE_ALTIVEC)
+    simd_support |= JSIMD_ALTIVEC;
+#elif defined(__OpenBSD__)
+  int mib[2] = { CTL_MACHDEP, CPU_ALTIVEC };
+  int altivec;
+  size_t len = sizeof(altivec);
+  if (sysctl(mib, 2, &altivec, &len, NULL, 0) == 0 && altivec != 0)
     simd_support |= JSIMD_ALTIVEC;
 #endif
 


### PR DESCRIPTION
This is similar to what has been done in 4ad94b2963268ea57a77dcd8af8a9a6fe5db70a7 for AmigaOS 4.

This lets OpenBSD detect which PPC CPUs have AltiVec support, at runtime.

This patch (backported for 1.5.1) has just been added in OpenBSD -current:
http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/graphics/jpeg/patches/patch-simd_jsimd_powerpc_c

Tested on a G3 (no AltiVec) and a G5 (with AltiVec).