### PR TITLE
Avoid integer overflow on corrupted image in decode_mcu_DC_first()

### DIFF
--- a/jdphuff.c
+++ b/jdphuff.c
@@ -18,6 +18,9 @@
  */
 
 #define JPEG_INTERNALS
+
+#include <limits.h>
+
 #include "jinclude.h"
 #include "jpeglib.h"
 #include "jdhuff.h"             /* Declarations shared with jdhuff.c */
@@ -340,6 +343,10 @@ decode_mcu_DC_first(j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
       }
 
       /* Convert DC difference to actual value, update last_dc_val */
+      if( (state.last_dc_val[ci] >= 0 && s > INT_MAX - state.last_dc_val[ci]) ||
+          (state.last_dc_val[ci] < 0 && s < INT_MIN - state.last_dc_val[ci]) ) {
+        ERREXIT(cinfo, JERR_BAD_DCT_COEF);
+      }
       s += state.last_dc_val[ci];
       state.last_dc_val[ci] = s;
       /* Scale and output the coefficient (assumes jpeg_natural_order[0]=0) */


### PR DESCRIPTION
fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9447 (reproducer file attached)
Credit to OSS Fuzz
![clusterfuzz-testcase-minimized-gdal_filesystem_fuzzer-5765666949824512](https://user-images.githubusercontent.com/1192433/43013040-df38e1d4-8c47-11e8-8fa2-8136dd1e6872.jpg)
