### PR TITLE
Fix copy-paste oversight in comment

### DIFF
--- a/wrjpgcom.c
+++ b/wrjpgcom.c
@@ -247,7 +247,7 @@ copy_variable (void)
   if (length < 2)
     ERREXIT("Erroneous JPEG marker length");
   length -= 2;
-  /* Skip over the remaining bytes */
+  /* Copy the remaining bytes */
   while (length > 0) {
     write_1_byte(read_1_byte());
     length--;


### PR DESCRIPTION
Comment was a copy-paste of the one in the function below and was not modified.