### PR TITLE
x32: SIMD support for progressive Huffmann encoding

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,8 +13,6 @@ compiler flags.
 automatically detect an x32 build.
      - Java does not support the x32 ABI, and thus the TurboJPEG Java API will
 automatically be disabled with x32 builds.
-     - SIMD acceleration for progressive Huffman encoding does not (currently)
-work with the x32 ABI and will be disabled in x32 builds.
 
 
 2.0.1

--- a/simd/x86_64/jsimd.c
+++ b/simd/x86_64/jsimd.c
@@ -1031,8 +1031,6 @@ jsimd_can_encode_mcu_AC_first_prepare(void)
     return 0;
   if (sizeof(JCOEF) != 2)
     return 0;
-  if (SIZEOF_SIZE_T != 8)
-    return 0;
   if (simd_support & JSIMD_SSE2)
     return 1;
 
@@ -1056,8 +1054,6 @@ jsimd_can_encode_mcu_AC_refine_prepare(void)
   if (DCTSIZE != 8)
     return 0;
   if (sizeof(JCOEF) != 2)
-    return 0;
-  if (SIZEOF_SIZE_T != 8)
     return 0;
   if (simd_support & JSIMD_SSE2)
     return 1;


### PR DESCRIPTION
With x86_64 and i386 not sharing the same code base these size_t checks don't seem to serve any purpose.