### PR TITLE
Private simd symbols

### DIFF
--- a/simd/arm/jsimd_neon.S
+++ b/simd/arm/jsimd_neon.S
@@ -46,6 +46,7 @@
 /* Supplementary macro for setting function attributes */
 .macro asm_function fname
 #ifdef __APPLE__
+    .private_extern _\fname
     .globl _\fname
 _\fname:
 #else

--- a/simd/arm/jsimd_neon.S
+++ b/simd/arm/jsimd_neon.S
@@ -7,7 +7,7 @@
  * Copyright (C) 2014, Siarhei Siamashka.  All Rights Reserved.
  * Copyright (C) 2014, Linaro Limited.  All Rights Reserved.
  * Copyright (C) 2015, D. R. Commander.  All Rights Reserved.
- * Copyright (C) 2015-2016, Matthieu Darbois.  All Rights Reserved.
+ * Copyright (C) 2015-2016, 2018, Matthieu Darbois.  All Rights Reserved.
  *
  * This software is provided 'as-is', without any express or implied
  * warranty.  In no event will the authors be held liable for any damages

--- a/simd/arm64/jsimd_neon.S
+++ b/simd/arm64/jsimd_neon.S
@@ -7,7 +7,7 @@
  * Copyright (C) 2013-2014, Linaro Limited.  All Rights Reserved.
  * Author: Ragesh Radhakrishnan <ragesh.r@linaro.org>
  * Copyright (C) 2014-2016, D. R. Commander.  All Rights Reserved.
- * Copyright (C) 2015-2016, Matthieu Darbois.  All Rights Reserved.
+ * Copyright (C) 2015-2016, 2018, Matthieu Darbois.  All Rights Reserved.
  * Copyright (C) 2016, Siarhei Siamashka.  All Rights Reserved.
  *
  * This software is provided 'as-is', without any express or implied

--- a/simd/arm64/jsimd_neon.S
+++ b/simd/arm64/jsimd_neon.S
@@ -42,6 +42,7 @@
 /* Supplementary macro for setting function attributes */
 .macro asm_function fname
 #ifdef __APPLE__
+    .private_extern _\fname
     .globl _\fname
 _\fname:
 #else

--- a/simd/i386/jccolext-avx2.asm
+++ b/simd/i386/jccolext-avx2.asm
@@ -41,7 +41,7 @@
 
     align       32
 
-    global      EXTN(jsimd_rgb_ycc_convert_avx2)
+    GLOBAL_FUNCTION(jsimd_rgb_ycc_convert_avx2)
 
 EXTN(jsimd_rgb_ycc_convert_avx2):
     push        ebp

--- a/simd/i386/jccolext-mmx.asm
+++ b/simd/i386/jccolext-mmx.asm
@@ -40,7 +40,7 @@
 %define gotptr          wk(0)-SIZEOF_POINTER    ; void * gotptr
 
         align   32
-        global  EXTN(jsimd_rgb_ycc_convert_mmx)
+        GLOBAL_FUNCTION(jsimd_rgb_ycc_convert_mmx)
 
 EXTN(jsimd_rgb_ycc_convert_mmx):
         push    ebp

--- a/simd/i386/jccolext-sse2.asm
+++ b/simd/i386/jccolext-sse2.asm
@@ -40,7 +40,7 @@
 
     align       32
 
-    global      EXTN(jsimd_rgb_ycc_convert_sse2)
+    GLOBAL_FUNCTION(jsimd_rgb_ycc_convert_sse2)
 
 EXTN(jsimd_rgb_ycc_convert_sse2):
     push        ebp

--- a/simd/i386/jccolor-avx2.asm
+++ b/simd/i386/jccolor-avx2.asm
@@ -36,7 +36,7 @@ F_0_337 equ (F_0_587 - F_0_250)  ; FIX(0.58700) - FIX(0.25000)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_rgb_ycc_convert_avx2)
+    GLOBAL_DATA(jconst_rgb_ycc_convert_avx2)
 
 EXTN(jconst_rgb_ycc_convert_avx2):
 

--- a/simd/i386/jccolor-mmx.asm
+++ b/simd/i386/jccolor-mmx.asm
@@ -36,7 +36,7 @@ F_0_337 equ     (F_0_587 - F_0_250)     ; FIX(0.58700) - FIX(0.25000)
         SECTION SEG_CONST
 
         alignz  32
-        global  EXTN(jconst_rgb_ycc_convert_mmx)
+        GLOBAL_DATA(jconst_rgb_ycc_convert_mmx)
 
 EXTN(jconst_rgb_ycc_convert_mmx):
 

--- a/simd/i386/jccolor-sse2.asm
+++ b/simd/i386/jccolor-sse2.asm
@@ -35,7 +35,7 @@ F_0_337 equ (F_0_587 - F_0_250)  ; FIX(0.58700) - FIX(0.25000)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_rgb_ycc_convert_sse2)
+    GLOBAL_DATA(jconst_rgb_ycc_convert_sse2)
 
 EXTN(jconst_rgb_ycc_convert_sse2):
 

--- a/simd/i386/jcgray-avx2.asm
+++ b/simd/i386/jcgray-avx2.asm
@@ -32,7 +32,7 @@ F_0_337 equ (F_0_587 - F_0_250)  ; FIX(0.58700) - FIX(0.25000)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_rgb_gray_convert_avx2)
+    GLOBAL_DATA(jconst_rgb_gray_convert_avx2)
 
 EXTN(jconst_rgb_gray_convert_avx2):
 

--- a/simd/i386/jcgray-mmx.asm
+++ b/simd/i386/jcgray-mmx.asm
@@ -32,7 +32,7 @@ F_0_337 equ     (F_0_587 - F_0_250)     ; FIX(0.58700) - FIX(0.25000)
         SECTION SEG_CONST
 
         alignz  32
-        global  EXTN(jconst_rgb_gray_convert_mmx)
+        GLOBAL_DATA(jconst_rgb_gray_convert_mmx)
 
 EXTN(jconst_rgb_gray_convert_mmx):
 

--- a/simd/i386/jcgray-sse2.asm
+++ b/simd/i386/jcgray-sse2.asm
@@ -31,7 +31,7 @@ F_0_337 equ (F_0_587 - F_0_250)  ; FIX(0.58700) - FIX(0.25000)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_rgb_gray_convert_sse2)
+    GLOBAL_DATA(jconst_rgb_gray_convert_sse2)
 
 EXTN(jconst_rgb_gray_convert_sse2):
 

--- a/simd/i386/jcgryext-avx2.asm
+++ b/simd/i386/jcgryext-avx2.asm
@@ -41,7 +41,7 @@
 
     align       32
 
-    global      EXTN(jsimd_rgb_gray_convert_avx2)
+    GLOBAL_FUNCTION(jsimd_rgb_gray_convert_avx2)
 
 EXTN(jsimd_rgb_gray_convert_avx2):
     push        ebp

--- a/simd/i386/jcgryext-mmx.asm
+++ b/simd/i386/jcgryext-mmx.asm
@@ -40,7 +40,7 @@
 %define gotptr          wk(0)-SIZEOF_POINTER    ; void * gotptr
 
         align   32
-        global  EXTN(jsimd_rgb_gray_convert_mmx)
+        GLOBAL_FUNCTION(jsimd_rgb_gray_convert_mmx)
 
 EXTN(jsimd_rgb_gray_convert_mmx):
         push    ebp

--- a/simd/i386/jcgryext-sse2.asm
+++ b/simd/i386/jcgryext-sse2.asm
@@ -40,7 +40,7 @@
 
     align       32
 
-    global      EXTN(jsimd_rgb_gray_convert_sse2)
+    GLOBAL_FUNCTION(jsimd_rgb_gray_convert_sse2)
 
 EXTN(jsimd_rgb_gray_convert_sse2):
     push        ebp

--- a/simd/i386/jchuff-sse2.asm
+++ b/simd/i386/jchuff-sse2.asm
@@ -26,7 +26,7 @@
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_huff_encode_one_block)
+    GLOBAL_DATA(jconst_huff_encode_one_block)
 
 EXTN(jconst_huff_encode_one_block):
 
@@ -179,7 +179,7 @@ EXTN(jconst_huff_encode_one_block):
 %define put_bits    edi
 
     align       32
-    global      EXTN(jsimd_huff_encode_one_block_sse2)
+    GLOBAL_FUNCTION(jsimd_huff_encode_one_block_sse2)
 
 EXTN(jsimd_huff_encode_one_block_sse2):
     push        ebp

--- a/simd/i386/jcsample-avx2.asm
+++ b/simd/i386/jcsample-avx2.asm
@@ -41,7 +41,7 @@
 %define output_data(b)  (b)+28          ; JSAMPARRAY output_data
 
     align       32
-    global      EXTN(jsimd_h2v1_downsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v1_downsample_avx2)
 
 EXTN(jsimd_h2v1_downsample_avx2):
     push        ebp
@@ -213,7 +213,7 @@ EXTN(jsimd_h2v1_downsample_avx2):
 %define output_data(b)  (b)+28          ; JSAMPARRAY output_data
 
     align       32
