### PR TITLE
Add -ggdb flags when compiling in debug mode for MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,12 @@ message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
 # to set a variable's value based on the build type when using Visual Studio.
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(BUILD "${BUILD}d")
+  
+  # Add more debug information with gdb
+  if(MINGW)
+	  set (CMAKE_C_FLAGS "-ggdb" )
+	  set (CMAKE_CXX_FLAGS "-ggdb" )
+  endif()
 endif()
 
 message(STATUS "VERSION = ${VERSION}, BUILD = ${BUILD}")


### PR DESCRIPTION
When compiling for Windows with MinGW32 in debug mode, the option -ggdb must be added to get full symbols with the GNU debugger. Note, that the symbols are loaded only since gdb 7.7 in my case (but not with 7.2).