### PR TITLE
simd: Require hard float for MIPS

### DIFF
--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -273,7 +273,7 @@ message(STATUS "CMAKE_ASM_FLAGS = ${EFFECTIVE_ASM_FLAGS}")
 set(CMAKE_REQUIRED_FLAGS -mdspr2)
 
 check_c_source_compiles("
-  #if !(defined(__mips__) && __mips_isa_rev >= 2)
+  #if !(defined(__mips__) && __mips_isa_rev >= 2) && !(defined(__mips_soft_float))
   #error MIPS DSPr2 is currently only available on MIPS32r2 platforms.
   #endif
   int main(void) {


### PR DESCRIPTION
Some MIPS toolchains such as the one in OpenWrt are built with soft float to enable
greater compatibility with less capable devices. This causes compilation issues with
missing opcodes.