-    global      EXTN(jsimd_h2v2_downsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v2_downsample_avx2)
 
 EXTN(jsimd_h2v2_downsample_avx2):
     push        ebp

--- a/simd/i386/jcsample-mmx.asm
+++ b/simd/i386/jcsample-mmx.asm
@@ -40,7 +40,7 @@
 %define output_data(b)  (b)+28          ; JSAMPARRAY output_data
 
         align   32
-        global  EXTN(jsimd_h2v1_downsample_mmx)
+        GLOBAL_FUNCTION(jsimd_h2v1_downsample_mmx)
 
 EXTN(jsimd_h2v1_downsample_mmx):
         push    ebp
@@ -182,7 +182,7 @@ EXTN(jsimd_h2v1_downsample_mmx):
 %define output_data(b)  (b)+28          ; JSAMPARRAY output_data
 
         align   32
-        global  EXTN(jsimd_h2v2_downsample_mmx)
+        GLOBAL_FUNCTION(jsimd_h2v2_downsample_mmx)
 
 EXTN(jsimd_h2v2_downsample_mmx):
         push    ebp

--- a/simd/i386/jcsample-sse2.asm
+++ b/simd/i386/jcsample-sse2.asm
@@ -40,7 +40,7 @@
 %define output_data(b)  (b)+28          ; JSAMPARRAY output_data
 
     align       32
-    global      EXTN(jsimd_h2v1_downsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v1_downsample_sse2)
 
 EXTN(jsimd_h2v1_downsample_sse2):
     push        ebp
@@ -195,7 +195,7 @@ EXTN(jsimd_h2v1_downsample_sse2):
 %define output_data(b)  (b)+28          ; JSAMPARRAY output_data
 
     align       32
-    global      EXTN(jsimd_h2v2_downsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v2_downsample_sse2)
 
 EXTN(jsimd_h2v2_downsample_sse2):
     push        ebp

--- a/simd/i386/jdcolext-avx2.asm
+++ b/simd/i386/jdcolext-avx2.asm
@@ -41,7 +41,7 @@
 %define gotptr        wk(0)-SIZEOF_POINTER  ; void * gotptr
 
     align       32
-    global      EXTN(jsimd_ycc_rgb_convert_avx2)
+    GLOBAL_FUNCTION(jsimd_ycc_rgb_convert_avx2)
 
 EXTN(jsimd_ycc_rgb_convert_avx2):
     push        ebp

--- a/simd/i386/jdcolext-mmx.asm
+++ b/simd/i386/jdcolext-mmx.asm
@@ -40,7 +40,7 @@
 %define gotptr          wk(0)-SIZEOF_POINTER    ; void * gotptr
 
         align   32
-        global  EXTN(jsimd_ycc_rgb_convert_mmx)
+        GLOBAL_FUNCTION(jsimd_ycc_rgb_convert_mmx)
 
 EXTN(jsimd_ycc_rgb_convert_mmx):
         push    ebp

--- a/simd/i386/jdcolext-sse2.asm
+++ b/simd/i386/jdcolext-sse2.asm
@@ -40,7 +40,7 @@
 %define gotptr        wk(0)-SIZEOF_POINTER  ; void * gotptr
 
     align       32
-    global      EXTN(jsimd_ycc_rgb_convert_sse2)
+    GLOBAL_FUNCTION(jsimd_ycc_rgb_convert_sse2)
 
 EXTN(jsimd_ycc_rgb_convert_sse2):
     push        ebp

--- a/simd/i386/jdcolor-avx2.asm
+++ b/simd/i386/jdcolor-avx2.asm
@@ -35,7 +35,7 @@ F_0_228 equ (131072 - F_1_772)  ; FIX(2) - FIX(1.77200)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_ycc_rgb_convert_avx2)
+    GLOBAL_DATA(jconst_ycc_rgb_convert_avx2)
 
 EXTN(jconst_ycc_rgb_convert_avx2):
 

--- a/simd/i386/jdcolor-mmx.asm
+++ b/simd/i386/jdcolor-mmx.asm
@@ -34,7 +34,7 @@ F_0_228 equ     (131072 - F_1_772)      ; FIX(2) - FIX(1.77200)
         SECTION SEG_CONST
 
         alignz  32
-        global  EXTN(jconst_ycc_rgb_convert_mmx)
+        GLOBAL_DATA(jconst_ycc_rgb_convert_mmx)
 
 EXTN(jconst_ycc_rgb_convert_mmx):
 

--- a/simd/i386/jdcolor-sse2.asm
+++ b/simd/i386/jdcolor-sse2.asm
@@ -34,7 +34,7 @@ F_0_228 equ (131072 - F_1_772)  ; FIX(2) - FIX(1.77200)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_ycc_rgb_convert_sse2)
+    GLOBAL_DATA(jconst_ycc_rgb_convert_sse2)
 
 EXTN(jconst_ycc_rgb_convert_sse2):
 

--- a/simd/i386/jdmerge-avx2.asm
+++ b/simd/i386/jdmerge-avx2.asm
@@ -35,7 +35,7 @@ F_0_228 equ (131072 - F_1_772)  ; FIX(2) - FIX(1.77200)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_merged_upsample_avx2)
+    GLOBAL_DATA(jconst_merged_upsample_avx2)
 
 EXTN(jconst_merged_upsample_avx2):
 

--- a/simd/i386/jdmerge-mmx.asm
+++ b/simd/i386/jdmerge-mmx.asm
@@ -34,7 +34,7 @@ F_0_228 equ     (131072 - F_1_772)      ; FIX(2) - FIX(1.77200)
         SECTION SEG_CONST
 
         alignz  32
-        global  EXTN(jconst_merged_upsample_mmx)
+        GLOBAL_DATA(jconst_merged_upsample_mmx)
 
 EXTN(jconst_merged_upsample_mmx):
 

--- a/simd/i386/jdmerge-sse2.asm
+++ b/simd/i386/jdmerge-sse2.asm
@@ -34,7 +34,7 @@ F_0_228 equ (131072 - F_1_772)  ; FIX(2) - FIX(1.77200)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_merged_upsample_sse2)
+    GLOBAL_DATA(jconst_merged_upsample_sse2)
 
 EXTN(jconst_merged_upsample_sse2):
 

--- a/simd/i386/jdmrgext-avx2.asm
+++ b/simd/i386/jdmrgext-avx2.asm
@@ -41,7 +41,7 @@
 %define gotptr        wk(0)-SIZEOF_POINTER  ; void * gotptr
 
     align       32
-    global      EXTN(jsimd_h2v1_merged_upsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v1_merged_upsample_avx2)
 
 EXTN(jsimd_h2v1_merged_upsample_avx2):
     push        ebp
@@ -521,7 +521,7 @@ EXTN(jsimd_h2v1_merged_upsample_avx2):
 %define output_buf(b)        (b)+20     ; JSAMPARRAY output_buf
 
     align       32
-    global      EXTN(jsimd_h2v2_merged_upsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v2_merged_upsample_avx2)
 
 EXTN(jsimd_h2v2_merged_upsample_avx2):
     push        ebp

--- a/simd/i386/jdmrgext-mmx.asm
+++ b/simd/i386/jdmrgext-mmx.asm
@@ -40,7 +40,7 @@
 %define gotptr          wk(0)-SIZEOF_POINTER    ; void * gotptr
 
         align   32
-        global  EXTN(jsimd_h2v1_merged_upsample_mmx)
+        GLOBAL_FUNCTION(jsimd_h2v1_merged_upsample_mmx)
 
 EXTN(jsimd_h2v1_merged_upsample_mmx):
         push    ebp
@@ -409,7 +409,7 @@ EXTN(jsimd_h2v1_merged_upsample_mmx):
 %define output_buf(b)           (b)+20          ; JSAMPARRAY output_buf
 
         align   32
-        global  EXTN(jsimd_h2v2_merged_upsample_mmx)
+        GLOBAL_FUNCTION(jsimd_h2v2_merged_upsample_mmx)
 
 EXTN(jsimd_h2v2_merged_upsample_mmx):
         push    ebp

--- a/simd/i386/jdmrgext-sse2.asm
+++ b/simd/i386/jdmrgext-sse2.asm
@@ -40,7 +40,7 @@
 %define gotptr        wk(0)-SIZEOF_POINTER  ; void * gotptr
 
     align       32
-    global      EXTN(jsimd_h2v1_merged_upsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v1_merged_upsample_sse2)
 
 EXTN(jsimd_h2v1_merged_upsample_sse2):
     push        ebp
@@ -463,7 +463,7 @@ EXTN(jsimd_h2v1_merged_upsample_sse2):
 %define output_buf(b)        (b)+20     ; JSAMPARRAY output_buf
 
     align       32
-    global      EXTN(jsimd_h2v2_merged_upsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v2_merged_upsample_sse2)
 
 EXTN(jsimd_h2v2_merged_upsample_sse2):
     push        ebp

--- a/simd/i386/jdsample-avx2.asm
+++ b/simd/i386/jdsample-avx2.asm
@@ -23,7 +23,7 @@
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_fancy_upsample_avx2)
+    GLOBAL_DATA(jconst_fancy_upsample_avx2)
 
 EXTN(jconst_fancy_upsample_avx2):
 
