### PR TITLE
simd, cmake: add ability to NOT build 3DNow support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,8 @@ option(WITH_SIMD "Include SIMD extensions, if available for this platform" TRUE)
 boolean_number(WITH_SIMD)
 option(WITH_TURBOJPEG "Include the TurboJPEG API library and associated test programs" TRUE)
 boolean_number(WITH_TURBOJPEG)
+option(WITH_3DNOW "Enable 3DNow supprt" TRUE)
+boolean_number(WITH_3DNOW)
 
 macro(report_option var desc)
   if(${var})
@@ -237,6 +239,8 @@ endif()
 if(NOT WITH_JPEG8)
   report_option(WITH_MEM_SRCDST "In-memory source/destination managers")
 endif()
+
+report_option(WITH_3DNOW "AMD 3DNow support")
 
 set(SO_AGE 2)
 if(WITH_MEM_SRCDST)

--- a/jconfig.h.in
+++ b/jconfig.h.in
@@ -21,6 +21,9 @@
 /* Use accelerated SIMD routines. */
 #cmakedefine WITH_SIMD 1
 
+/* Support 3DNow */
+#cmakedefine WITH_3DNOW 1
+
 /*
  * Define BITS_IN_JSAMPLE as either
  *   8   for 8-bit sample values (the usual setting)

--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -114,8 +114,7 @@ if(CPU_TYPE STREQUAL "x86_64")
     x86_64/jdcolor-avx2.asm x86_64/jdmerge-avx2.asm x86_64/jdsample-avx2.asm
     x86_64/jfdctint-avx2.asm x86_64/jidctint-avx2.asm x86_64/jquanti-avx2.asm)
 else()
-  set(SIMD_SOURCES i386/jsimdcpu.asm i386/jfdctflt-3dn.asm
-    i386/jidctflt-3dn.asm i386/jquant-3dn.asm
+  set(SIMD_SOURCES i386/jsimdcpu.asm
     i386/jccolor-mmx.asm i386/jcgray-mmx.asm i386/jcsample-mmx.asm
     i386/jdcolor-mmx.asm i386/jdmerge-mmx.asm i386/jdsample-mmx.asm
     i386/jfdctfst-mmx.asm i386/jfdctint-mmx.asm i386/jidctfst-mmx.asm
@@ -130,6 +129,10 @@ else()
     i386/jccolor-avx2.asm i386/jcgray-avx2.asm i386/jcsample-avx2.asm
     i386/jdcolor-avx2.asm i386/jdmerge-avx2.asm i386/jdsample-avx2.asm
     i386/jfdctint-avx2.asm i386/jidctint-avx2.asm i386/jquanti-avx2.asm)
+  if(WITH_3DNOW)
+    set(SIMD_SOURCES ${SIMD_SOURCES} i386/jfdctflt-3dn.asm
+      i386/jidctflt-3dn.asm i386/jquant-3dn.asm)
+  endif()
 endif()
 
 if(MSVC_IDE)

--- a/simd/i386/jsimd.c
+++ b/simd/i386/jsimd.c
@@ -57,9 +57,11 @@ init_simd(void)
   env = getenv("JSIMD_FORCEMMX");
   if ((env != NULL) && (strcmp(env, "1") == 0))
     simd_support &= JSIMD_MMX;
+#ifdef WITH_3DNOW
   env = getenv("JSIMD_FORCE3DNOW");
   if ((env != NULL) && (strcmp(env, "1") == 0))
     simd_support &= JSIMD_3DNOW | JSIMD_MMX;
+#endif
   env = getenv("JSIMD_FORCESSE");
   if ((env != NULL) && (strcmp(env, "1") == 0))
     simd_support &= JSIMD_SSE | JSIMD_MMX;
@@ -785,8 +787,10 @@ jsimd_can_convsamp_float(void)
     return 1;
   if (simd_support & JSIMD_SSE)
     return 1;
+#ifdef WITH_3DNOW
   if (simd_support & JSIMD_3DNOW)
     return 1;
+#endif
 
   return 0;
 }
@@ -811,8 +815,10 @@ jsimd_convsamp_float(JSAMPARRAY sample_data, JDIMENSION start_col,
     jsimd_convsamp_float_sse2(sample_data, start_col, workspace);
   else if (simd_support & JSIMD_SSE)
     jsimd_convsamp_float_sse(sample_data, start_col, workspace);
+#ifdef WITH_3DNOW
   else
     jsimd_convsamp_float_3dnow(sample_data, start_col, workspace);
+#endif
 }
 
 GLOBAL(int)
@@ -868,8 +874,10 @@ jsimd_can_fdct_float(void)
 
   if ((simd_support & JSIMD_SSE) && IS_ALIGNED_SSE(jconst_fdct_float_sse))
     return 1;
+#ifdef WITH_3DNOW
   if (simd_support & JSIMD_3DNOW)
     return 1;
+#endif
 
   return 0;
 }
@@ -899,8 +907,10 @@ jsimd_fdct_float(FAST_FLOAT *data)
 {
   if ((simd_support & JSIMD_SSE) && IS_ALIGNED_SSE(jconst_fdct_float_sse))
     jsimd_fdct_float_sse(data);
+#ifdef WITH_3DNOW
   else if (simd_support & JSIMD_3DNOW)
     jsimd_fdct_float_3dnow(data);
+#endif
 }
 
 GLOBAL(int)
@@ -943,8 +953,10 @@ jsimd_can_quantize_float(void)
     return 1;
   if (simd_support & JSIMD_SSE)
     return 1;
+#ifdef WITH_3DNOW
   if (simd_support & JSIMD_3DNOW)
     return 1;
+#endif
 
   return 0;
 }
@@ -968,8 +980,10 @@ jsimd_quantize_float(JCOEFPTR coef_block, FAST_FLOAT *divisors,
     jsimd_quantize_float_sse2(coef_block, divisors, workspace);
   else if (simd_support & JSIMD_SSE)
     jsimd_quantize_float_sse(coef_block, divisors, workspace);
+#ifdef WITH_3DNOW
   else
     jsimd_quantize_float_3dnow(coef_block, divisors, workspace);
+#endif
 }
 
 GLOBAL(int)
@@ -1122,9 +1136,10 @@ jsimd_can_idct_float(void)
     return 1;
   if ((simd_support & JSIMD_SSE) && IS_ALIGNED_SSE(jconst_idct_float_sse))
     return 1;
+#ifdef WITH_3DNOW
   if (simd_support & JSIMD_3DNOW)
     return 1;
-
+#endif
   return 0;
 }
 
@@ -1168,9 +1183,11 @@ jsimd_idct_float(j_decompress_ptr cinfo, jpeg_component_info *compptr,
   else if ((simd_support & JSIMD_SSE) && IS_ALIGNED_SSE(jconst_idct_float_sse))
     jsimd_idct_float_sse(compptr->dct_table, coef_block, output_buf,
                          output_col);
+#ifdef WITH_3DNOW
   else
     jsimd_idct_float_3dnow(compptr->dct_table, coef_block, output_buf,
                            output_col);
+#endif
 }
 
 GLOBAL(int)

--- a/simd/jsimd.h
+++ b/simd/jsimd.h
@@ -18,7 +18,9 @@
 
 #define JSIMD_NONE     0x00
 #define JSIMD_MMX      0x01
+#ifdef WITH_3DNOW
 #define JSIMD_3DNOW    0x02
+#endif
 #define JSIMD_SSE      0x04
 #define JSIMD_SSE2     0x08
 #define JSIMD_NEON     0x10
@@ -870,8 +872,10 @@ EXTERN(void) jsimd_convsamp_altivec
   (JSAMPARRAY sample_data, JDIMENSION start_col, DCTELEM *workspace);
 
 /* Floating Point Sample Conversion */
