### PR TITLE
simd: mips: Don't compile float code on softfloat targets

### DIFF
--- a/simd/mips/jsimd.c
+++ b/simd/mips/jsimd.c
@@ -678,6 +678,9 @@ jsimd_can_convsamp(void)
 GLOBAL(int)
 jsimd_can_convsamp_float(void)
 {
+#ifdef __mips_soft_float
+  return 0;
+#endif
   init_simd();
 
   /* The code is optimised for these values only */
@@ -709,7 +712,9 @@ GLOBAL(void)
 jsimd_convsamp_float(JSAMPARRAY sample_data, JDIMENSION start_col,
                      FAST_FLOAT *workspace)
 {
+#ifndef __mips_soft_float
   jsimd_convsamp_float_dspr2(sample_data, start_col, workspace);
+#endif
 }
 
 GLOBAL(int)
@@ -791,6 +796,9 @@ jsimd_can_quantize(void)
 GLOBAL(int)
 jsimd_can_quantize_float(void)
 {
+#ifdef __mips_soft_float
+  return 0;
+#endif
   init_simd();
 
   /* The code is optimised for these values only */
@@ -821,7 +829,9 @@ GLOBAL(void)
 jsimd_quantize_float(JCOEFPTR coef_block, FAST_FLOAT *divisors,
                      FAST_FLOAT *workspace)
 {
+#ifndef __mips_soft_float
   jsimd_quantize_float_dspr2(coef_block, divisors, workspace);
+#endif
 }
 
 GLOBAL(int)

--- a/simd/mips/jsimd_dspr2.S
+++ b/simd/mips/jsimd_dspr2.S
@@ -2810,6 +2810,7 @@ LEAF_DSPR2(jsimd_quantize_dspr2)
 END(jsimd_quantize_dspr2)
 
 
+#ifndef __mips_soft_float
 /*****************************************************************************/
 LEAF_DSPR2(jsimd_quantize_float_dspr2)
 /*
@@ -2889,6 +2890,7 @@ LEAF_DSPR2(jsimd_quantize_float_dspr2)
      nop
 
 END(jsimd_quantize_float_dspr2)
+#endif
 
 
 /*****************************************************************************/
@@ -4110,6 +4112,7 @@ LEAF_DSPR2(jsimd_convsamp_dspr2)
 END(jsimd_convsamp_dspr2)
 
 
+#ifndef __mips_soft_float
 /*****************************************************************************/
 LEAF_DSPR2(jsimd_convsamp_float_dspr2)
 /*
@@ -4467,5 +4470,6 @@ LEAF_DSPR2(jsimd_convsamp_float_dspr2)
      nop
 
 END(jsimd_convsamp_float_dspr2)
+#endif
 
 /*****************************************************************************/


### PR DESCRIPTION
Doing so causes opcode errors.

Signed-off-by: Rosen Penev <rosenp@gmail.com>