@@ -59,7 +59,7 @@ PW_EIGHT times 16 dw 8
 %define output_data_ptr(b)  (b)+20      ; JSAMPARRAY *output_data_ptr
 
     align       32
-    global      EXTN(jsimd_h2v1_fancy_upsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v1_fancy_upsample_avx2)
 
 EXTN(jsimd_h2v1_fancy_upsample_avx2):
     push        ebp
@@ -225,7 +225,7 @@ EXTN(jsimd_h2v1_fancy_upsample_avx2):
 %define gotptr        wk(0)-SIZEOF_POINTER  ; void *gotptr
 
     align       32
-    global      EXTN(jsimd_h2v2_fancy_upsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v2_fancy_upsample_avx2)
 
 EXTN(jsimd_h2v2_fancy_upsample_avx2):
     push        ebp
@@ -570,7 +570,7 @@ EXTN(jsimd_h2v2_fancy_upsample_avx2):
 %define output_data_ptr(b)  (b)+20      ; JSAMPARRAY *output_data_ptr
 
     align       32
-    global      EXTN(jsimd_h2v1_upsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v1_upsample_avx2)
 
 EXTN(jsimd_h2v1_upsample_avx2):
     push        ebp
@@ -671,7 +671,7 @@ EXTN(jsimd_h2v1_upsample_avx2):
 %define output_data_ptr(b)  (b)+20      ; JSAMPARRAY *output_data_ptr
 
     align       32
-    global      EXTN(jsimd_h2v2_upsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v2_upsample_avx2)
 
 EXTN(jsimd_h2v2_upsample_avx2):
     push        ebp

--- a/simd/i386/jdsample-mmx.asm
+++ b/simd/i386/jdsample-mmx.asm
@@ -22,7 +22,7 @@
         SECTION SEG_CONST
 
         alignz  32
-        global  EXTN(jconst_fancy_upsample_mmx)
+        GLOBAL_DATA(jconst_fancy_upsample_mmx)
 
 EXTN(jconst_fancy_upsample_mmx):
 
@@ -58,7 +58,7 @@ PW_EIGHT        times 4 dw  8
 %define output_data_ptr(b)      (b)+20          ; JSAMPARRAY *output_data_ptr
 
         align   32
-        global  EXTN(jsimd_h2v1_fancy_upsample_mmx)
+        GLOBAL_FUNCTION(jsimd_h2v1_fancy_upsample_mmx)
 
 EXTN(jsimd_h2v1_fancy_upsample_mmx):
         push    ebp
@@ -216,7 +216,7 @@ EXTN(jsimd_h2v1_fancy_upsample_mmx):
 %define gotptr          wk(0)-SIZEOF_POINTER    ; void *gotptr
 
         align   32
-        global  EXTN(jsimd_h2v2_fancy_upsample_mmx)
+        GLOBAL_FUNCTION(jsimd_h2v2_fancy_upsample_mmx)
 
 EXTN(jsimd_h2v2_fancy_upsample_mmx):
         push    ebp
@@ -542,7 +542,7 @@ EXTN(jsimd_h2v2_fancy_upsample_mmx):
 %define output_data_ptr(b)      (b)+20          ; JSAMPARRAY *output_data_ptr
 
         align   32
-        global  EXTN(jsimd_h2v1_upsample_mmx)
+        GLOBAL_FUNCTION(jsimd_h2v1_upsample_mmx)
 
 EXTN(jsimd_h2v1_upsample_mmx):
         push    ebp
@@ -643,7 +643,7 @@ EXTN(jsimd_h2v1_upsample_mmx):
 %define output_data_ptr(b)      (b)+20          ; JSAMPARRAY *output_data_ptr
 
         align   32
-        global  EXTN(jsimd_h2v2_upsample_mmx)
+        GLOBAL_FUNCTION(jsimd_h2v2_upsample_mmx)
 
 EXTN(jsimd_h2v2_upsample_mmx):
         push    ebp

--- a/simd/i386/jdsample-sse2.asm
+++ b/simd/i386/jdsample-sse2.asm
@@ -22,7 +22,7 @@
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_fancy_upsample_sse2)
+    GLOBAL_DATA(jconst_fancy_upsample_sse2)
 
 EXTN(jconst_fancy_upsample_sse2):
 
@@ -58,7 +58,7 @@ PW_EIGHT times 8 dw 8
 %define output_data_ptr(b)  (b)+20      ; JSAMPARRAY *output_data_ptr
 
     align       32
-    global      EXTN(jsimd_h2v1_fancy_upsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v1_fancy_upsample_sse2)
 
 EXTN(jsimd_h2v1_fancy_upsample_sse2):
     push        ebp
@@ -214,7 +214,7 @@ EXTN(jsimd_h2v1_fancy_upsample_sse2):
 %define gotptr        wk(0)-SIZEOF_POINTER  ; void *gotptr
 
     align       32
-    global      EXTN(jsimd_h2v2_fancy_upsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v2_fancy_upsample_sse2)
 
 EXTN(jsimd_h2v2_fancy_upsample_sse2):
     push        ebp
@@ -538,7 +538,7 @@ EXTN(jsimd_h2v2_fancy_upsample_sse2):
 %define output_data_ptr(b)  (b)+20      ; JSAMPARRAY *output_data_ptr
 
     align       32
-    global      EXTN(jsimd_h2v1_upsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v1_upsample_sse2)
 
 EXTN(jsimd_h2v1_upsample_sse2):
     push        ebp
@@ -637,7 +637,7 @@ EXTN(jsimd_h2v1_upsample_sse2):
 %define output_data_ptr(b)  (b)+20      ; JSAMPARRAY *output_data_ptr
 
     align       32
-    global      EXTN(jsimd_h2v2_upsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v2_upsample_sse2)
 
 EXTN(jsimd_h2v2_upsample_sse2):
     push        ebp

--- a/simd/i386/jfdctflt-3dn.asm
+++ b/simd/i386/jfdctflt-3dn.asm
@@ -27,7 +27,7 @@
         SECTION SEG_CONST
 
         alignz  32
-        global  EXTN(jconst_fdct_float_3dnow)
+        GLOBAL_DATA(jconst_fdct_float_3dnow)
 
 EXTN(jconst_fdct_float_3dnow):
 
@@ -55,7 +55,7 @@ PD_1_306        times 2 dd  1.306562964876376527856643
 %define WK_NUM          2
 
         align   32
-        global  EXTN(jsimd_fdct_float_3dnow)
+        GLOBAL_FUNCTION(jsimd_fdct_float_3dnow)
 
 EXTN(jsimd_fdct_float_3dnow):
         push    ebp

--- a/simd/i386/jfdctflt-sse.asm
+++ b/simd/i386/jfdctflt-sse.asm
@@ -37,7 +37,7 @@
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_fdct_float_sse)
+    GLOBAL_DATA(jconst_fdct_float_sse)
 
 EXTN(jconst_fdct_float_sse):
 
@@ -65,7 +65,7 @@ PD_1_306 times 4 dd 1.306562964876376527856643
 %define WK_NUM        2
 
     align       32
-    global      EXTN(jsimd_fdct_float_sse)
+    GLOBAL_FUNCTION(jsimd_fdct_float_sse)
 
 EXTN(jsimd_fdct_float_sse):
     push        ebp

--- a/simd/i386/jfdctfst-mmx.asm
+++ b/simd/i386/jfdctfst-mmx.asm
@@ -52,7 +52,7 @@ F_1_306 equ     DESCALE(1402911301,30-CONST_BITS)       ; FIX(1.306562965)
 %define CONST_SHIFT     (16 - PRE_MULTIPLY_SCALE_BITS - CONST_BITS)
 
         alignz  32
-        global  EXTN(jconst_fdct_ifast_mmx)
+        GLOBAL_DATA(jconst_fdct_ifast_mmx)
 
 EXTN(jconst_fdct_ifast_mmx):
 
@@ -80,7 +80,7 @@ PW_F1306        times 4 dw  F_1_306 << CONST_SHIFT
 %define WK_NUM          2
 
         align   32
-        global  EXTN(jsimd_fdct_ifast_mmx)
+        GLOBAL_FUNCTION(jsimd_fdct_ifast_mmx)
 
 EXTN(jsimd_fdct_ifast_mmx):
         push    ebp

--- a/simd/i386/jfdctfst-sse2.asm
+++ b/simd/i386/jfdctfst-sse2.asm
@@ -52,7 +52,7 @@ F_1_306 equ DESCALE(1402911301, 30-CONST_BITS)  ; FIX(1.306562965)
 %define CONST_SHIFT              (16 - PRE_MULTIPLY_SCALE_BITS - CONST_BITS)
 
     alignz      32
-    global      EXTN(jconst_fdct_ifast_sse2)
+    GLOBAL_DATA(jconst_fdct_ifast_sse2)
 
 EXTN(jconst_fdct_ifast_sse2):
 
@@ -80,7 +80,7 @@ PW_F1306 times 8 dw F_1_306 << CONST_SHIFT
 %define WK_NUM        2
 
     align       32
