### PR TITLE
Install: Add jpegint.h header to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1380,7 +1380,7 @@ endif()
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/jconfig.h
   ${CMAKE_CURRENT_SOURCE_DIR}/jerror.h ${CMAKE_CURRENT_SOURCE_DIR}/jmorecfg.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/jpeglib.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/jpegint.h ${CMAKE_CURRENT_SOURCE_DIR}/jpeglib.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 include(cmakescripts/BuildPackages.cmake)


### PR DESCRIPTION
RBDOOM-BFG-3 ( https://github.com/RobertBeckebans/RBDOOM-3-BFG )
includes the header file jpeglib.h from the libjpeg-turbo library.
RBDOOM-BFG-3 sets the env variable JPEG_INTERNALS and therefore
indirectly pulls in jpegint.h by including jpeglib.h .
However the libjpeg-turbo library cmake installer does not install
the jpegint.h library.