### PR TITLE
Small optimizations

### DIFF
--- a/simd/x86_64/jquanti-avx2.asm
+++ b/simd/x86_64/jquanti-avx2.asm
@@ -48,23 +48,23 @@ EXTN(jsimd_convsamp_avx2):
 
     mov         rsi, JSAMPROW [r10+0*SIZEOF_JSAMPROW]  ; (JSAMPLE *)
     mov         rdi, JSAMPROW [r10+1*SIZEOF_JSAMPROW]  ; (JSAMPLE *)
-    movq        xmm0, XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE]
-    pinsrq      xmm0, XMM_MMWORD [rdi+rax*SIZEOF_JSAMPLE], 1
+    vmovq        xmm0, XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE]
+    vpinsrq      xmm0, XMM_MMWORD [rdi+rax*SIZEOF_JSAMPLE], 1
 
     mov         rsi, JSAMPROW [r10+2*SIZEOF_JSAMPROW]  ; (JSAMPLE *)
     mov         rdi, JSAMPROW [r10+3*SIZEOF_JSAMPROW]  ; (JSAMPLE *)
-    movq        xmm1, XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE]
-    pinsrq      xmm1, XMM_MMWORD [rdi+rax*SIZEOF_JSAMPLE], 1
+    vmovq        xmm1, XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE]
+    vpinsrq      xmm1, XMM_MMWORD [rdi+rax*SIZEOF_JSAMPLE], 1
 
     mov         rsi, JSAMPROW [r10+4*SIZEOF_JSAMPROW]  ; (JSAMPLE *)
     mov         rdi, JSAMPROW [r10+5*SIZEOF_JSAMPROW]  ; (JSAMPLE *)
-    movq        xmm2, XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE]
-    pinsrq      xmm2, XMM_MMWORD [rdi+rax*SIZEOF_JSAMPLE], 1
+    vmovq        xmm2, XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE]
+    vpinsrq      xmm2, XMM_MMWORD [rdi+rax*SIZEOF_JSAMPLE], 1
 
     mov         rsi, JSAMPROW [r10+6*SIZEOF_JSAMPROW]  ; (JSAMPLE *)
     mov         rdi, JSAMPROW [r10+7*SIZEOF_JSAMPROW]  ; (JSAMPLE *)
-    movq        xmm3, XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE]
-    pinsrq      xmm3, XMM_MMWORD [rdi+rax*SIZEOF_JSAMPLE], 1
+    vmovq        xmm3, XMM_MMWORD [rsi+rax*SIZEOF_JSAMPLE]
+    vpinsrq      xmm3, XMM_MMWORD [rdi+rax*SIZEOF_JSAMPLE], 1
 
     vpmovzxbw   ymm0, xmm0              ; ymm0=(00 01 02 03 04 05 06 07 10 11 12 13 14 15 16 17)
     vpmovzxbw   ymm1, xmm1              ; ymm1=(20 21 22 23 24 25 26 27 30 31 32 33 34 35 36 37)


### PR DESCRIPTION
I've noticed that the routine to check the CPU features uses the full 64bit regs even if cpuid and xgetbv only write to the lower 32bits. We can use 32 bit registers and save some code size. 
Also in jsimd_convsamp_avx2() some legacy SSE instruction are mixed with VEX-coded AVX ones. I've switched all of them to VEX encoding to avoid any transition penality with the dirty upper state of ymm registers