-    global      EXTN(jsimd_fdct_ifast_sse2)
+    GLOBAL_FUNCTION(jsimd_fdct_ifast_sse2)
 
 EXTN(jsimd_fdct_ifast_sse2):
     push        ebp

--- a/simd/i386/jfdctint-avx2.asm
+++ b/simd/i386/jfdctint-avx2.asm
@@ -226,7 +226,7 @@ F_3_072 equ DESCALE(3299298341, 30-CONST_BITS)  ; FIX(3.072711026)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_fdct_islow_avx2)
+    GLOBAL_DATA(jconst_fdct_islow_avx2)
 
 EXTN(jconst_fdct_islow_avx2):
 
@@ -259,7 +259,7 @@ PW_1_NEG1                  times 8  dw  1
 %define data(b)       (b)+8             ; DCTELEM *data
 
     align       32
-    global      EXTN(jsimd_fdct_islow_avx2)
+    GLOBAL_FUNCTION(jsimd_fdct_islow_avx2)
 
 EXTN(jsimd_fdct_islow_avx2):
     push        ebp

--- a/simd/i386/jfdctint-mmx.asm
+++ b/simd/i386/jfdctint-mmx.asm
@@ -66,7 +66,7 @@ F_3_072 equ     DESCALE(3299298341,30-CONST_BITS)       ; FIX(3.072711026)
         SECTION SEG_CONST
 
         alignz  32
-        global  EXTN(jconst_fdct_islow_mmx)
+        GLOBAL_DATA(jconst_fdct_islow_mmx)
 
 EXTN(jconst_fdct_islow_mmx):
 
@@ -101,7 +101,7 @@ PW_DESCALE_P2X  times 4 dw  1 << (PASS1_BITS-1)
 %define WK_NUM          2
 
         align   32
-        global  EXTN(jsimd_fdct_islow_mmx)
+        GLOBAL_FUNCTION(jsimd_fdct_islow_mmx)
 
 EXTN(jsimd_fdct_islow_mmx):
         push    ebp

--- a/simd/i386/jfdctint-sse2.asm
+++ b/simd/i386/jfdctint-sse2.asm
@@ -66,7 +66,7 @@ F_3_072 equ DESCALE(3299298341, 30-CONST_BITS)  ; FIX(3.072711026)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_fdct_islow_sse2)
+    GLOBAL_DATA(jconst_fdct_islow_sse2)
 
 EXTN(jconst_fdct_islow_sse2):
 
@@ -101,7 +101,7 @@ PW_DESCALE_P2X times 8 dw  1 << (PASS1_BITS-1)
 %define WK_NUM        6
 
     align       32
-    global      EXTN(jsimd_fdct_islow_sse2)
+    GLOBAL_FUNCTION(jsimd_fdct_islow_sse2)
 
 EXTN(jsimd_fdct_islow_sse2):
     push        ebp

--- a/simd/i386/jidctflt-3dn.asm
+++ b/simd/i386/jidctflt-3dn.asm
@@ -27,7 +27,7 @@
         SECTION SEG_CONST
 
         alignz  32
-        global  EXTN(jconst_idct_float_3dnow)
+        GLOBAL_DATA(jconst_idct_float_3dnow)
 
 EXTN(jconst_idct_float_3dnow):
 
@@ -63,7 +63,7 @@ PB_CENTERJSAMP  times 8 db  CENTERJSAMPLE
                                         ; FAST_FLOAT workspace[DCTSIZE2]
 
         align   32
-        global  EXTN(jsimd_idct_float_3dnow)
+        GLOBAL_FUNCTION(jsimd_idct_float_3dnow)
 
 EXTN(jsimd_idct_float_3dnow):
         push    ebp

--- a/simd/i386/jidctflt-sse.asm
+++ b/simd/i386/jidctflt-sse.asm
@@ -37,7 +37,7 @@
         SECTION SEG_CONST
 
         alignz  32
-        global  EXTN(jconst_idct_float_sse)
+        GLOBAL_DATA(jconst_idct_float_sse)
 
 EXTN(jconst_idct_float_sse):
 
@@ -73,7 +73,7 @@ PB_CENTERJSAMP  times 8 db  CENTERJSAMPLE
                                         ; FAST_FLOAT workspace[DCTSIZE2]
 
         align   32
-        global  EXTN(jsimd_idct_float_sse)
+        GLOBAL_FUNCTION(jsimd_idct_float_sse)
 
 EXTN(jsimd_idct_float_sse):
         push    ebp

--- a/simd/i386/jidctflt-sse2.asm
+++ b/simd/i386/jidctflt-sse2.asm
@@ -37,7 +37,7 @@
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_idct_float_sse2)
+    GLOBAL_DATA(jconst_idct_float_sse2)
 
 EXTN(jconst_idct_float_sse2):
 
@@ -73,7 +73,7 @@ PB_CENTERJSAMP  times 16 db  CENTERJSAMPLE
                                         ; FAST_FLOAT workspace[DCTSIZE2]
 
     align       32
-    global      EXTN(jsimd_idct_float_sse2)
+    GLOBAL_FUNCTION(jsimd_idct_float_sse2)
 
 EXTN(jsimd_idct_float_sse2):
     push        ebp

--- a/simd/i386/jidctfst-mmx.asm
+++ b/simd/i386/jidctfst-mmx.asm
@@ -59,7 +59,7 @@ F_1_613 equ     (F_2_613 - (1 << CONST_BITS))   ; FIX(2.613125930) - FIX(1)
 %define CONST_SHIFT     (16 - PRE_MULTIPLY_SCALE_BITS - CONST_BITS)
 
         alignz  32
-        global  EXTN(jconst_idct_ifast_mmx)
+        GLOBAL_DATA(jconst_idct_ifast_mmx)
 
 EXTN(jconst_idct_ifast_mmx):
 
@@ -94,7 +94,7 @@ PB_CENTERJSAMP  times 8 db  CENTERJSAMPLE
                                         ; JCOEF workspace[DCTSIZE2]
 
         align   32
-        global  EXTN(jsimd_idct_ifast_mmx)
+        GLOBAL_FUNCTION(jsimd_idct_ifast_mmx)
 
 EXTN(jsimd_idct_ifast_mmx):
         push    ebp

--- a/simd/i386/jidctfst-sse2.asm
+++ b/simd/i386/jidctfst-sse2.asm
@@ -59,7 +59,7 @@ F_1_613 equ (F_2_613 - (1 << CONST_BITS))       ; FIX(2.613125930) - FIX(1)
 %define CONST_SHIFT              (16 - PRE_MULTIPLY_SCALE_BITS - CONST_BITS)
 
     alignz      32
-    global      EXTN(jconst_idct_ifast_sse2)
+    GLOBAL_DATA(jconst_idct_ifast_sse2)
 
 EXTN(jconst_idct_ifast_sse2):
 
@@ -92,7 +92,7 @@ PB_CENTERJSAMP times 16 db  CENTERJSAMPLE
 %define WK_NUM         2
 
     align       32
-    global      EXTN(jsimd_idct_ifast_sse2)
+    GLOBAL_FUNCTION(jsimd_idct_ifast_sse2)
 
 EXTN(jsimd_idct_ifast_sse2):
     push        ebp

--- a/simd/i386/jidctint-avx2.asm
+++ b/simd/i386/jidctint-avx2.asm
@@ -253,7 +253,7 @@ F_3_072 equ DESCALE(3299298341, 30-CONST_BITS)  ; FIX(3.072711026)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_idct_islow_avx2)
+    GLOBAL_DATA(jconst_idct_islow_avx2)
 
 EXTN(jconst_idct_islow_avx2):
 
@@ -294,7 +294,7 @@ PW_1_NEG1                  times 8  dw  1
 %define WK_NUM         4
 
     align       32
-    global      EXTN(jsimd_idct_islow_avx2)
+    GLOBAL_FUNCTION(jsimd_idct_islow_avx2)
 
 EXTN(jsimd_idct_islow_avx2):
     push        ebp

--- a/simd/i386/jidctint-mmx.asm
+++ b/simd/i386/jidctint-mmx.asm
@@ -66,7 +66,7 @@ F_3_072 equ     DESCALE(3299298341,30-CONST_BITS)       ; FIX(3.072711026)
         SECTION SEG_CONST
 
         alignz  32
-        global  EXTN(jconst_idct_islow_mmx)
+        GLOBAL_DATA(jconst_idct_islow_mmx)
 
 EXTN(jconst_idct_islow_mmx):
 
@@ -107,7 +107,7 @@ PB_CENTERJSAMP  times 8 db  CENTERJSAMPLE
                                         ; JCOEF workspace[DCTSIZE2]
 
         align   32
-        global  EXTN(jsimd_idct_islow_mmx)
+        GLOBAL_FUNCTION(jsimd_idct_islow_mmx)
 
 EXTN(jsimd_idct_islow_mmx):
         push    ebp

--- a/simd/i386/jidctint-sse2.asm
+++ b/simd/i386/jidctint-sse2.asm
@@ -66,7 +66,7 @@ F_3_072 equ DESCALE(3299298341, 30-CONST_BITS)  ; FIX(3.072711026)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_idct_islow_sse2)
+    GLOBAL_DATA(jconst_idct_islow_sse2)
 
 EXTN(jconst_idct_islow_sse2):
 
