### PR TITLE
Win/x64: Fix improper callee save of xmm8-xmm11

### DIFF
--- a/simd/nasm/jsimdext.inc
+++ b/simd/nasm/jsimdext.inc
@@ -379,30 +379,30 @@ const_base:
 %endmacro
 
 %imacro push_xmm 1
-    movaps      XMMWORD [rsp-1*SIZEOF_XMMWORD], xmm8
+    sub         rsp, %1 * SIZEOF_XMMWORD
+    movaps      XMMWORD [rsp+0*SIZEOF_XMMWORD], xmm8
 %if %1 > 1
-    movaps      XMMWORD [rsp-2*SIZEOF_XMMWORD], xmm9
+    movaps      XMMWORD [rsp+1*SIZEOF_XMMWORD], xmm9
 %endif
 %if %1 > 2
-    movaps      XMMWORD [rsp-3*SIZEOF_XMMWORD], xmm10
+    movaps      XMMWORD [rsp+2*SIZEOF_XMMWORD], xmm10
 %endif
 %if %1 > 3
-    movaps      XMMWORD [rsp-4*SIZEOF_XMMWORD], xmm11
+    movaps      XMMWORD [rsp+3*SIZEOF_XMMWORD], xmm11
 %endif
-    sub         rsp, %1 * SIZEOF_XMMWORD
 %endmacro
 
 %imacro pop_xmm 1
-%if %1 > 3
-    movaps      xmm11, XMMWORD [rsp+0*SIZEOF_XMMWORD]
+    movaps      xmm8, XMMWORD [rsp+0*SIZEOF_XMMWORD]
+%if %1 > 1
+    movaps      xmm9, XMMWORD [rsp+1*SIZEOF_XMMWORD]
 %endif
 %if %1 > 2
-    movaps      xmm10, XMMWORD [rsp+1*SIZEOF_XMMWORD]
+    movaps      xmm10, XMMWORD [rsp+2*SIZEOF_XMMWORD]
 %endif
-%if %1 > 1
-    movaps      xmm9, XMMWORD [rsp+2*SIZEOF_XMMWORD]
+%if %1 > 3
+    movaps      xmm11, XMMWORD [rsp+3*SIZEOF_XMMWORD]
 %endif
-    movaps      xmm8, XMMWORD [rsp+3*SIZEOF_XMMWORD]
     add         rsp, %1 * SIZEOF_XMMWORD
 %endmacro
 


### PR DESCRIPTION
push_xmm macro shall adjust the stack pointer as the first operation.
Otherwise, ABI conformance is not respected.