### PR TITLE
honor max_memory_to_use if its set

### DIFF
--- a/jmemnobs.c
+++ b/jmemnobs.c
@@ -66,14 +66,24 @@ jpeg_free_large (j_common_ptr cinfo, void *object, size_t sizeofobject)
 
 /*
  * This routine computes the total memory space available for allocation.
- * Here we always say, "we got all you want bud!"
  */
 
 GLOBAL(size_t)
 jpeg_mem_available (j_common_ptr cinfo, size_t min_bytes_needed,
                     size_t max_bytes_needed, size_t already_allocated)
 {
-  return max_bytes_needed;
+  if (!cinfo->mem->max_memory_to_use)
+  {
+    /* Here we always say, "we got all you want bud!" */
+    return max_bytes_needed;
+  }
+
+  if (cinfo->mem->max_memory_to_use - already_allocated >= max_bytes_needed)
+  {
+      return max_bytes_needed;
+  }
+
+  return cinfo->mem->max_memory_to_use - already_allocated;
 }
 
 


### PR DESCRIPTION
I'd like to use JPEGMEM to limit memory that libjpeg will allocate
to reject sizes that would trigger the default 2G limit under asan
while fuzzing LibreOffice's jpeg integration