### PR TITLE
Remove useless checks for SIMD progressive huffman encoding

### DIFF
--- a/simd/i386/jsimd.c
+++ b/simd/i386/jsimd.c
@@ -1210,15 +1210,9 @@ jsimd_can_encode_mcu_AC_first_prepare(void)
     return 0;
   if (SIZEOF_SIZE_T != 4)
     return 0;
-  if (!(simd_support & JSIMD_SSE2))
-    return 0;
-#if defined(HAVE_BUILTIN_CTZL)
-  return 1;
-#elif defined(HAVE_BITSCANFORWARD)
-  return 1;
-#else
+  if (simd_support & JSIMD_SSE2)
+    return 1;
   return 0;
-#endif
 }
 
 GLOBAL(void)
@@ -1241,15 +1235,9 @@ jsimd_can_encode_mcu_AC_refine_prepare(void)
     return 0;
   if (SIZEOF_SIZE_T != 4)
     return 0;
-  if (!(simd_support & JSIMD_SSE2))
-    return 0;
-#if defined(HAVE_BUILTIN_CTZL)
-  return 1;
-#elif defined(HAVE_BITSCANFORWARD)
-  return 1;
-#else
+  if (simd_support & JSIMD_SSE2)
+    return 1;
   return 0;
-#endif
 }
 
 GLOBAL(int)

--- a/simd/x86_64/jsimd.c
+++ b/simd/x86_64/jsimd.c
@@ -1033,15 +1033,9 @@ jsimd_can_encode_mcu_AC_first_prepare(void)
     return 0;
   if (SIZEOF_SIZE_T != 8)
     return 0;
-  if (!(simd_support & JSIMD_SSE2))
-    return 0;
-#if defined(HAVE_BUILTIN_CTZL)
-  return 1;
-#elif defined(HAVE_BITSCANFORWARD64)
-  return 1;
-#else
+  if (simd_support & JSIMD_SSE2)
+    return 1;
   return 0;
-#endif
 }
 
 GLOBAL(void)
@@ -1064,15 +1058,9 @@ jsimd_can_encode_mcu_AC_refine_prepare(void)
     return 0;
   if (SIZEOF_SIZE_T != 8)
     return 0;
-  if (!(simd_support & JSIMD_SSE2))
-    return 0;
-#if defined(HAVE_BUILTIN_CTZL)
-  return 1;
-#elif defined(HAVE_BITSCANFORWARD64)
-  return 1;
-#else
+  if (simd_support & JSIMD_SSE2)
+    return 1;
   return 0;
-#endif
 }
 
 GLOBAL(int)


### PR DESCRIPTION
Those checks were there for the 1st PR (#46) that was made for SSE2 progressive encoding and that had a different frontend C function for the SIMD case. This is not the case anymore, these checks are now useless.