@@ -105,7 +105,7 @@ PB_CENTERJSAMP times 16 db  CENTERJSAMPLE
 %define WK_NUM         12
 
     align       32
-    global      EXTN(jsimd_idct_islow_sse2)
+    GLOBAL_FUNCTION(jsimd_idct_islow_sse2)
 
 EXTN(jsimd_idct_islow_sse2):
     push        ebp

--- a/simd/i386/jidctred-mmx.asm
+++ b/simd/i386/jidctred-mmx.asm
@@ -72,7 +72,7 @@ F_3_624 equ     DESCALE(3891787747,30-CONST_BITS)       ; FIX(3.624509785)
         SECTION SEG_CONST
 
         alignz  32
-        global  EXTN(jconst_idct_red_mmx)
+        GLOBAL_DATA(jconst_idct_red_mmx)
 
 EXTN(jconst_idct_red_mmx):
 
@@ -115,7 +115,7 @@ PB_CENTERJSAMP  times 8 db  CENTERJSAMPLE
                                         ; JCOEF workspace[DCTSIZE2]
 
         align   32
-        global  EXTN(jsimd_idct_4x4_mmx)
+        GLOBAL_FUNCTION(jsimd_idct_4x4_mmx)
 
 EXTN(jsimd_idct_4x4_mmx):
         push    ebp
@@ -503,7 +503,7 @@ EXTN(jsimd_idct_4x4_mmx):
 %define output_col(b)   (b)+20          ; JDIMENSION output_col
 
         align   32
-        global  EXTN(jsimd_idct_2x2_mmx)
+        GLOBAL_FUNCTION(jsimd_idct_2x2_mmx)
 
 EXTN(jsimd_idct_2x2_mmx):
         push    ebp

--- a/simd/i386/jidctred-sse2.asm
+++ b/simd/i386/jidctred-sse2.asm
@@ -72,7 +72,7 @@ F_3_624 equ DESCALE(3891787747, 30-CONST_BITS)  ; FIX(3.624509785)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_idct_red_sse2)
+    GLOBAL_DATA(jconst_idct_red_sse2)
 
 EXTN(jconst_idct_red_sse2):
 
@@ -113,7 +113,7 @@ PB_CENTERJSAMP  times 16 db  CENTERJSAMPLE
 %define WK_NUM         2
 
     align       32
-    global      EXTN(jsimd_idct_4x4_sse2)
+    GLOBAL_FUNCTION(jsimd_idct_4x4_sse2)
 
 EXTN(jsimd_idct_4x4_sse2):
     push        ebp
@@ -424,7 +424,7 @@ EXTN(jsimd_idct_4x4_sse2):
 %define output_col(b)  (b)+20           ; JDIMENSION output_col
 
     align       32
-    global      EXTN(jsimd_idct_2x2_sse2)
+    GLOBAL_FUNCTION(jsimd_idct_2x2_sse2)
 
 EXTN(jsimd_idct_2x2_sse2):
     push        ebp

--- a/simd/i386/jquant-3dn.asm
+++ b/simd/i386/jquant-3dn.asm
@@ -35,7 +35,7 @@
 %define workspace       ebp+16          ; FAST_FLOAT *workspace
 
         align   32
-        global  EXTN(jsimd_convsamp_float_3dnow)
+        GLOBAL_FUNCTION(jsimd_convsamp_float_3dnow)
 
 EXTN(jsimd_convsamp_float_3dnow):
         push    ebp
@@ -138,7 +138,7 @@ EXTN(jsimd_convsamp_float_3dnow):
 %define workspace       ebp+16          ; FAST_FLOAT *workspace
 
         align   32
-        global  EXTN(jsimd_quantize_float_3dnow)
+        GLOBAL_FUNCTION(jsimd_quantize_float_3dnow)
 
 EXTN(jsimd_quantize_float_3dnow):
         push    ebp

--- a/simd/i386/jquant-mmx.asm
+++ b/simd/i386/jquant-mmx.asm
@@ -35,7 +35,7 @@
 %define workspace       ebp+16          ; DCTELEM *workspace
 
         align   32
-        global  EXTN(jsimd_convsamp_mmx)
+        GLOBAL_FUNCTION(jsimd_convsamp_mmx)
 
 EXTN(jsimd_convsamp_mmx):
         push    ebp
@@ -140,7 +140,7 @@ EXTN(jsimd_convsamp_mmx):
 %define workspace       ebp+16          ; DCTELEM *workspace
 
         align   32
-        global  EXTN(jsimd_quantize_mmx)
+        GLOBAL_FUNCTION(jsimd_quantize_mmx)
 
 EXTN(jsimd_quantize_mmx):
         push    ebp

--- a/simd/i386/jquant-sse.asm
+++ b/simd/i386/jquant-sse.asm
@@ -35,7 +35,7 @@
 %define workspace       ebp+16          ; FAST_FLOAT *workspace
 
         align   32
-        global  EXTN(jsimd_convsamp_float_sse)
+        GLOBAL_FUNCTION(jsimd_convsamp_float_sse)
 
 EXTN(jsimd_convsamp_float_sse):
         push    ebp
@@ -138,7 +138,7 @@ EXTN(jsimd_convsamp_float_sse):
 %define workspace       ebp+16          ; FAST_FLOAT *workspace
 
         align   32
-        global  EXTN(jsimd_quantize_float_sse)
+        GLOBAL_FUNCTION(jsimd_quantize_float_sse)
 
 EXTN(jsimd_quantize_float_sse):
         push    ebp

--- a/simd/i386/jquantf-sse2.asm
+++ b/simd/i386/jquantf-sse2.asm
@@ -35,7 +35,7 @@
 %define workspace    ebp+16             ; FAST_FLOAT *workspace
 
     align       32
-    global      EXTN(jsimd_convsamp_float_sse2)
+    GLOBAL_FUNCTION(jsimd_convsamp_float_sse2)
 
 EXTN(jsimd_convsamp_float_sse2):
     push        ebp
@@ -115,7 +115,7 @@ EXTN(jsimd_convsamp_float_sse2):
 %define workspace   ebp+16              ; FAST_FLOAT *workspace
 
     align       32
-    global      EXTN(jsimd_quantize_float_sse2)
+    GLOBAL_FUNCTION(jsimd_quantize_float_sse2)
 
 EXTN(jsimd_quantize_float_sse2):
     push        ebp

--- a/simd/i386/jquanti-avx2.asm
+++ b/simd/i386/jquanti-avx2.asm
@@ -36,7 +36,7 @@
 %define workspace    ebp+16             ; DCTELEM *workspace
 
     align       32
-    global      EXTN(jsimd_convsamp_avx2)
+    GLOBAL_FUNCTION(jsimd_convsamp_avx2)
 
 EXTN(jsimd_convsamp_avx2):
     push        ebp
@@ -126,7 +126,7 @@ EXTN(jsimd_convsamp_avx2):
 %define workspace   ebp+16              ; DCTELEM *workspace
 
     align       32
-    global      EXTN(jsimd_quantize_avx2)
+    GLOBAL_FUNCTION(jsimd_quantize_avx2)
 
 EXTN(jsimd_quantize_avx2):
     push        ebp

--- a/simd/i386/jquanti-sse2.asm
+++ b/simd/i386/jquanti-sse2.asm
@@ -35,7 +35,7 @@
 %define workspace    ebp+16             ; DCTELEM *workspace
 
     align       32
-    global      EXTN(jsimd_convsamp_sse2)
+    GLOBAL_FUNCTION(jsimd_convsamp_sse2)
 
 EXTN(jsimd_convsamp_sse2):
     push        ebp
@@ -117,7 +117,7 @@ EXTN(jsimd_convsamp_sse2):
 %define workspace   ebp+16              ; DCTELEM *workspace
 
     align       32
-    global      EXTN(jsimd_quantize_sse2)
+    GLOBAL_FUNCTION(jsimd_quantize_sse2)
 
 EXTN(jsimd_quantize_sse2):
     push        ebp

--- a/simd/i386/jsimdcpu.asm
+++ b/simd/i386/jsimdcpu.asm
@@ -29,7 +29,7 @@
 ;
 
     align       32
-    global      EXTN(jpeg_simd_cpu_support)
+    GLOBAL_FUNCTION(jpeg_simd_cpu_support)
 
 EXTN(jpeg_simd_cpu_support):
     push        ebx

--- a/simd/mips/jsimd_dspr2_asm.h
+++ b/simd/mips/jsimd_dspr2_asm.h
@@ -2,6 +2,7 @@
  * MIPS DSPr2 optimizations for libjpeg-turbo
  *
  * Copyright (C) 2013, MIPS Technologies, Inc., California.
+ * Copyright (C) 2018, Matthieu Darbois.  All Rights Reserved.
  * All Rights Reserved.
  * Authors:  Teodora Novkovic (teodora.novkovic@imgtec.com)
  *           Darko Laus       (darko.laus@imgtec.com)

