### PR TITLE
fix install of binaries with a static only library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,9 @@ endif()
 
 include(cmakescripts/GNUInstallDirs.cmake)
 
+if(ENABLE_SHARED)
 set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_FULL_LIBDIR})
+endif()
 
 macro(report_directory var)
   if(CMAKE_INSTALL_${var} STREQUAL CMAKE_INSTALL_FULL_${var})


### PR DESCRIPTION
Define CMAKE_INSTALL_RPATH only if ENABLE_SHARED is set otherwise the
following error is raised:

CMake Error at cmake_install.cmake:73 (file):
  file RPATH_CHANGE could not write new RPATH:

    /usr/lib

  to the file:

    /home/fabrice/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/bin/rdjpgcom

  No valid ELF RPATH or RUNPATH entry exists in the file;

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>