### PR TITLE
Option to make SIMD symbols private for macOS x86/64 builds

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -345,6 +345,16 @@ On Un*x systems, prior to running CMake, you can set the `CC` environment
 variable to the command used to invoke the C compiler.
 
 
+### Private SIMD symbols on Mac
+
+This requires the use of the YASM assembler.
+
+    export ASM_NASM={yasm_binary_path}/yasm
+    cd {build_directory}
+    cmake -G"Unix Makefiles" -DCMAKE_ASM_NASM_FLAGS=-DMACHO_PRIVATE_EXTERN [additional CMake flags] {source_directory}
+    make
+
+
 ### 32-bit MinGW Build on Un*x (including Mac and Cygwin)
 
 Create a file called **toolchain.cmake** under *{build_directory}*, with the

--- a/simd/nasm/jsimdext.inc
+++ b/simd/nasm/jsimdext.inc
@@ -194,11 +194,21 @@ section .note.GNU-stack noalloc noexec nowrite progbits
 %ifdef ELF      ; ----(nasm -felf[64] -DELF ...)--------
 %define GLOBAL_FUNCTION(name)  global EXTN(name):function hidden
 %define GLOBAL_DATA(name)      global EXTN(name):data hidden
-;%elifdef MACHO  ; ----(nasm -fmacho -DMACHO ...)--------
-;%define GLOBAL_FUNCTION(name)  global EXTN(name):private_extern
-;%define GLOBAL_DATA(name)      global EXTN(name):private_extern
-%else
+%elifdef MACHO  ; ----(nasm -fmacho -DMACHO ...)--------
+%ifdef MACHO_PRIVATE_EXTERN
+%ifndef __YASM_VER__
+%fatal "-DMACHO_PRIVATE_EXTERN requires to use YASM"
+%endif
+%define GLOBAL_FUNCTION(name)  global EXTN(name):private_extern
+%define GLOBAL_DATA(name)      global EXTN(name):private_extern
+%endif
+%endif
+
+%ifndef GLOBAL_FUNCTION
 %define GLOBAL_FUNCTION(name)  global EXTN(name)
+%endif
+
+%ifndef GLOBAL_DATA
 %define GLOBAL_DATA(name)      global EXTN(name)
 %endif
 


### PR DESCRIPTION
Follow-up of #180 and #210 