--- a/simd/mips/jsimd_dspr2_asm.h
+++ b/simd/mips/jsimd_dspr2_asm.h
@@ -89,11 +89,19 @@
 #define f30  $f30
 #define f31  $f31
 
+#ifdef __ELF__
+#define HIDDEN_SYMBOL(symbol) .hidden  symbol;
+#else
+#define HIDDEN_SYMBOL(symbol)
+#endif
+
+
 /*
  * LEAF_MIPS32R2 - declare leaf routine for MIPS32r2
  */
 #define LEAF_MIPS32R2(symbol)                           \
                 .globl  symbol;                         \
+                 HIDDEN_SYMBOL(symbol)                  \
                 .align  2;                              \
                 .type   symbol, @function;              \
                 .ent    symbol, 0;                      \

--- a/simd/nasm/jsimdext.inc
+++ b/simd/nasm/jsimdext.inc
@@ -188,6 +188,22 @@ section .note.GNU-stack noalloc noexec nowrite progbits
 %endif
 
 ; --------------------------------------------------------------------------
+;  Hidden symbols
+;
+%ifdef ELF ; ----(nasm -felf[64] -DELF ...)------------
+%define GLOBAL_FUNCTION(name) global EXTN(name):function hidden
+%define GLOBAL_DATA(name)     global EXTN(name):data hidden
+;%elifdef MACHO ; ----(nasm -fmacho -DMACHO ...)--------
+;%define GLOBAL_FUNCTION(name) global EXTN(name):private_extern
+;%define GLOBAL_DATA(name)     global EXTN(name):private_extern
+%else
+%define GLOBAL_FUNCTION(name) global EXTN(name)
+%define GLOBAL_DATA(name)     global EXTN(name)
+%endif
+
+
+
+; --------------------------------------------------------------------------
 ;  Macros for position-independent code (PIC) support
 ;
 %ifndef GOT_SYMBOL

--- a/simd/x86_64/jccolext-avx2.asm
+++ b/simd/x86_64/jccolext-avx2.asm
@@ -39,7 +39,7 @@
 
     align       32
 
-    global      EXTN(jsimd_rgb_ycc_convert_avx2)
+    GLOBAL_FUNCTION(jsimd_rgb_ycc_convert_avx2)
 
 EXTN(jsimd_rgb_ycc_convert_avx2):
     push        rbp

--- a/simd/x86_64/jccolext-sse2.asm
+++ b/simd/x86_64/jccolext-sse2.asm
@@ -38,7 +38,7 @@
 
     align       32
 
-    global      EXTN(jsimd_rgb_ycc_convert_sse2)
+    GLOBAL_FUNCTION(jsimd_rgb_ycc_convert_sse2)
 
 EXTN(jsimd_rgb_ycc_convert_sse2):
     push        rbp

--- a/simd/x86_64/jccolor-avx2.asm
+++ b/simd/x86_64/jccolor-avx2.asm
@@ -36,7 +36,7 @@ F_0_337 equ (F_0_587 - F_0_250)  ; FIX(0.58700) - FIX(0.25000)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_rgb_ycc_convert_avx2)
+    GLOBAL_DATA(jconst_rgb_ycc_convert_avx2)
 
 EXTN(jconst_rgb_ycc_convert_avx2):
 

--- a/simd/x86_64/jccolor-sse2.asm
+++ b/simd/x86_64/jccolor-sse2.asm
@@ -35,7 +35,7 @@ F_0_337 equ (F_0_587 - F_0_250)  ; FIX(0.58700) - FIX(0.25000)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_rgb_ycc_convert_sse2)
+    GLOBAL_DATA(jconst_rgb_ycc_convert_sse2)
 
 EXTN(jconst_rgb_ycc_convert_sse2):
 

--- a/simd/x86_64/jcgray-avx2.asm
+++ b/simd/x86_64/jcgray-avx2.asm
@@ -32,7 +32,7 @@ F_0_337 equ (F_0_587 - F_0_250)  ; FIX(0.58700) - FIX(0.25000)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_rgb_gray_convert_avx2)
+    GLOBAL_DATA(jconst_rgb_gray_convert_avx2)
 
 EXTN(jconst_rgb_gray_convert_avx2):
 

--- a/simd/x86_64/jcgray-sse2.asm
+++ b/simd/x86_64/jcgray-sse2.asm
@@ -31,7 +31,7 @@ F_0_337 equ (F_0_587 - F_0_250)  ; FIX(0.58700) - FIX(0.25000)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_rgb_gray_convert_sse2)
+    GLOBAL_DATA(jconst_rgb_gray_convert_sse2)
 
 EXTN(jconst_rgb_gray_convert_sse2):
 

--- a/simd/x86_64/jcgryext-avx2.asm
+++ b/simd/x86_64/jcgryext-avx2.asm
@@ -39,7 +39,7 @@
 
     align       32
 
-    global      EXTN(jsimd_rgb_gray_convert_avx2)
+    GLOBAL_FUNCTION(jsimd_rgb_gray_convert_avx2)
 
 EXTN(jsimd_rgb_gray_convert_avx2):
     push        rbp

--- a/simd/x86_64/jcgryext-sse2.asm
+++ b/simd/x86_64/jcgryext-sse2.asm
@@ -38,7 +38,7 @@
 
     align       32
 
-    global      EXTN(jsimd_rgb_gray_convert_sse2)
+    GLOBAL_FUNCTION(jsimd_rgb_gray_convert_sse2)
 
 EXTN(jsimd_rgb_gray_convert_sse2):
     push        rbp

--- a/simd/x86_64/jchuff-sse2.asm
+++ b/simd/x86_64/jchuff-sse2.asm
@@ -26,7 +26,7 @@
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_huff_encode_one_block)
+    GLOBAL_DATA(jconst_huff_encode_one_block)
 
 EXTN(jconst_huff_encode_one_block):
 
@@ -183,7 +183,7 @@ EXTN(jconst_huff_encode_one_block):
 %define buffer      rax
 
     align       32
-    global      EXTN(jsimd_huff_encode_one_block_sse2)
+    GLOBAL_FUNCTION(jsimd_huff_encode_one_block_sse2)
 
 EXTN(jsimd_huff_encode_one_block_sse2):
     push        rbp

--- a/simd/x86_64/jcsample-avx2.asm
+++ b/simd/x86_64/jcsample-avx2.asm
@@ -41,7 +41,7 @@
 ; r15 = JSAMPARRAY output_data
 
     align       32
-    global      EXTN(jsimd_h2v1_downsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v1_downsample_avx2)
 
 EXTN(jsimd_h2v1_downsample_avx2):
     push        rbp
@@ -202,7 +202,7 @@ EXTN(jsimd_h2v1_downsample_avx2):
 ; r15 = JSAMPARRAY output_data
 
     align       32
-    global      EXTN(jsimd_h2v2_downsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v2_downsample_avx2)
 
 EXTN(jsimd_h2v2_downsample_avx2):
     push        rbp

--- a/simd/x86_64/jcsample-sse2.asm
+++ b/simd/x86_64/jcsample-sse2.asm
@@ -40,7 +40,7 @@
 ; r15 = JSAMPARRAY output_data
 
     align       32
-    global      EXTN(jsimd_h2v1_downsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v1_downsample_sse2)
 
 EXTN(jsimd_h2v1_downsample_sse2):
     push        rbp
@@ -184,7 +184,7 @@ EXTN(jsimd_h2v1_downsample_sse2):
 ; r15 = JSAMPARRAY output_data
 
     align       32
-    global      EXTN(jsimd_h2v2_downsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v2_downsample_sse2)
 
 EXTN(jsimd_h2v2_downsample_sse2):
     push        rbp

--- a/simd/x86_64/jdcolext-avx2.asm
+++ b/simd/x86_64/jdcolext-avx2.asm
@@ -39,7 +39,7 @@
 %define WK_NUM  2
 
     align       32
-    global      EXTN(jsimd_ycc_rgb_convert_avx2)
+    GLOBAL_FUNCTION(jsimd_ycc_rgb_convert_avx2)
 
 EXTN(jsimd_ycc_rgb_convert_avx2):
     push        rbp

--- a/simd/x86_64/jdcolext-sse2.asm
+++ b/simd/x86_64/jdcolext-sse2.asm
@@ -38,7 +38,7 @@
 %define WK_NUM  2
 
     align       32
-    global      EXTN(jsimd_ycc_rgb_convert_sse2)
+    GLOBAL_FUNCTION(jsimd_ycc_rgb_convert_sse2)
 
 EXTN(jsimd_ycc_rgb_convert_sse2):
     push        rbp

--- a/simd/x86_64/jdcolor-avx2.asm
+++ b/simd/x86_64/jdcolor-avx2.asm
@@ -35,7 +35,7 @@ F_0_228 equ (131072 - F_1_772)  ; FIX(2) - FIX(1.77200)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_ycc_rgb_convert_avx2)
+    GLOBAL_DATA(jconst_ycc_rgb_convert_avx2)
 
 EXTN(jconst_ycc_rgb_convert_avx2):
 

