### PR TITLE
Handle NULL buffer when discarding rows

### DIFF
--- a/jdpostct.c
+++ b/jdpostct.c
@@ -132,6 +132,11 @@ post_process_1pass (j_decompress_ptr cinfo,
   my_post_ptr post = (my_post_ptr) cinfo->post;
   JDIMENSION num_rows, max_rows;
 
+  /* read_and_discard_scanlines may call it with rows "available", but no buffer */
+  if (output_buf == NULL) {
+    return;
+  }
+
   /* Fill the buffer, but not more than what we can dump out in one go. */
   /* Note we rely on the upsampler to detect bottom of image. */
   max_rows = out_rows_avail - *out_row_ctr;

--- a/jerror.h
+++ b/jerror.h
@@ -208,6 +208,7 @@ JMESSAGE(JERR_NO_ARITH_TABLE, "Arithmetic table 0x%02x was not defined")
 JMESSAGE(JWRN_ARITH_BAD_CODE, "Corrupt JPEG data: bad arithmetic code")
 #endif
 #endif
+JMESSAGE(JERR_BAD_PARAM, "Bogus parameter")
 
 #ifdef JMAKE_ENUM_LIST
 

--- a/jquant1.c
+++ b/jquant1.c
@@ -531,6 +531,10 @@ quantize_ord_dither (j_decompress_ptr cinfo, JSAMPARRAY input_buf,
   JDIMENSION col;
   JDIMENSION width = cinfo->output_width;
 
+  if (output_buf == NULL && num_rows) {
+    ERREXIT(cinfo, JERR_BAD_PARAM);
+  }
+
   for (row = 0; row < num_rows; row++) {
     /* Initialize output values to 0 so can process components separately */
     jzero_far((void *) output_buf[row], (size_t) (width * sizeof(JSAMPLE)));


### PR DESCRIPTION
I've got a report about a crash:

https://github.com/mozilla/mozjpeg/issues/268

I've handled in the function that crashed (jquant1.c) as well as up the stack in the function that was the real cause of it (`read_and_discard_scanlines` uses `NULL` buffer and expects that to be handled gracefully).