### PR TITLE
Win/x64: Fix callee saved xmm registers in x86_64/jidctint-avx2.asm

### DIFF
--- a/simd/x86_64/jidctint-avx2.asm
+++ b/simd/x86_64/jidctint-avx2.asm
@@ -286,6 +286,7 @@ EXTN(jsimd_idct_islow_avx2):
     push        rbp
     mov         rax, rsp                     ; rax = original rbp
     mov         rbp, rsp                     ; rbp = aligned rbp
+    push_xmm    4
     collect_args 4
 
     ; ---- Pass 1: process columns.
@@ -409,6 +410,7 @@ EXTN(jsimd_idct_islow_avx2):
     movq        XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE], xmm7
 
     uncollect_args 4
+    pop_xmm     4
     pop         rbp
     ret
 


### PR DESCRIPTION
AppVeyor build was failing because of this on `tjbench-shared-tile` mingw64 test (infinite loop of some kind).