--- a/simd/x86_64/jdcolor-sse2.asm
+++ b/simd/x86_64/jdcolor-sse2.asm
@@ -34,7 +34,7 @@ F_0_228 equ (131072 - F_1_772)  ; FIX(2) - FIX(1.77200)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_ycc_rgb_convert_sse2)
+    GLOBAL_DATA(jconst_ycc_rgb_convert_sse2)
 
 EXTN(jconst_ycc_rgb_convert_sse2):
 

--- a/simd/x86_64/jdmerge-avx2.asm
+++ b/simd/x86_64/jdmerge-avx2.asm
@@ -35,7 +35,7 @@ F_0_228 equ (131072 - F_1_772)  ; FIX(2) - FIX(1.77200)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_merged_upsample_avx2)
+    GLOBAL_DATA(jconst_merged_upsample_avx2)
 
 EXTN(jconst_merged_upsample_avx2):
 

--- a/simd/x86_64/jdmerge-sse2.asm
+++ b/simd/x86_64/jdmerge-sse2.asm
@@ -34,7 +34,7 @@ F_0_228 equ (131072 - F_1_772)  ; FIX(2) - FIX(1.77200)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_merged_upsample_sse2)
+    GLOBAL_DATA(jconst_merged_upsample_sse2)
 
 EXTN(jconst_merged_upsample_sse2):
 

--- a/simd/x86_64/jdmrgext-avx2.asm
+++ b/simd/x86_64/jdmrgext-avx2.asm
@@ -39,7 +39,7 @@
 %define WK_NUM  3
 
     align       32
-    global      EXTN(jsimd_h2v1_merged_upsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v1_merged_upsample_avx2)
 
 EXTN(jsimd_h2v1_merged_upsample_avx2):
     push        rbp
@@ -503,7 +503,7 @@ EXTN(jsimd_h2v1_merged_upsample_avx2):
 ; r13 = JSAMPARRAY output_buf
 
     align       32
-    global      EXTN(jsimd_h2v2_merged_upsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v2_merged_upsample_avx2)
 
 EXTN(jsimd_h2v2_merged_upsample_avx2):
     push        rbp

--- a/simd/x86_64/jdmrgext-sse2.asm
+++ b/simd/x86_64/jdmrgext-sse2.asm
@@ -38,7 +38,7 @@
 %define WK_NUM  3
 
     align       32
-    global      EXTN(jsimd_h2v1_merged_upsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v1_merged_upsample_sse2)
 
 EXTN(jsimd_h2v1_merged_upsample_sse2):
     push        rbp
@@ -445,7 +445,7 @@ EXTN(jsimd_h2v1_merged_upsample_sse2):
 ; r13 = JSAMPARRAY output_buf
 
     align       32
-    global      EXTN(jsimd_h2v2_merged_upsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v2_merged_upsample_sse2)
 
 EXTN(jsimd_h2v2_merged_upsample_sse2):
     push        rbp

--- a/simd/x86_64/jdsample-avx2.asm
+++ b/simd/x86_64/jdsample-avx2.asm
@@ -23,7 +23,7 @@
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_fancy_upsample_avx2)
+    GLOBAL_DATA(jconst_fancy_upsample_avx2)
 
 EXTN(jconst_fancy_upsample_avx2):
 
@@ -59,7 +59,7 @@ PW_EIGHT times 16 dw 8
 ; r13 = JSAMPARRAY *output_data_ptr
 
     align       32
-    global      EXTN(jsimd_h2v1_fancy_upsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v1_fancy_upsample_avx2)
 
 EXTN(jsimd_h2v1_fancy_upsample_avx2):
     push        rbp
@@ -213,7 +213,7 @@ EXTN(jsimd_h2v1_fancy_upsample_avx2):
 %define WK_NUM  4
 
     align       32
-    global      EXTN(jsimd_h2v2_fancy_upsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v2_fancy_upsample_avx2)
 
 EXTN(jsimd_h2v2_fancy_upsample_avx2):
     push        rbp
@@ -524,7 +524,7 @@ EXTN(jsimd_h2v2_fancy_upsample_avx2):
 ; r13 = JSAMPARRAY *output_data_ptr
 
     align       32
-    global      EXTN(jsimd_h2v1_upsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v1_upsample_avx2)
 
 EXTN(jsimd_h2v1_upsample_avx2):
     push        rbp
@@ -615,7 +615,7 @@ EXTN(jsimd_h2v1_upsample_avx2):
 ; r13 = JSAMPARRAY *output_data_ptr
 
     align       32
-    global      EXTN(jsimd_h2v2_upsample_avx2)
+    GLOBAL_FUNCTION(jsimd_h2v2_upsample_avx2)
 
 EXTN(jsimd_h2v2_upsample_avx2):
     push        rbp

--- a/simd/x86_64/jdsample-sse2.asm
+++ b/simd/x86_64/jdsample-sse2.asm
@@ -22,7 +22,7 @@
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_fancy_upsample_sse2)
+    GLOBAL_DATA(jconst_fancy_upsample_sse2)
 
 EXTN(jconst_fancy_upsample_sse2):
 
@@ -58,7 +58,7 @@ PW_EIGHT times 8 dw 8
 ; r13 = JSAMPARRAY *output_data_ptr
 
     align       32
-    global      EXTN(jsimd_h2v1_fancy_upsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v1_fancy_upsample_sse2)
 
 EXTN(jsimd_h2v1_fancy_upsample_sse2):
     push        rbp
@@ -200,7 +200,7 @@ EXTN(jsimd_h2v1_fancy_upsample_sse2):
 %define WK_NUM  4
 
     align       32
-    global      EXTN(jsimd_h2v2_fancy_upsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v2_fancy_upsample_sse2)
 
 EXTN(jsimd_h2v2_fancy_upsample_sse2):
     push        rbp
@@ -497,7 +497,7 @@ EXTN(jsimd_h2v2_fancy_upsample_sse2):
 ; r13 = JSAMPARRAY *output_data_ptr
 
     align       32
-    global      EXTN(jsimd_h2v1_upsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v1_upsample_sse2)
 
 EXTN(jsimd_h2v1_upsample_sse2):
     push        rbp
@@ -586,7 +586,7 @@ EXTN(jsimd_h2v1_upsample_sse2):
 ; r13 = JSAMPARRAY *output_data_ptr
 
     align       32
-    global      EXTN(jsimd_h2v2_upsample_sse2)
+    GLOBAL_FUNCTION(jsimd_h2v2_upsample_sse2)
 
 EXTN(jsimd_h2v2_upsample_sse2):
     push        rbp

--- a/simd/x86_64/jfdctflt-sse.asm
+++ b/simd/x86_64/jfdctflt-sse.asm
@@ -37,7 +37,7 @@
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_fdct_float_sse)
+    GLOBAL_DATA(jconst_fdct_float_sse)
 
 EXTN(jconst_fdct_float_sse):
 
@@ -64,7 +64,7 @@ PD_1_306 times 4 dd 1.306562964876376527856643
 %define WK_NUM  2
 
     align       32
-    global      EXTN(jsimd_fdct_float_sse)
+    GLOBAL_FUNCTION(jsimd_fdct_float_sse)
 
 EXTN(jsimd_fdct_float_sse):
     push        rbp

--- a/simd/x86_64/jfdctfst-sse2.asm
+++ b/simd/x86_64/jfdctfst-sse2.asm
@@ -52,7 +52,7 @@ F_1_306 equ DESCALE(1402911301, 30-CONST_BITS)  ; FIX(1.306562965)
 %define CONST_SHIFT              (16 - PRE_MULTIPLY_SCALE_BITS - CONST_BITS)
 
     alignz      32
-    global      EXTN(jconst_fdct_ifast_sse2)
+    GLOBAL_DATA(jconst_fdct_ifast_sse2)
 
 EXTN(jconst_fdct_ifast_sse2):
 
@@ -79,7 +79,7 @@ PW_F1306 times 8 dw F_1_306 << CONST_SHIFT
 %define WK_NUM  2
 
     align       32
-    global      EXTN(jsimd_fdct_ifast_sse2)
+    GLOBAL_FUNCTION(jsimd_fdct_ifast_sse2)
 
 EXTN(jsimd_fdct_ifast_sse2):
     push        rbp

--- a/simd/x86_64/jfdctint-avx2.asm
+++ b/simd/x86_64/jfdctint-avx2.asm
@@ -226,7 +226,7 @@ F_3_072 equ DESCALE(3299298341, 30-CONST_BITS)  ; FIX(3.072711026)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_fdct_islow_avx2)
+    GLOBAL_DATA(jconst_fdct_islow_avx2)
 
 EXTN(jconst_fdct_islow_avx2):
 
@@ -259,7 +259,7 @@ PW_1_NEG1                  times 8  dw  1
 ; r10 = DCTELEM *data
 
     align       32
-    global      EXTN(jsimd_fdct_islow_avx2)
+    GLOBAL_FUNCTION(jsimd_fdct_islow_avx2)
 
 EXTN(jsimd_fdct_islow_avx2):
     push        rbp