+#ifdef WITH_3DNOW
 EXTERN(void) jsimd_convsamp_float_3dnow
   (JSAMPARRAY sample_data, JDIMENSION start_col, FAST_FLOAT *workspace);
+#endif
 
 EXTERN(void) jsimd_convsamp_float_sse
   (JSAMPARRAY sample_data, JDIMENSION start_col, FAST_FLOAT *workspace);
@@ -912,7 +916,9 @@ EXTERN(void) jsimd_fdct_ifast_dspr2(DCTELEM *data);
 EXTERN(void) jsimd_fdct_ifast_altivec(DCTELEM *data);
 
 /* Floating Point Forward DCT */
+#ifdef WITH_3DNOW
 EXTERN(void) jsimd_fdct_float_3dnow(FAST_FLOAT *data);
+#endif
 
 extern const int jconst_fdct_float_sse[];
 EXTERN(void) jsimd_fdct_float_sse(FAST_FLOAT *data);
@@ -940,8 +946,10 @@ EXTERN(void) jsimd_quantize_altivec
   (JCOEFPTR coef_block, DCTELEM *divisors, DCTELEM *workspace);
 
 /* Floating Point Quantization */
+#ifdef WITH_3DNOW
 EXTERN(void) jsimd_quantize_float_3dnow
   (JCOEFPTR coef_block, FAST_FLOAT *divisors, FAST_FLOAT *workspace);
+#endif
 
 EXTERN(void) jsimd_quantize_float_sse
   (JCOEFPTR coef_block, FAST_FLOAT *divisors, FAST_FLOAT *workspace);
@@ -1045,9 +1053,11 @@ EXTERN(void) jsimd_idct_ifast_altivec
    JDIMENSION output_col);
 
 /* Floating Point Inverse DCT */
+#ifdef WITH_3DNOW
 EXTERN(void) jsimd_idct_float_3dnow
   (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
    JDIMENSION output_col);
+#endif
 
 extern const int jconst_idct_float_sse[];
 EXTERN(void) jsimd_idct_float_sse

--- a/win/jconfig.h.in
+++ b/win/jconfig.h.in
@@ -6,6 +6,7 @@
 #cmakedefine D_ARITH_CODING_SUPPORTED
 #cmakedefine MEM_SRCDST_SUPPORTED
 #cmakedefine WITH_SIMD
+#cmakedefine WITH_3DNOW
 
 #define BITS_IN_JSAMPLE  @BITS_IN_JSAMPLE@      /* use 8 or 12 */
 


### PR DESCRIPTION
AMD has dropped support for 3DNow instructions over 8 years ago, so in most
cases AMD processors will utilize SSE, SSE2 and/or AVX code path, leaving
3DNow code untouched and just taking storage space.
This commit adds new cmake option (WITH_3DNOW) that defaults to TRUE and
can be changed to FALSE to entirely disable 3DNow support.

Signed-off-by: Piotr Dałek <git@predictor.org.pl>