### PR TITLE
fix wrongly defined define HAVE_STDLIB_H

### DIFF
--- a/jconfig.h.in
+++ b/jconfig.h.in
@@ -10,16 +10,16 @@
 #define LIBJPEG_TURBO_VERSION_NUMBER  @LIBJPEG_TURBO_VERSION_NUMBER@
 
 /* Support arithmetic encoding */
-#cmakedefine C_ARITH_CODING_SUPPORTED
+#cmakedefine C_ARITH_CODING_SUPPORTED 1
 
 /* Support arithmetic decoding */
-#cmakedefine D_ARITH_CODING_SUPPORTED
+#cmakedefine D_ARITH_CODING_SUPPORTED 1
 
 /* Support in-memory source/destination managers */
-#cmakedefine MEM_SRCDST_SUPPORTED
+#cmakedefine MEM_SRCDST_SUPPORTED 1
 
 /* Use accelerated SIMD routines. */
-#cmakedefine WITH_SIMD
+#cmakedefine WITH_SIMD 1
 
 /*
  * Define BITS_IN_JSAMPLE as either
@@ -33,37 +33,37 @@
 #define BITS_IN_JSAMPLE  @BITS_IN_JSAMPLE@      /* use 8 or 12 */
 
 /* Define to 1 if you have the <locale.h> header file. */
-#cmakedefine HAVE_LOCALE_H
+#cmakedefine HAVE_LOCALE_H 1
 
 /* Define to 1 if you have the <stddef.h> header file. */
-#cmakedefine HAVE_STDDEF_H
+#cmakedefine HAVE_STDDEF_H 1
 
 /* Define to 1 if you have the <stdlib.h> header file. */
-#cmakedefine HAVE_STDLIB_H
+#cmakedefine HAVE_STDLIB_H 1
 
 /* Define if you need to include <sys/types.h> to get size_t. */
-#cmakedefine NEED_SYS_TYPES_H
+#cmakedefine NEED_SYS_TYPES_H 1
 
 /* Define if you have BSD-like bzero and bcopy in <strings.h> rather than
    memset/memcpy in <string.h>. */
-#cmakedefine NEED_BSD_STRINGS
+#cmakedefine NEED_BSD_STRINGS 1
 
 /* Define to 1 if the system has the type `unsigned char'. */
-#cmakedefine HAVE_UNSIGNED_CHAR
+#cmakedefine HAVE_UNSIGNED_CHAR 1
 
 /* Define to 1 if the system has the type `unsigned short'. */
-#cmakedefine HAVE_UNSIGNED_SHORT
+#cmakedefine HAVE_UNSIGNED_SHORT 1
 
 /* Compiler does not support pointers to undefined structures. */
-#cmakedefine INCOMPLETE_TYPES_BROKEN
+#cmakedefine INCOMPLETE_TYPES_BROKEN 1
 
 /* Define if your (broken) compiler shifts signed values as if they were
    unsigned. */
-#cmakedefine RIGHT_SHIFT_IS_UNSIGNED
+#cmakedefine RIGHT_SHIFT_IS_UNSIGNED 1
 
 /* Define to 1 if type `char' is unsigned and you are not using gcc.  */
 #ifndef __CHAR_UNSIGNED__
-  #cmakedefine __CHAR_UNSIGNED__
+  #cmakedefine __CHAR_UNSIGNED__ 1
 #endif
 
 /* Define to empty if `const' does not conform to ANSI C. */

--- a/jconfigint.h.in
+++ b/jconfigint.h.in
@@ -17,10 +17,10 @@
 #define SIZEOF_SIZE_T  @SIZE_T@
 
 /* Define if your compiler has __builtin_ctzl() and sizeof(unsigned long) == sizeof(size_t). */
-#cmakedefine HAVE_BUILTIN_CTZL
+#cmakedefine HAVE_BUILTIN_CTZL 1
 
 /* Define to 1 if you have the <intrin.h> header file. */
-#cmakedefine HAVE_INTRIN_H
+#cmakedefine HAVE_INTRIN_H 1
 
 #if defined(_MSC_VER) && defined(HAVE_INTRIN_H)
 #if (SIZEOF_SIZE_T == 8)


### PR DESCRIPTION
when change build system from autotools to cmake, below
part is replace wrongly:

"#undef HAVE_STDLIB_H"
should be change to "#cmakedefine HAVE_STDLIB_H 1"
not "#cmakedefine HAVE_STDLIB_H"

otherwise, even if stdlib.h is found, output file
of configure_file() will define like: #define HAVE_STDLIB_H
but we need it as #define HAVE_STDLIB_H 1, since for
different defination of HAVE_STDLIB_H will cause below error:
error: "HAVE_STDLIB_H" redefined [-Werror]

Signed-off-by: Changqing Li <changqing.li@windriver.com>