--- a/simd/x86_64/jfdctint-sse2.asm
+++ b/simd/x86_64/jfdctint-sse2.asm
@@ -66,7 +66,7 @@ F_3_072 equ DESCALE(3299298341, 30-CONST_BITS)  ; FIX(3.072711026)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_fdct_islow_sse2)
+    GLOBAL_DATA(jconst_fdct_islow_sse2)
 
 EXTN(jconst_fdct_islow_sse2):
 
@@ -100,7 +100,7 @@ PW_DESCALE_P2X times 8 dw  1 << (PASS1_BITS-1)
 %define WK_NUM  6
 
     align       32
-    global      EXTN(jsimd_fdct_islow_sse2)
+    GLOBAL_FUNCTION(jsimd_fdct_islow_sse2)
 
 EXTN(jsimd_fdct_islow_sse2):
     push        rbp

--- a/simd/x86_64/jidctflt-sse2.asm
+++ b/simd/x86_64/jidctflt-sse2.asm
@@ -37,7 +37,7 @@
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_idct_float_sse2)
+    GLOBAL_DATA(jconst_idct_float_sse2)
 
 EXTN(jconst_idct_float_sse2):
 
@@ -73,7 +73,7 @@ PB_CENTERJSAMP  times 16 db  CENTERJSAMPLE
                                         ; FAST_FLOAT workspace[DCTSIZE2]
 
     align       32
-    global      EXTN(jsimd_idct_float_sse2)
+    GLOBAL_FUNCTION(jsimd_idct_float_sse2)
 
 EXTN(jsimd_idct_float_sse2):
     push        rbp

--- a/simd/x86_64/jidctfst-sse2.asm
+++ b/simd/x86_64/jidctfst-sse2.asm
@@ -59,7 +59,7 @@ F_1_613 equ (F_2_613 - (1 << CONST_BITS))       ; FIX(2.613125930) - FIX(1)
 %define CONST_SHIFT              (16 - PRE_MULTIPLY_SCALE_BITS - CONST_BITS)
 
     alignz      32
-    global      EXTN(jconst_idct_ifast_sse2)
+    GLOBAL_DATA(jconst_idct_ifast_sse2)
 
 EXTN(jconst_idct_ifast_sse2):
 
@@ -92,7 +92,7 @@ PB_CENTERJSAMP times 16 db  CENTERJSAMPLE
 %define WK_NUM        2
 
     align       32
-    global      EXTN(jsimd_idct_ifast_sse2)
+    GLOBAL_FUNCTION(jsimd_idct_ifast_sse2)
 
 EXTN(jsimd_idct_ifast_sse2):
     push        rbp

--- a/simd/x86_64/jidctint-avx2.asm
+++ b/simd/x86_64/jidctint-avx2.asm
@@ -243,7 +243,7 @@ F_3_072 equ DESCALE(3299298341, 30-CONST_BITS)  ; FIX(3.072711026)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_idct_islow_avx2)
+    GLOBAL_DATA(jconst_idct_islow_avx2)
 
 EXTN(jconst_idct_islow_avx2):
 
@@ -280,7 +280,7 @@ PW_1_NEG1                  times 8  dw  1
 ; r13d = JDIMENSION output_col
 
     align       32
-    global      EXTN(jsimd_idct_islow_avx2)
+    GLOBAL_FUNCTION(jsimd_idct_islow_avx2)
 
 EXTN(jsimd_idct_islow_avx2):
     push        rbp

--- a/simd/x86_64/jidctint-sse2.asm
+++ b/simd/x86_64/jidctint-sse2.asm
@@ -66,7 +66,7 @@ F_3_072 equ DESCALE(3299298341, 30-CONST_BITS)  ; FIX(3.072711026)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_idct_islow_sse2)
+    GLOBAL_DATA(jconst_idct_islow_sse2)
 
 EXTN(jconst_idct_islow_sse2):
 
@@ -105,7 +105,7 @@ PB_CENTERJSAMP times 16 db  CENTERJSAMPLE
 %define WK_NUM        12
 
     align       32
-    global      EXTN(jsimd_idct_islow_sse2)
+    GLOBAL_FUNCTION(jsimd_idct_islow_sse2)
 
 EXTN(jsimd_idct_islow_sse2):
     push        rbp

--- a/simd/x86_64/jidctred-sse2.asm
+++ b/simd/x86_64/jidctred-sse2.asm
@@ -72,7 +72,7 @@ F_3_624 equ DESCALE(3891787747, 30-CONST_BITS)  ; FIX(3.624509785)
     SECTION     SEG_CONST
 
     alignz      32
-    global      EXTN(jconst_idct_red_sse2)
+    GLOBAL_DATA(jconst_idct_red_sse2)
 
 EXTN(jconst_idct_red_sse2):
 
@@ -113,7 +113,7 @@ PB_CENTERJSAMP  times 16 db  CENTERJSAMPLE
 %define WK_NUM        2
 
     align       32
-    global      EXTN(jsimd_idct_4x4_sse2)
+    GLOBAL_FUNCTION(jsimd_idct_4x4_sse2)
 
 EXTN(jsimd_idct_4x4_sse2):
     push        rbp
@@ -412,7 +412,7 @@ EXTN(jsimd_idct_4x4_sse2):
 ; r13d = JDIMENSION output_col
 
     align       32
-    global      EXTN(jsimd_idct_2x2_sse2)
+    GLOBAL_FUNCTION(jsimd_idct_2x2_sse2)
 
 EXTN(jsimd_idct_2x2_sse2):
     push        rbp

--- a/simd/x86_64/jquantf-sse2.asm
+++ b/simd/x86_64/jquantf-sse2.asm
@@ -35,7 +35,7 @@
 ; r12 = FAST_FLOAT *workspace
 
     align       32
-    global      EXTN(jsimd_convsamp_float_sse2)
+    GLOBAL_FUNCTION(jsimd_convsamp_float_sse2)
 
 EXTN(jsimd_convsamp_float_sse2):
     push        rbp
@@ -109,7 +109,7 @@ EXTN(jsimd_convsamp_float_sse2):
 ; r12 = FAST_FLOAT *workspace
 
     align       32
-    global      EXTN(jsimd_quantize_float_sse2)
+    GLOBAL_FUNCTION(jsimd_quantize_float_sse2)
 
 EXTN(jsimd_quantize_float_sse2):
     push        rbp

--- a/simd/x86_64/jquanti-avx2.asm
+++ b/simd/x86_64/jquanti-avx2.asm
@@ -36,7 +36,7 @@
 ; r12 = DCTELEM *workspace
 
     align       32
-    global      EXTN(jsimd_convsamp_avx2)
+    GLOBAL_FUNCTION(jsimd_convsamp_avx2)
 
 EXTN(jsimd_convsamp_avx2):
     push        rbp
@@ -111,7 +111,7 @@ EXTN(jsimd_convsamp_avx2):
 ; r12 = DCTELEM *workspace
 
     align       32
-    global      EXTN(jsimd_quantize_avx2)
+    GLOBAL_FUNCTION(jsimd_quantize_avx2)
 
 EXTN(jsimd_quantize_avx2):
     push        rbp

--- a/simd/x86_64/jquanti-sse2.asm
+++ b/simd/x86_64/jquanti-sse2.asm
@@ -35,7 +35,7 @@
 ; r12 = DCTELEM *workspace
 
     align       32
-    global      EXTN(jsimd_convsamp_sse2)
+    GLOBAL_FUNCTION(jsimd_convsamp_sse2)
 
 EXTN(jsimd_convsamp_sse2):
     push        rbp
@@ -111,7 +111,7 @@ EXTN(jsimd_convsamp_sse2):
 ; r12 = DCTELEM *workspace
 
     align       32
-    global      EXTN(jsimd_quantize_sse2)
+    GLOBAL_FUNCTION(jsimd_quantize_sse2)
 
 EXTN(jsimd_quantize_sse2):
     push        rbp

--- a/simd/x86_64/jsimdcpu.asm
+++ b/simd/x86_64/jsimdcpu.asm
@@ -30,7 +30,7 @@
 ;
 
     align       32
-    global      EXTN(jpeg_simd_cpu_support)
+    GLOBAL_FUNCTION(jpeg_simd_cpu_support)
 
 EXTN(jpeg_simd_cpu_support):
     push        rbx


### PR DESCRIPTION
According to discussion in #180 

**x86/x86-64**
- ELF (Linux/Android)
  - [x] support both NASM and YASM
  - [x] The feature is always enabled as it doesn't change the NASM/YASM requirements
  - [x] Tested on `dcommander/buildljt:latest` docker image + YASM 1.2.0
- MACHO (MacOS)
  - [ ] Make it build-time optional when using YASM and disabled by default on that platform

**ARM/ARM64**
- MACHO (iOS)
  - [x] The feature is always enabled like it is for ELF platforms
  - [x] Tested using Xcode 9.2 (following Xcode 5 and later procedure) 
  - [ ] Test with older Xcode (Unfortunately, I can't do that anymore. There shouldn't be an issue since `.private_extern` was part of MACHO assembler directives before the first iPhone came out)

**MIPS**
- ELF (Linux/Android)
  - [x] The feature is always enabled
  - [x] Tested on Debian GNU/Linux 8.6 (jessie)

If it seems good, I will follow-up with MacOS.
