### PR TITLE
Add support for out-of-source build and support for adding the librar…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,7 @@ if(ENABLE_STATIC OR WITH_TURBOJPEG)
   add_library(jpeg-static STATIC ${JPEG_SOURCES} ${SIMD_OBJS})
   if(NOT MSVC)
     set_target_properties(jpeg-static PROPERTIES OUTPUT_NAME jpeg)
+    target_include_directories(jpeg-staic PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
   endif()
   if(WITH_SIMD)
     add_dependencies(jpeg-static simd)
@@ -278,6 +279,7 @@ if(WITH_TURBOJPEG)
     endif()
     target_link_libraries(turbojpeg jpeg-static)
     set_target_properties(turbojpeg PROPERTIES LINK_INTERFACE_LIBRARIES "")
+    target_include_directories(turbojpeg PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
     add_executable(tjunittest tjunittest.c tjutil.c)
     target_link_libraries(tjunittest turbojpeg)
@@ -287,6 +289,7 @@ if(WITH_TURBOJPEG)
     target_link_libraries(tjbench turbojpeg jpeg-static)
     set_property(TARGET tjbench PROPERTY COMPILE_FLAGS
       "-DBMP_SUPPORTED -DPPM_SUPPORTED")
+    target_include_directories(tjbench PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
   endif()
 
   if(ENABLE_STATIC)
@@ -298,6 +301,7 @@ if(WITH_TURBOJPEG)
     if(WITH_SIMD)
       add_dependencies(turbojpeg-static simd)
     endif()
+    target_include_directories(turbojpeg-static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
     add_executable(tjunittest-static tjunittest.c tjutil.c)
     target_link_libraries(tjunittest-static turbojpeg-static)
@@ -307,6 +311,7 @@ if(WITH_TURBOJPEG)
     target_link_libraries(tjbench-static turbojpeg-static jpeg-static)
     set_property(TARGET tjbench-static PROPERTY COMPILE_FLAGS
       "-DBMP_SUPPORTED -DPPM_SUPPORTED")
+    target_include_directories(tjbench-static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
   endif()
 endif()
 
@@ -929,7 +934,7 @@ if(WITH_TURBOJPEG)
         DESTINATION bin RENAME tjbench.exe)
     endif()
   endif()
-  install(FILES ${CMAKE_SOURCE_DIR}/turbojpeg.h DESTINATION include)
+  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/turbojpeg.h DESTINATION include)
 endif()
 
 if(ENABLE_STATIC)
@@ -946,17 +951,17 @@ endif()
 
 install(TARGETS rdjpgcom wrjpgcom RUNTIME DESTINATION bin)
 
-install(FILES ${CMAKE_SOURCE_DIR}/README.ijg ${CMAKE_SOURCE_DIR}/README.md
-  ${CMAKE_SOURCE_DIR}/example.c ${CMAKE_SOURCE_DIR}/libjpeg.txt
-  ${CMAKE_SOURCE_DIR}/structure.txt ${CMAKE_SOURCE_DIR}/usage.txt
-  ${CMAKE_SOURCE_DIR}/wizard.txt
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/README.ijg ${CMAKE_CURRENT_SOURCE_DIR}/README.md
+  ${CMAKE_CURRENT_SOURCE_DIR}/example.c ${CMAKE_CURRENT_SOURCE_DIR}/libjpeg.txt
+  ${CMAKE_CURRENT_SOURCE_DIR}/structure.txt ${CMAKE_CURRENT_SOURCE_DIR}/usage.txt
+  ${CMAKE_CURRENT_SOURCE_DIR}/wizard.txt
   DESTINATION doc)
 
-install(FILES ${CMAKE_BINARY_DIR}/jconfig.h ${CMAKE_SOURCE_DIR}/jerror.h
-  ${CMAKE_SOURCE_DIR}/jmorecfg.h ${CMAKE_SOURCE_DIR}/jpeglib.h
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/jconfig.h ${CMAKE_CURRENT_SOURCE_DIR}/jerror.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/jmorecfg.h ${CMAKE_CURRENT_SOURCE_DIR}/jpeglib.h
   DESTINATION include)
 
-configure_file("${CMAKE_SOURCE_DIR}/cmakescripts/cmake_uninstall.cmake.in"
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmakescripts/cmake_uninstall.cmake.in"
   "cmake_uninstall.cmake" IMMEDIATE @ONLY)
 
 add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P cmake_uninstall.cmake)

--- a/sharedlib/CMakeLists.txt
+++ b/sharedlib/CMakeLists.txt
@@ -16,7 +16,7 @@ if(MSVC)
 endif()
 
 foreach(src ${JPEG_SOURCES})
-  set(JPEG_SRCS ${JPEG_SRCS} ${CMAKE_SOURCE_DIR}/${src})
+  set(JPEG_SRCS ${JPEG_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/../${src})
 endforeach()
 
 if(WITH_SIMD)
@@ -26,10 +26,10 @@ endif()
 
 if(WITH_MEM_SRCDST AND NOT WITH_JPEG8)
   add_library(jpeg SHARED ${JPEG_SRCS} ${SIMD_OBJS}
-    ${CMAKE_SOURCE_DIR}/win/jpeg${DLL_VERSION}-memsrcdst.def)
+    ${CMAKE_CURRENT_SOURCE_DIR}/../win/jpeg${DLL_VERSION}-memsrcdst.def)
 else()
   add_library(jpeg SHARED ${JPEG_SRCS} ${SIMD_OBJS}
-    ${CMAKE_SOURCE_DIR}/win/jpeg${DLL_VERSION}.def)
+    ${CMAKE_CURRENT_SOURCE_DIR}/../win/jpeg${DLL_VERSION}.def)
 endif()
 set_target_properties(jpeg PROPERTIES SOVERSION ${DLL_VERSION}
   VERSION ${FULLVERSION})
@@ -66,6 +66,7 @@ set_property(TARGET jpegtran PROPERTY COMPILE_FLAGS "-DUSE_SETMODE")
 
 add_executable(jcstest ../jcstest.c)
 target_link_libraries(jcstest jpeg)
+target_include_directories(jcstest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../)
 
 install(TARGETS jpeg cjpeg djpeg jpegtran
   ARCHIVE DESTINATION lib

--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -12,7 +12,7 @@ else()
     set(NAFLAGS -fwin32 -DWIN32)
   endif()
 endif()
-set(NAFLAGS ${NAFLAGS} -I${CMAKE_SOURCE_DIR}/win/ -I${CMAKE_CURRENT_SOURCE_DIR}/)
+set(NAFLAGS ${NAFLAGS} -I${CMAKE_CURRENT_SOURCE_DIR}/../win/ -I${CMAKE_CURRENT_SOURCE_DIR}/)
 
 # This only works if building from the command line.  There is currently no way
 # to set a variable's value based on the build type when using the MSVC IDE.
@@ -45,7 +45,7 @@ else()
   set(OBJDIR ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
-file(GLOB INC_FILES *.inc)
+file(GLOB INC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.inc)
 
 foreach(file ${SIMD_BASENAMES})
   set(DEPFILE "")


### PR DESCRIPTION
…y to a parent project using add_subdirectory directive.

The tested builds are made with the default libjpeg-turbo configuration flags on Windows platform using Visual Studio studio generator. The tests include in-source and out-of-source builds, and also building the lib as part of a parent CMakeLists.txt, such as the following:
```
cmake_minimum_required (VERSION 2.6)
set(CMAKE_CONFIGURATION_TYPES "Debug;Release")

add_subdirectory(libjpeg-turbo "libjpeg-turbo_build")
```

CMake was invoked with following command line commands:

```
cmake -DCMAKE_INSTALL_PREFIX=C:/install .\CMakeLists.txt
cmake --build . --target install
```