### PR TITLE
simd: Update DSPr2 check

### DIFF
--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -273,7 +273,7 @@ message(STATUS "CMAKE_ASM_FLAGS = ${EFFECTIVE_ASM_FLAGS}")
 set(CMAKE_REQUIRED_FLAGS -mdspr2)
 
 check_c_source_compiles("
-  #if !(defined(__mips__) && __mips_isa_rev >= 2)
+  #ifndef __mips_dspr2
   #error MIPS DSPr2 is currently only available on MIPS32r2 platforms.
   #endif
   int main(void) {


### PR DESCRIPTION
The original was only a partial fix that only worked because OpenWrt passes -mips16. If PKG_USE_MIPS16:=0 is passed (-mno-mips16 in gcc), then compilation fails as before.