### PR TITLE
cmake: more visibility for NO_GETENV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,8 @@ option(WITH_SIMD "Include SIMD extensions, if available for this platform" TRUE)
 boolean_number(WITH_SIMD)
 option(WITH_TURBOJPEG "Include the TurboJPEG API library and associated test programs" TRUE)
 boolean_number(WITH_TURBOJPEG)
+option(NO_GETENV "Enable GETENV to control memory usage and force code paths externally" FALSE)
+boolean_number(NO_GETENV)
 
 macro(report_option var desc)
   if(${var})

--- a/jconfig.h.in
+++ b/jconfig.h.in
@@ -21,6 +21,9 @@
 /* Use accelerated SIMD routines. */
 #cmakedefine WITH_SIMD 1
 
+/* Disable GETENV */
+#cmakedefine NO_GETENV
+
 /*
  * Define BITS_IN_JSAMPLE as either
  *   8   for 8-bit sample values (the usual setting)

--- a/win/jconfig.h.in
+++ b/win/jconfig.h.in
@@ -6,6 +6,7 @@
 #cmakedefine D_ARITH_CODING_SUPPORTED
 #cmakedefine MEM_SRCDST_SUPPORTED
 #cmakedefine WITH_SIMD
+#cmakedefine NO_GETENV
 
 #define BITS_IN_JSAMPLE  @BITS_IN_JSAMPLE@      /* use 8 or 12 */
 


### PR DESCRIPTION
Majority of libjpeg-turbo users are totally unaware of the built-in ability
to control memory usage and/or code paths used by library by means of
environment variables. This might be desireable for performance testing
purposes, but in real life it's only dangerous (library will crash when forced
to use particular code paths on CPUs that don't support them).

NO_GETENV define is already in library code, the only thing this patch does
is adding it to CMake so it can be seen without digging through the code ~~and
sets it to 1 so the code covered is not built-in by default~~ (it doesn't do this
anymore, as this breaks tests).

Signed-off-by: Piotr Dałek <git@predictor.org.pl>