### PR TITLE
Use precise #if conditional for JERR_ARITH_NOTIMPL

### DIFF
--- a/jerror.h
+++ b/jerror.h
@@ -43,7 +43,7 @@ typedef enum {
 JMESSAGE(JMSG_NOMESSAGE, "Bogus message code %d") /* Must be first entry! */
 
 /* For maintenance convenience, list is alphabetical by message code name */
-#if JPEG_LIB_VERSION < 70
+#if !defined(C_ARITH_CODING_SUPPORTED) || !defined(D_ARITH_CODING_SUPPORTED)
 JMESSAGE(JERR_ARITH_NOTIMPL,
          "Sorry, arithmetic coding is not implemented")
 #endif


### PR DESCRIPTION
**Issue**

The current `jerror.h` just checks on the version number to decide whether it should include the `JERR_ARITH_NOTIMPL` error message. However, all call-sites are (correctly) only depending on `C_ARITH_CODING_SUPPORTED` and `D_ARITH_CODING_SUPPORTED`.  [Click here for all usages in this repo](https://github.com/libjpeg-turbo/libjpeg-turbo/search?utf8=%E2%9C%93&q=JERR_ARITH_NOTIMPL&type=)

This might seem a bit nitty since currently `configure.ac` ensures that arithmetic coding is always enabled for `JPEG_LIB_VERSION >= 70`. However, if using alternative build environments this is something one would stumble on. Also, it's also better to rely on the preprocessor than the configure script and it makes this more robust to future changes.

**Repro**

We can reproduce the scenario by temporarily disabling the override in `configure.ac`. See patch at the end to test locally.

```
$ git apply ~/remove_version_override.patch # see appendix below
$ autoreconf -fiv
$ ./configure --with-jpeg8 --without-arith-enc --without-arith-dec
...
checking whether to include arithmetic encoding support... no
checking whether to include arithmetic decoding support... no
...
$ make
...
  CC       jcinit.lo
jcinit.c:49:20: error: use of undeclared identifier 'JERR_ARITH_NOTIMPL'
    ERREXIT(cinfo, JERR_ARITH_NOTIMPL);
                   ^
1 error generated.
...
```

**After the fix**

```
$ git apply ~/remove_version_override.patch # see appendix below
$ autoreconf -fiv
$ ./configure --with-jpeg8 --without-arith-enc --without-arith-dec
...
checking whether to include arithmetic encoding support... no
checking whether to include arithmetic decoding support... no
...
$ make
...
  CC       jcstest.o
  CCLD     jcstest
  CCLD     tjunittest
$ echo $?
0
$ make test
...
echo GREAT SUCCESS!
GREAT SUCCESS!
```

**Appendix: remove_version_override.patch**

```
diff --git a/configure.ac b/configure.ac
index 5766b87..0a24f3c 100644
--- a/configure.ac
+++ b/configure.ac
@@ -293,9 +293,6 @@ AC_ARG_WITH([arith-enc],
 if test "x$with_12bit" = "xyes"; then
   with_arith_enc=no
 fi
-if test "x${with_jpeg8}" = "xyes" -o "x${with_jpeg7}" = "xyes"; then
-  with_arith_enc=yes
-fi
 if test "x$with_arith_enc" = "xno"; then
   AC_MSG_RESULT(no)
   RPM_CONFIG_ARGS="$RPM_CONFIG_ARGS --without-arith-enc"
@@ -312,9 +309,6 @@ AC_ARG_WITH([arith-dec],
 if test "x$with_12bit" = "xyes"; then
   with_arith_dec=no
 fi
-if test "x${with_jpeg8}" = "xyes" -o "x${with_jpeg7}" = "xyes"; then
-  with_arith_dec=yes
-fi
 if test "x$with_arith_dec" = "xno"; then
   AC_MSG_RESULT(no)
   RPM_CONFIG_ARGS="$RPM_CONFIG_ARGS --without-arith-dec"
```
