### PR TITLE
jpeg_skip_scanlines: fix NPE with fast upsampling

### DIFF
--- a/jdapistd.c
+++ b/jdapistd.c
@@ -318,12 +318,15 @@ read_and_discard_scanlines(j_decompress_ptr cinfo, JDIMENSION num_lines)
   JDIMENSION n;
   void (*color_convert) (j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                          JDIMENSION input_row, JSAMPARRAY output_buf,
-                         int num_rows);
+                         int num_rows) = NULL;
   void (*color_quantize) (j_decompress_ptr cinfo, JSAMPARRAY input_buf,
                           JSAMPARRAY output_buf, int num_rows) = NULL;
 
-  color_convert = cinfo->cconvert->color_convert;
-  cinfo->cconvert->color_convert = noop_convert;
+  if (cinfo->cconvert) {
+    color_convert = cinfo->cconvert->color_convert;
+    cinfo->cconvert->color_convert = noop_convert;
+  }
+
   if (cinfo->cquantize && cinfo->cquantize->color_quantize) {
     color_quantize = cinfo->cquantize->color_quantize;
     cinfo->cquantize->color_quantize = noop_quantize;
@@ -332,7 +335,9 @@ read_and_discard_scanlines(j_decompress_ptr cinfo, JDIMENSION num_lines)
   for (n = 0; n < num_lines; n++)
     jpeg_read_scanlines(cinfo, NULL, 1);
 
-  cinfo->cconvert->color_convert = color_convert;
+  if (color_convert)
+    cinfo->cconvert->color_convert = color_convert;
+
   if (color_quantize)
     cinfo->cquantize->color_quantize = color_quantize;
 }


### PR DESCRIPTION
Fixes null pointer reference when do_fancy_upscaling is disabled.

Test case: on a 5184x3456 jpg.
./djpeg-static -nosmooth -crop 5184x1024+0+100 -targa file.jpg > out.tga

```gdb
0x00007ffff792b07f in read_and_discard_scanlines (cinfo=0x7fffc0003ac8, num_lines=0) at /home/dw/sw/libjpeg-turbo/jdapistd.c:325
325       color_convert = cinfo->cconvert->color_convert;
(gdb) bt
#0  0x00007ffff792b07f in read_and_discard_scanlines (cinfo=0x7fffc0003ac8, num_lines=0) at /home/dw/sw/libjpeg-turbo/jdapistd.c:325
#1  0x00007ffff792b1d0 in increment_simple_rowgroup_ctr (cinfo=0x7fffc0003ac8, rows=0) at /home/dw/sw/libjpeg-turbo/jdapistd.c:361
#2  0x00007ffff792b76c in jpeg_skip_scanlines (cinfo=0x7fffc0003ac8, num_lines=288) at /home/dw/sw/libjpeg-turbo/jdapistd.c:525
...
```

cinfo->cconvert is NULL. This is a valid state. How it gets to this state is via use_merged_upsample()

```
do_fancy_upsampling == TRUE
   use_merged_upsample() => FALSE 
      master->using_merged_upsample = FALSE
         jinit_color_deconverter => 
            cinfo->cconvert = (assigned)

do_fancy_upsampling == FALSE
   use_merged_upsample() => TRUE 
      master->using_merged_upsample = TRUE
         jinit_merged_upsampler()
         cinfo->cconvert = (left as null)
```

Note: djpeg (command as given) is still broken somewhere else after this fix, there is another segfault which is unrelated.
