### PR TITLE
optimize huffmann compressor

### DIFF
--- a/jchuff.c
+++ b/jchuff.c
@@ -72,11 +72,29 @@ typedef unsigned long long bit_buf_type;
 typedef size_t bit_buf_type;
 #endif
 
+#if defined WITH_SIMD && !(defined __arm__ || defined __aarch64__)
+typedef unsigned long long simd_bit_buf_type;
+#else
+typedef bit_buf_type simd_bit_buf_type;
+#endif
+
 typedef struct {
-  bit_buf_type put_buffer;              /* current bit-accumulation buffer */
-  int put_bits;                         /* # of bits now in it */
+  union {
+      bit_buf_type buffer;              /* current bit-accumulation buffer */
+      simd_bit_buf_type buffer_simd;
+  } put;
+  int free_bits;                         /* # of bits now in it */
   int last_dc_val[MAX_COMPS_IN_SCAN];   /* last DC coef for each component */
 } savable_state;
+
+#if (defined(SIZEOF_SIZE_T) && SIZEOF_SIZE_T == 8) || defined(_WIN64) || (defined(__x86_64__) && defined(__ILP32__))
+#define BIT_BUFFER_SIZE 64
+#elif (defined(SIZEOF_SIZE_T) && SIZEOF_SIZE_T == 4) || defined(_WIN32)
+#define BIT_BUFFER_SIZE 32
+#else
+#error Cannot determine word size
+#endif
+#define SIMD_BIT_BUFFER_SIZE (sizeof(simd_bit_buf_type) * 8)
 
 /* This macro is to work around compilers with missing or broken
  * structure assignment.  You'll need to fix this code if you have
@@ -88,8 +106,8 @@ typedef struct {
 #else
 #if MAX_COMPS_IN_SCAN == 4
 #define ASSIGN_STATE(dest, src) \
-  ((dest).put_buffer = (src).put_buffer, \
-   (dest).put_bits = (src).put_bits, \
+  ((dest).put.buffer_simd = (src).put.buffer_simd, \
+   (dest).free_bits = (src).free_bits, \
    (dest).last_dc_val[0] = (src).last_dc_val[0], \
    (dest).last_dc_val[1] = (src).last_dc_val[1], \
    (dest).last_dc_val[2] = (src).last_dc_val[2], \
@@ -130,6 +148,7 @@ typedef struct {
   size_t free_in_buffer;        /* # of byte spaces remaining in buffer */
   savable_state cur;            /* Current bit buffer & DC state */
   j_compress_ptr cinfo;         /* dump_buffer needs access to this */
+  int simd;
 } working_state;
 
 
@@ -208,8 +227,17 @@ start_pass_huff(j_compress_ptr cinfo, boolean gather_statistics)
   }
 
   /* Initialize bit buffer to empty */
-  entropy->saved.put_buffer = 0;
-  entropy->saved.put_bits = 0;
+  if (entropy->simd) {
+    entropy->saved.put.buffer_simd = 0;
+#if defined __arm__ || defined __aarch64__
+    entropy->saved.free_bits = 0;
+#else
+    entropy->saved.free_bits = SIMD_BIT_BUFFER_SIZE;
+#endif
+  } else {
+    entropy->saved.put.buffer = 0;
+    entropy->saved.free_bits = BIT_BUFFER_SIZE;
+  }
 
   /* Initialize restart stuff */
   entropy->restarts_to_go = cinfo->restart_interval;
@@ -341,90 +369,83 @@ dump_buffer(working_state *state)
 
 /* Outputting bits to the file */
 
-/* These macros perform the same task as the emit_bits() function in the
- * original libjpeg code.  In addition to reducing overhead by explicitly
- * inlining the code, additional performance is achieved by taking into
- * account the size of the bit buffer and waiting until it is almost full
- * before emptying it.  This mostly benefits 64-bit platforms, since 6
- * bytes can be stored in a 64-bit bit buffer before it has to be emptied.
- */
-
-#define EMIT_BYTE() { \
-  JOCTET c; \
-  put_bits -= 8; \
-  c = (JOCTET)GETJOCTET(put_buffer >> put_bits); \
-  *buffer++ = c; \
-  if (c == 0xFF)  /* need to stuff a zero byte? */ \
-    *buffer++ = 0; \
+/* Outputs byte v and an additional 0-byte, buffer is advanced by 2 only if
+   the v is 0xff */
+#define EMIT_BYTE(v) { \
+  buffer[0] = (JOCTET)(v); \
+  buffer[1] = 0; \
+  buffer -= -2 + ((JOCTET)(v) < 0xff); \
 }
 
-#define PUT_BITS(code, size) { \
-  put_bits += size; \
-  put_buffer = (put_buffer << size) | code; \
-}
-
-#define CHECKBUF15() { \
-  if (put_bits > 15) { \
-    EMIT_BYTE() \
-    EMIT_BYTE() \
+/* Output the entire put_buffer */
+/* If there are no 0xff bytes in it, write directly to buffer */
+#if BIT_BUFFER_SIZE == 64
+#define FLUSH do { \
+  if (put_buffer & 0x8080808080808080 & ~(put_buffer + 0x0101010101010101)) { \
+    EMIT_BYTE(put_buffer >> 56); \
+    EMIT_BYTE(put_buffer >> 48); \
+    EMIT_BYTE(put_buffer >> 40); \
+    EMIT_BYTE(put_buffer >> 32); \
+    EMIT_BYTE(put_buffer >> 24); \
+    EMIT_BYTE(put_buffer >> 16); \
+    EMIT_BYTE(put_buffer >>  8); \
+    EMIT_BYTE(put_buffer      ); \
+  } else { \
+    buffer[0] = put_buffer >> 56; \
+    buffer[1] = put_buffer >> 48; \
+    buffer[2] = put_buffer >> 40; \
+    buffer[3] = put_buffer >> 32; \
+    buffer[4] = put_buffer >> 24; \
+    buffer[5] = put_buffer >> 16; \
+    buffer[6] = put_buffer >> 8; \
+    buffer[7] = put_buffer; \
+    buffer += 8; \
   } \
-}
-
-#define CHECKBUF31() { \
-  if (put_bits > 31) { \
-    EMIT_BYTE() \
-    EMIT_BYTE() \
-    EMIT_BYTE() \
-    EMIT_BYTE() \
-  } \
-}
-
-#define CHECKBUF47() { \
-  if (put_bits > 47) { \
-    EMIT_BYTE() \
-    EMIT_BYTE() \
-    EMIT_BYTE() \
-    EMIT_BYTE() \
-    EMIT_BYTE() \
-    EMIT_BYTE() \
-  } \
-}
-
-#if !defined(_WIN32) && !defined(SIZEOF_SIZE_T)
-#error Cannot determine word size
-#endif
-
-#if SIZEOF_SIZE_T == 8 || defined(_WIN64) || (defined(__x86_64__) && defined(__ILP32__))
-
-#define EMIT_BITS(code, size) { \
-  CHECKBUF47() \
-  PUT_BITS(code, size) \
-}
-
-#define EMIT_CODE(code, size) { \
-  temp2 &= (((JLONG)1) << nbits) - 1; \
-  CHECKBUF31() \
-  PUT_BITS(code, size) \
-  PUT_BITS(temp2, nbits) \
-}
-
+} while(0)
 #else
-
-#define EMIT_BITS(code, size) { \
-  PUT_BITS(code, size) \
-  CHECKBUF15() \
-}
-
-#define EMIT_CODE(code, size) { \
-  temp2 &= (((JLONG)1) << nbits) - 1; \
-  PUT_BITS(code, size) \
-  CHECKBUF15() \
-  PUT_BITS(temp2, nbits) \
-  CHECKBUF15() \
-}
-
+#define FLUSH do { \
+  if (put_buffer & 0x80808080 & ~(put_buffer + 0x01010101)) { \
+    EMIT_BYTE(put_buffer >> 24); \
+    EMIT_BYTE(put_buffer >> 16); \
+    EMIT_BYTE(put_buffer >>  8); \
+    EMIT_BYTE(put_buffer      ); \
+  } else { \
+    buffer[0] = put_buffer >> 24; \
+    buffer[1] = put_buffer >> 16; \
+    buffer[2] = put_buffer >> 8; \
+    buffer[3] = put_buffer; \
+    buffer += 4; \
+  } \
+} while(0)
 #endif
 
+/* Fill put_buffer with leading bits from code to capacity,
+   then output put_buffer and set put_buffer to contain the remaining
+   bits of code */
+#define PUT_AND_FLUSH(code, size) do { \
+  put_buffer = (put_buffer << (size + free_bits)) | (code >> -free_bits); \
+  FLUSH; \
+  free_bits += BIT_BUFFER_SIZE; \
+  put_buffer = code; \
+} while(0)
+
+/* Insert code into put_buffer, output put_buffer if needed */
+/* Can't flush with free_bits == 0, since the left shift
+   in PUT_AND_FLUSH would have undefined behavior */
+#define PUT_BITS(code, size) do { \
+  free_bits -= size; \
+  if (free_bits < 0) \
+    PUT_AND_FLUSH(code, size); \
+  else \
+    put_buffer = (put_buffer << size) | code; \
+} while(0)
+
+#define PUT_CODE(code, size) do { \
+  temp &= (((JLONG)1) << nbits) - 1; \
+  temp |= code << nbits; \
+  nbits += size; \
+  PUT_BITS(temp, nbits); \
+} while(0)
 
 /* Although it is exceedingly rare, it is possible for a Huffman-encoded
  * coefficient block to be larger than the 128-byte unencoded block.  For each
@@ -447,6 +468,7 @@ dump_buffer(working_state *state)
 
 #define STORE_BUFFER() { \
   if (localbuf) { \
+    size_t bytes, bytestocopy; \
     bytes = buffer - _buffer; \
     buffer = _buffer; \
     while (bytes > 0) { \
@@ -469,20 +491,47 @@ dump_buffer(working_state *state)
 LOCAL(boolean)
 flush_bits(working_state *state)
 {
-  JOCTET _buffer[BUFSIZE], *buffer;
-  bit_buf_type put_buffer;  int put_bits;
-  size_t bytes, bytestocopy;  int localbuf = 0;
+  JOCTET _buffer[BUFSIZE], *buffer, temp;
+  simd_bit_buf_type put_buffer;  int put_bits;
+  int localbuf = 0;
 
-  put_buffer = state->cur.put_buffer;
-  put_bits = state->cur.put_bits;
+
+  if (state->simd) {
+#if defined __arm__ || defined __aarch64__
+    put_bits = state->cur.free_bits;
+#else
+    put_bits = SIMD_BIT_BUFFER_SIZE - state->cur.free_bits;
+#endif
+    put_buffer = state->cur.put.buffer_simd;
+  } else {
+    put_bits = BIT_BUFFER_SIZE - state->cur.free_bits;
+    put_buffer = state->cur.put.buffer;
+  }
+
   LOAD_BUFFER()
 
-  /* fill any partial byte with ones */
-  PUT_BITS(0x7F, 7)
-  while (put_bits >= 8) EMIT_BYTE()
+  while (put_bits >= 8) {
+    put_bits -= 8;
+    temp = (JOCTET)(put_buffer >> put_bits);
+    EMIT_BYTE(temp);
+  }
+  if (put_bits) {
+    /* fill partial byte with ones */
+    temp = (JOCTET)((put_buffer << (8 - put_bits)) | (0xff >> put_bits));
+    EMIT_BYTE(temp);
+  }
 
-  state->cur.put_buffer = 0;    /* and reset bit-buffer to empty */
-  state->cur.put_bits = 0;
+  if (state->simd) {
+    state->cur.put.buffer_simd = 0;    /* and reset bit-buffer to empty */
+#if defined __arm__ || defined __aarch64__
+    state->cur.free_bits = 0;
+#else
+    state->cur.free_bits = SIMD_BIT_BUFFER_SIZE;
+#endif
+  } else {
+    state->cur.put.buffer = 0;
+    state->cur.free_bits = BIT_BUFFER_SIZE;
+  }
   STORE_BUFFER()
 
   return TRUE;
@@ -496,7 +545,7 @@ encode_one_block_simd(working_state *state, JCOEFPTR block, int last_dc_val,
                       c_derived_tbl *dctbl, c_derived_tbl *actbl)
 {
   JOCTET _buffer[BUFSIZE], *buffer;
-  size_t bytes, bytestocopy;  int localbuf = 0;
+  int localbuf = 0;
 
   LOAD_BUFFER()
 
@@ -512,53 +561,41 @@ LOCAL(boolean)
 encode_one_block(working_state *state, JCOEFPTR block, int last_dc_val,
                  c_derived_tbl *dctbl, c_derived_tbl *actbl)
 {
-  int temp, temp2, temp3;
-  int nbits;
-  int r, code, size;
+  int temp, nbits, free_bits;
+  bit_buf_type put_buffer;
   JOCTET _buffer[BUFSIZE], *buffer;
-  bit_buf_type put_buffer;  int put_bits;
-  int code_0xf0 = actbl->ehufco[0xf0], size_0xf0 = actbl->ehufsi[0xf0];
-  size_t bytes, bytestocopy;  int localbuf = 0;
+  int localbuf = 0;
 
-  put_buffer = state->cur.put_buffer;
-  put_bits = state->cur.put_bits;
+  free_bits = state->cur.free_bits;
+  put_buffer = state->cur.put.buffer;
   LOAD_BUFFER()
 
   /* Encode the DC coefficient difference per section F.1.2.1 */
 
-  temp = temp2 = block[0] - last_dc_val;
+  temp = block[0] - last_dc_val;
 
   /* This is a well-known technique for obtaining the absolute value without a
    * branch.  It is derived from an assembly language technique presented in
    * "How to Optimize for the Pentium Processors", Copyright (c) 1996, 1997 by
    * Agner Fog.
    */
-  temp3 = temp >> (CHAR_BIT * sizeof(int) - 1);
-  temp ^= temp3;
-  temp -= temp3;
-
-  /* For a negative input, want temp2 = bitwise complement of abs(input) */
   /* This code assumes we are on a two's complement machine */
-  temp2 += temp3;
+  nbits = temp >> (CHAR_BIT * sizeof(int) - 1);
+  temp += nbits;
+  nbits ^= temp;
 
   /* Find the number of bits needed for the magnitude of the coefficient */
-  nbits = JPEG_NBITS(temp);
+  nbits = JPEG_NBITS(nbits);
 
   /* Emit the Huffman-coded symbol for the number of bits */
-  code = dctbl->ehufco[nbits];
-  size = dctbl->ehufsi[nbits];
-  EMIT_BITS(code, size)
-
-  /* Mask off any extra bits in code */
-  temp2 &= (((JLONG)1) << nbits) - 1;
-
   /* Emit that number of bits of the value, if positive, */
   /* or the complement of its magnitude, if negative. */
-  EMIT_BITS(temp2, nbits)
+  PUT_CODE(dctbl->ehufco[nbits], dctbl->ehufsi[nbits]);
 
   /* Encode the AC coefficients per section F.1.2.2 */
 
-  r = 0;                        /* r = run length of zeros */
+  {
+    int r = 0;                        /* r = run length of zeros */
 
 /* Manually unroll the k loop to eliminate the counter variable.  This
  * improves performance greatly on systems with a limited number of
@@ -566,51 +603,45 @@ encode_one_block(working_state *state, JCOEFPTR block, int last_dc_val,
  */
 #define kloop(jpeg_natural_order_of_k) { \
   if ((temp = block[jpeg_natural_order_of_k]) == 0) { \
-    r++; \
+    r += 16; \
   } else { \
-    temp2 = temp; \
     /* Branch-less absolute value, bitwise complement, etc., same as above */ \
-    temp3 = temp >> (CHAR_BIT * sizeof(int) - 1); \
-    temp ^= temp3; \
-    temp -= temp3; \
-    temp2 += temp3; \
-    nbits = JPEG_NBITS_NONZERO(temp); \
+    nbits = temp >> (CHAR_BIT * sizeof(int) - 1); \
+    temp += nbits; \
+    nbits ^= temp; \
+    nbits = JPEG_NBITS_NONZERO(nbits); \
     /* if run length > 15, must emit special run-length-16 codes (0xF0) */ \
-    while (r > 15) { \
-      EMIT_BITS(code_0xf0, size_0xf0) \
-      r -= 16; \
+    while (r >= 16 * 16) { \
+      r -= 16 * 16; \
+      PUT_BITS(actbl->ehufco[0xf0], actbl->ehufsi[0xf0]); \
     } \
     /* Emit Huffman symbol for run length / number of bits */ \
-    temp3 = (r << 4) + nbits; \
-    code = actbl->ehufco[temp3]; \
-    size = actbl->ehufsi[temp3]; \
-    EMIT_CODE(code, size) \
+    r += nbits; \
+    PUT_CODE(actbl->ehufco[r], actbl->ehufsi[r]); \
     r = 0; \
   } \
 }
+    /* One iteration for each value in jpeg_natural_order[] */
+    kloop(1);   kloop(8);   kloop(16);  kloop(9);   kloop(2);   kloop(3);
+    kloop(10);  kloop(17);  kloop(24);  kloop(32);  kloop(25);  kloop(18);
+    kloop(11);  kloop(4);   kloop(5);   kloop(12);  kloop(19);  kloop(26);
+    kloop(33);  kloop(40);  kloop(48);  kloop(41);  kloop(34);  kloop(27);
+    kloop(20);  kloop(13);  kloop(6);   kloop(7);   kloop(14);  kloop(21);
+    kloop(28);  kloop(35);  kloop(42);  kloop(49);  kloop(56);  kloop(57);
+    kloop(50);  kloop(43);  kloop(36);  kloop(29);  kloop(22);  kloop(15);
+    kloop(23);  kloop(30);  kloop(37);  kloop(44);  kloop(51);  kloop(58);
+    kloop(59);  kloop(52);  kloop(45);  kloop(38);  kloop(31);  kloop(39);
+    kloop(46);  kloop(53);  kloop(60);  kloop(61);  kloop(54);  kloop(47);
+    kloop(55);  kloop(62);  kloop(63);
 
-  /* One iteration for each value in jpeg_natural_order[] */
-  kloop(1);   kloop(8);   kloop(16);  kloop(9);   kloop(2);   kloop(3);
-  kloop(10);  kloop(17);  kloop(24);  kloop(32);  kloop(25);  kloop(18);
-  kloop(11);  kloop(4);   kloop(5);   kloop(12);  kloop(19);  kloop(26);
-  kloop(33);  kloop(40);  kloop(48);  kloop(41);  kloop(34);  kloop(27);
-  kloop(20);  kloop(13);  kloop(6);   kloop(7);   kloop(14);  kloop(21);
-  kloop(28);  kloop(35);  kloop(42);  kloop(49);  kloop(56);  kloop(57);
-  kloop(50);  kloop(43);  kloop(36);  kloop(29);  kloop(22);  kloop(15);
-  kloop(23);  kloop(30);  kloop(37);  kloop(44);  kloop(51);  kloop(58);
-  kloop(59);  kloop(52);  kloop(45);  kloop(38);  kloop(31);  kloop(39);
-  kloop(46);  kloop(53);  kloop(60);  kloop(61);  kloop(54);  kloop(47);
-  kloop(55);  kloop(62);  kloop(63);
-
-  /* If the last coef(s) were zero, emit an end-of-block code */
-  if (r > 0) {
-    code = actbl->ehufco[0];
-    size = actbl->ehufsi[0];
-    EMIT_BITS(code, size)
+    /* If the last coef(s) were zero, emit an end-of-block code */
+    if (r > 0) {
+      PUT_BITS(actbl->ehufco[0], actbl->ehufsi[0]);
+    }
   }
 
-  state->cur.put_buffer = put_buffer;
-  state->cur.put_bits = put_bits;
+  state->cur.put.buffer = put_buffer;
+  state->cur.free_bits = free_bits;
   STORE_BUFFER()
 
   return TRUE;
@@ -659,6 +690,7 @@ encode_mcu_huff(j_compress_ptr cinfo, JBLOCKROW *MCU_data)
   state.free_in_buffer = cinfo->dest->free_in_buffer;
   ASSIGN_STATE(state.cur, entropy->saved);
   state.cinfo = cinfo;
+  state.simd = entropy->simd;
 
   /* Emit restart marker if needed */
   if (cinfo->restart_interval) {
@@ -728,6 +760,7 @@ finish_pass_huff(j_compress_ptr cinfo)
   state.free_in_buffer = cinfo->dest->free_in_buffer;
   ASSIGN_STATE(state.cur, entropy->saved);
   state.cinfo = cinfo;
+  state.simd = entropy->simd;
 
   /* Flush out the last data */
   if (!flush_bits(&state))

--- a/simd/i386/jchuff-sse2.asm
+++ b/simd/i386/jchuff-sse2.asm
@@ -198,7 +198,8 @@ EXTN(jsimd_huff_encode_one_block_sse2):
 
     mov         esi, POINTER [eax+8]       ; (working_state *state)
     mov         put_buffer, DWORD [esi+8]  ; put_buffer = state->cur.put_buffer;
-    mov         put_bits, DWORD [esi+12]   ; put_bits = state->cur.put_bits;
+    mov         put_bits, 64
+    sub         put_bits, DWORD [esi+16]   ; put_bits = state->cur.put_bits;
     push        esi                        ; esi is now scratch
 
     get_GOT     edx                        ; get GOT address
@@ -408,7 +409,9 @@ EXTN(jsimd_huff_encode_one_block_sse2):
     pop         esi
     ; Save put_buffer & put_bits
     mov         DWORD [esi+8], put_buffer  ; state->cur.put_buffer = put_buffer;
-    mov         DWORD [esi+12], put_bits   ; state->cur.put_bits = put_bits;
+    sub         put_bits, 64
+    neg         put_bits
+    mov         DWORD [esi+16], put_bits   ; state->cur.put_bits = put_bits;
 
     pop         ebp
     pop         edi

--- a/simd/nasm/jsimdext.inc
+++ b/simd/nasm/jsimdext.inc
@@ -137,6 +137,8 @@ section .note.GNU-stack noalloc noexec nowrite progbits
 %define POINTER         qword           ; general pointer type
 %define SIZEOF_POINTER  SIZEOF_QWORD    ; sizeof(POINTER)
 %define POINTER_BIT     QWORD_BIT       ; sizeof(POINTER)*BYTE_BIT
+%define resp            resq
+%define dp              dq
 %define raxp            rax
 %define rbxp            rbx
 %define rcxp            rcx
@@ -159,6 +161,8 @@ section .note.GNU-stack noalloc noexec nowrite progbits
 %define POINTER         dword           ; general pointer type
 %define SIZEOF_POINTER  SIZEOF_DWORD    ; sizeof(POINTER)
 %define POINTER_BIT     DWORD_BIT       ; sizeof(POINTER)*BYTE_BIT
+%define resp            resd
+%define dp              dd
 ; x86_64 ILP32 ABI (x32)
 %define raxp            eax
 %define rbxp            ebx

--- a/simd/x86_64/jchuff-sse2.asm
+++ b/simd/x86_64/jchuff-sse2.asm
@@ -201,7 +201,8 @@ EXTN(jsimd_huff_encode_one_block_sse2):
     mov         buffer, r11                  ; r11 is now sratch
 
     mov         put_buffer, MMWORD [r10+SIZEOF_POINTER*2]    ; put_buffer = state->cur.put_buffer;
-    mov         put_bits,    DWORD [r10+SIZEOF_POINTER*2+8]  ; put_bits = state->cur.put_bits;
+    mov         put_bits, 64
+    sub         put_bits,    DWORD [r10+SIZEOF_POINTER*2+8]  ; put_bits = state->cur.put_bits;
     push        r10                          ; r10 is now scratch
 
     ; Encode the DC coefficient difference per section F.1.2.1
@@ -334,6 +335,8 @@ EXTN(jsimd_huff_encode_one_block_sse2):
     pop         r10
     ; Save put_buffer & put_bits
     mov         MMWORD [r10+SIZEOF_POINTER*2], put_buffer  ; state->cur.put_buffer = put_buffer;
+    sub         put_bits, 64
+    neg         put_bits
     mov         DWORD  [r10+SIZEOF_POINTER*2+8], put_bits  ; state->cur.put_bits = put_bits;
 
     pop         rbx

--- a/simd/x86_64/jchuff-sse2.asm
+++ b/simd/x86_64/jchuff-sse2.asm
@@ -16,149 +16,152 @@
 ; http://sourceforge.net/project/showfiles.php?group_id=6208
 ;
 ; This file contains an SSE2 implementation for Huffman coding of one block.
-; The following code is based directly on jchuff.c; see jchuff.c for more
-; details.
+; The following code is based on jchuff.c; see jchuff.c for more details.
 ;
 ; [TAB8]
 
 %include "jsimdext.inc"
 
+struc working_state
+.next_output_byte:   resp    1   ; => next byte to write in buffer
+.free_in_buffer:     resp    1   ; # of byte spaces remaining in buffer
+.cur.put.buffer_simd resq    1   ; current bit-accumulation buffer
+.cur.free_bits       resd    1   ; # of free bits now in it
+.cur.last_dc_val     resd    4   ; last DC coef for each component
+.cinfo:              resp    1   ; dump_buffer needs access to this
+endstruc
+
+struc c_derived_tbl
+.ehufco:             resd    256 ; code for each symbol
+.ehufsi:             resb    256 ; length of code for each symbol
+; If no code has been allocated for a symbol S, ehufsi[S] contains 0
+endstruc
+
 ; --------------------------------------------------------------------------
     SECTION     SEG_CONST
 
     alignz      32
-    GLOBAL_DATA(jconst_huff_encode_one_block)
 
+    GLOBAL_DATA(jconst_huff_encode_one_block)
 EXTN(jconst_huff_encode_one_block):
 
-%include "jpeg_nbits_table.inc"
+jpeg_mask_bits  dd 0x0000, 0x0001, 0x0003, 0x0007
+                dd 0x000f, 0x001f, 0x003f, 0x007f
+                dd 0x00ff, 0x01ff, 0x03ff, 0x07ff
+                dd 0x0fff, 0x1fff, 0x3fff, 0x7fff
 
     alignz      32
+
+       times 1 << 14 db 15
+       times 1 << 13 db 14
+       times 1 << 12 db 13
+       times 1 << 11 db 12
+       times 1 << 10 db 11
+       times 1 <<  9 db 10
+       times 1 <<  8 db  9
+       times 1 <<  7 db  8
+       times 1 <<  6 db  7
+       times 1 <<  5 db  6
+       times 1 <<  4 db  5
+       times 1 <<  3 db  4
+       times 1 <<  2 db  3
+       times 1 <<  1 db  2
+       times 1 <<  0 db  1
+       times 1       db  0
+jpeg_nbits_table:
+       times 1       db  0
+       times 1 <<  0 db  1
+       times 1 <<  1 db  2
+       times 1 <<  2 db  3
+       times 1 <<  3 db  4
+       times 1 <<  4 db  5
+       times 1 <<  5 db  6
+       times 1 <<  6 db  7
+       times 1 <<  7 db  8
+       times 1 <<  8 db  9
+       times 1 <<  9 db 10
+       times 1 << 10 db 11
+       times 1 << 11 db 12
+       times 1 << 12 db 13
+       times 1 << 13 db 14
+       times 1 << 14 db 15
+
+    alignz      32
+
+%define NBITS(x) nbits_base + x
+%define MASK_BITS(x) NBITS((x) * 4) + (jpeg_mask_bits - jpeg_nbits_table)
 
 ; --------------------------------------------------------------------------
     SECTION     SEG_TEXT
     BITS        64
 
-; These macros perform the same task as the emit_bits() function in the
-; original libjpeg code.  In addition to reducing overhead by explicitly
-; inlining the code, additional performance is achieved by taking into
-; account the size of the bit buffer and waiting until it is almost full
-; before emptying it.  This mostly benefits 64-bit platforms, since 6
-; bytes can be stored in a 64-bit bit buffer before it has to be emptied.
+; Insert %%code into put_buffer, flush put_buffer and put the overflowing
+; bits of %%code into the now empty put_buffer.
+; uses:
+; %%code - contains the bits to shift into put_buffer, LSB aligned
+; %%jump_to - the label to jump to when leaving the function
+; put_buffer - (partially) filled buffer that will be full after inserting %%code
+; free_bits - the number of free bits in put_buffer after inserting %%code
+;             directly, is either 0 or negative
+; clobbers temp and %%code
 
-%macro EMIT_BYTE 0
-    sub         put_bits, 8             ; put_bits -= 8;
-    mov         rdx, put_buffer
-    mov         ecx, put_bits
-    shr         rdx, cl                 ; c = (JOCTET)GETJOCTET(put_buffer >> put_bits);
-    mov         byte [buffer], dl       ; *buffer++ = c;
-    add         buffer, 1
-    cmp         dl, 0xFF                ; need to stuff a zero byte?
-    jne         %%.EMIT_BYTE_END
-    mov         byte [buffer], 0        ; *buffer++ = 0;
-    add         buffer, 1
-%%.EMIT_BYTE_END:
-%endmacro
-
-%macro PUT_BITS 1
-    add         put_bits, ecx           ; put_bits += size;
-    shl         put_buffer, cl          ; put_buffer = (put_buffer << size);
-    or          put_buffer, %1
-%endmacro
-
-%macro CHECKBUF31 0
-    cmp         put_bits, 32            ; if (put_bits > 31) {
-    jl          %%.CHECKBUF31_END
-    EMIT_BYTE
-    EMIT_BYTE
-    EMIT_BYTE
-    EMIT_BYTE
-%%.CHECKBUF31_END:
-%endmacro
-
-%macro CHECKBUF47 0
-    cmp         put_bits, 48            ; if (put_bits > 47) {
-    jl          %%.CHECKBUF47_END
-    EMIT_BYTE
-    EMIT_BYTE
-    EMIT_BYTE
-    EMIT_BYTE
-    EMIT_BYTE
-    EMIT_BYTE
-%%.CHECKBUF47_END:
-%endmacro
-
-%macro EMIT_BITS 2
-    CHECKBUF47
-    mov         ecx, %2
-    PUT_BITS    %1
-%endmacro
-
-%macro kloop_prepare 37                 ;(ko, jno0, ..., jno31, xmm0, xmm1, xmm2, xmm3)
-    pxor        xmm8, xmm8              ; __m128i neg = _mm_setzero_si128();
-    pxor        xmm9, xmm9              ; __m128i neg = _mm_setzero_si128();
-    pxor        xmm10, xmm10            ; __m128i neg = _mm_setzero_si128();
-    pxor        xmm11, xmm11            ; __m128i neg = _mm_setzero_si128();
-    pinsrw      %34, word [r12 + %2  * SIZEOF_WORD], 0  ; xmm_shadow[0] = block[jno0];
-    pinsrw      %35, word [r12 + %10 * SIZEOF_WORD], 0  ; xmm_shadow[8] = block[jno8];
-    pinsrw      %36, word [r12 + %18 * SIZEOF_WORD], 0  ; xmm_shadow[16] = block[jno16];
-    pinsrw      %37, word [r12 + %26 * SIZEOF_WORD], 0  ; xmm_shadow[24] = block[jno24];
-    pinsrw      %34, word [r12 + %3  * SIZEOF_WORD], 1  ; xmm_shadow[1] = block[jno1];
-    pinsrw      %35, word [r12 + %11 * SIZEOF_WORD], 1  ; xmm_shadow[9] = block[jno9];
-    pinsrw      %36, word [r12 + %19 * SIZEOF_WORD], 1  ; xmm_shadow[17] = block[jno17];
-    pinsrw      %37, word [r12 + %27 * SIZEOF_WORD], 1  ; xmm_shadow[25] = block[jno25];
-    pinsrw      %34, word [r12 + %4  * SIZEOF_WORD], 2  ; xmm_shadow[2] = block[jno2];
-    pinsrw      %35, word [r12 + %12 * SIZEOF_WORD], 2  ; xmm_shadow[10] = block[jno10];
-    pinsrw      %36, word [r12 + %20 * SIZEOF_WORD], 2  ; xmm_shadow[18] = block[jno18];
-    pinsrw      %37, word [r12 + %28 * SIZEOF_WORD], 2  ; xmm_shadow[26] = block[jno26];
-    pinsrw      %34, word [r12 + %5  * SIZEOF_WORD], 3  ; xmm_shadow[3] = block[jno3];
-    pinsrw      %35, word [r12 + %13 * SIZEOF_WORD], 3  ; xmm_shadow[11] = block[jno11];
-    pinsrw      %36, word [r12 + %21 * SIZEOF_WORD], 3  ; xmm_shadow[19] = block[jno19];
-    pinsrw      %37, word [r12 + %29 * SIZEOF_WORD], 3  ; xmm_shadow[27] = block[jno27];
-    pinsrw      %34, word [r12 + %6  * SIZEOF_WORD], 4  ; xmm_shadow[4] = block[jno4];
-    pinsrw      %35, word [r12 + %14 * SIZEOF_WORD], 4  ; xmm_shadow[12] = block[jno12];
-    pinsrw      %36, word [r12 + %22 * SIZEOF_WORD], 4  ; xmm_shadow[20] = block[jno20];
-    pinsrw      %37, word [r12 + %30 * SIZEOF_WORD], 4  ; xmm_shadow[28] = block[jno28];
-    pinsrw      %34, word [r12 + %7  * SIZEOF_WORD], 5  ; xmm_shadow[5] = block[jno5];
-    pinsrw      %35, word [r12 + %15 * SIZEOF_WORD], 5  ; xmm_shadow[13] = block[jno13];
-    pinsrw      %36, word [r12 + %23 * SIZEOF_WORD], 5  ; xmm_shadow[21] = block[jno21];
-    pinsrw      %37, word [r12 + %31 * SIZEOF_WORD], 5  ; xmm_shadow[29] = block[jno29];
-    pinsrw      %34, word [r12 + %8  * SIZEOF_WORD], 6  ; xmm_shadow[6] = block[jno6];
-    pinsrw      %35, word [r12 + %16 * SIZEOF_WORD], 6  ; xmm_shadow[14] = block[jno14];
-    pinsrw      %36, word [r12 + %24 * SIZEOF_WORD], 6  ; xmm_shadow[22] = block[jno22];
-    pinsrw      %37, word [r12 + %32 * SIZEOF_WORD], 6  ; xmm_shadow[30] = block[jno30];
-    pinsrw      %34, word [r12 + %9  * SIZEOF_WORD], 7  ; xmm_shadow[7] = block[jno7];
-    pinsrw      %35, word [r12 + %17 * SIZEOF_WORD], 7  ; xmm_shadow[15] = block[jno15];
-    pinsrw      %36, word [r12 + %25 * SIZEOF_WORD], 7  ; xmm_shadow[23] = block[jno23];
-%if %1 != 32
-    pinsrw      %37, word [r12 + %33 * SIZEOF_WORD], 7  ; xmm_shadow[31] = block[jno31];
-%else
-    pinsrw      %37, ebx, 7             ; xmm_shadow[31] = block[jno31];
-%endif
-    pcmpgtw     xmm8, %34               ; neg = _mm_cmpgt_epi16(neg, x1);
-    pcmpgtw     xmm9, %35               ; neg = _mm_cmpgt_epi16(neg, x1);
-    pcmpgtw     xmm10, %36              ; neg = _mm_cmpgt_epi16(neg, x1);
-    pcmpgtw     xmm11, %37              ; neg = _mm_cmpgt_epi16(neg, x1);
-    paddw       %34, xmm8               ; x1 = _mm_add_epi16(x1, neg);
-    paddw       %35, xmm9               ; x1 = _mm_add_epi16(x1, neg);
-    paddw       %36, xmm10              ; x1 = _mm_add_epi16(x1, neg);
-    paddw       %37, xmm11              ; x1 = _mm_add_epi16(x1, neg);
-    pxor        %34, xmm8               ; x1 = _mm_xor_si128(x1, neg);
-    pxor        %35, xmm9               ; x1 = _mm_xor_si128(x1, neg);
-    pxor        %36, xmm10              ; x1 = _mm_xor_si128(x1, neg);
-    pxor        %37, xmm11              ; x1 = _mm_xor_si128(x1, neg);
-    pxor        xmm8, %34               ; neg = _mm_xor_si128(neg, x1);
-    pxor        xmm9, %35               ; neg = _mm_xor_si128(neg, x1);
-    pxor        xmm10, %36              ; neg = _mm_xor_si128(neg, x1);
-    pxor        xmm11, %37              ; neg = _mm_xor_si128(neg, x1);
-    movdqa      XMMWORD [t1 + %1 * SIZEOF_WORD], %34           ; _mm_storeu_si128((__m128i *)(t1 + ko), x1);
-    movdqa      XMMWORD [t1 + (%1 + 8) * SIZEOF_WORD], %35     ; _mm_storeu_si128((__m128i *)(t1 + ko + 8), x1);
-    movdqa      XMMWORD [t1 + (%1 + 16) * SIZEOF_WORD], %36    ; _mm_storeu_si128((__m128i *)(t1 + ko + 16), x1);
-    movdqa      XMMWORD [t1 + (%1 + 24) * SIZEOF_WORD], %37    ; _mm_storeu_si128((__m128i *)(t1 + ko + 24), x1);
-    movdqa      XMMWORD [t2 + %1 * SIZEOF_WORD], xmm8          ; _mm_storeu_si128((__m128i *)(t2 + ko), neg);
-    movdqa      XMMWORD [t2 + (%1 + 8) * SIZEOF_WORD], xmm9    ; _mm_storeu_si128((__m128i *)(t2 + ko + 8), neg);
-    movdqa      XMMWORD [t2 + (%1 + 16) * SIZEOF_WORD], xmm10  ; _mm_storeu_si128((__m128i *)(t2 + ko + 16), neg);
-    movdqa      XMMWORD [t2 + (%1 + 24) * SIZEOF_WORD], xmm11  ; _mm_storeu_si128((__m128i *)(t2 + ko + 24), neg);
+%macro EMIT_QWORD 1-2
+%define %%jump_to    %1
+%define %%extra_insn %2
+    add         nbitsb, free_bitsb      ; nbits += free_bits
+    neg         free_bitsb              ; free_bits = -free_bits
+    mov         tempd, code           ; temp = code;
+    shl         put_buffer, nbitsb      ; put_buffer <<= nbits
+    mov         nbitsb, free_bitsb      ; nbits = free_bits
+    neg         free_bitsb              ; free_bits = -free_bits;
+    shr         tempd, nbitsb           ; temp >>= nbits
+    or          tempq, put_buffer       ; temp |= put_buffer;
+    movq        xmm0, tempq             ; xmm0.u64 = { 0, temp };
+    bswap       tempq                   ; temp = htonl(temp);
+    mov         put_buffer, codeq     ; put_buffer = code
+    pcmpeqb     xmm0, xmm1              ; i = 0...15: xmm0.u8[i] = xmm0.u8[i] == 0xff ? 0xff : 0...;
+    %%extra_insn
+    pmovmskb    code, xmm0              ; i = 0...15: code = (((xmm0.u8[i] >> 7) << i) | ...);
+    mov         qword [buffer], tempq   ; memcpy(buffer, &temp, 8);
+    add         free_bitsb, 64          ; free_bits += 64;
+    add         bufferp, 8              ; buffer += 8;
+    test        code, code              ; if (code == 0)
+    jz          %%jump_to               ;     return;
+    cmp         tempb, 0xff             ; temp[0] - 0xff ?
+    mov         byte [buffer-7], 0      ; buffer[-7] = 0;
+    sbb         bufferp, 6              ; buffer -= 6 + (temp[0] - 0xff < 0);
+    mov         byte [buffer], temph    ; buffer[0] = temp[1];
+    cmp         temph, 0xff             ; temp[1] - 0xff ?
+    mov         byte [buffer+1], 0      ; buffer[1] = 0;
+    sbb         bufferp, -2             ; buffer -= -2 + (temp[1] - 0xff < 0);
+    shr         tempq, 16               ; temp >>= 16;
+    mov         byte [buffer], tempb    ; buffer[0] = temp[0];
+    cmp         tempb, 0xff             ; temp[0] - 0xff ?
+    mov         byte [buffer+1], 0      ; buffer[1] = 0;
+    sbb         bufferp, -2             ; buffer -= -2 + (temp[1] - 0xff < 0);
+    mov         byte [buffer], temph    ; buffer[0] = temp[1];
+    cmp         temph, 0xff             ; temp[1] - 0xff ?
+    mov         byte [buffer+1], 0      ; buffer[1] = 0;
+    sbb         bufferp, -2             ; buffer -= -2 + (temp[1] - 0xff < 0);
+    shr         tempq, 16               ; temp >>= 16;
+    mov         byte [buffer], tempb    ; buffer[0] = temp[0];
+    cmp         tempb, 0xff             ; temp[0] - 0xff ?
+    mov         byte [buffer+1], 0      ; buffer[1] = 0;
+    sbb         bufferp, -2             ; buffer -= -2 + (temp[1] - 0xff < 0);
+    mov         byte [buffer], temph    ; buffer[0] = temp[1];
+    cmp         temph, 0xff             ; temp[1] - 0xff ?
+    mov         byte [buffer+1], 0      ; buffer[1] = 0;
+    sbb         bufferp, -2             ; buffer -= -2 + (temp[1] - 0xff < 0);
+    shr         tempd, 16               ; temp >>= 16;
+    mov         byte [buffer], tempb    ; buffer[0] = temp[0];
+    cmp         tempb, 0xff             ; temp[0] - 0xff ?
+    mov         byte [buffer+1], 0      ; buffer[1] = 0;
+    sbb         bufferp, -2             ; buffer -= -2 + (temp[1] - 0xff < 0);
+    mov         byte [buffer], temph    ; buffer[0] = temp[1];
+    cmp         temph, 0xff             ; temp[1] - 0xff ?
+    mov         byte [buffer+1], 0      ; buffer[1] = 0;
+    sbb         bufferp, -2             ; buffer -= -2 + (temp[1] - 0xff < 0);
+    jmp         %%jump_to               ; return;
 %endmacro
 
 ;
@@ -170,182 +173,346 @@ EXTN(jconst_huff_encode_one_block):
 ;                                  c_derived_tbl *dctbl, c_derived_tbl *actbl)
 ;
 
-; r10 = working_state *state
-; r11 = JOCTET *buffer
-; r12 = JCOEFPTR block
-; r13d = int last_dc_val
-; r14 = c_derived_tbl *dctbl
-; r15 = c_derived_tbl *actbl
-
-%define t1          rbp - (DCTSIZE2 * SIZEOF_WORD)
-%define t2          t1 - (DCTSIZE2 * SIZEOF_WORD)
-%define put_buffer  r8
-%define put_bits    r9d
-%define buffer      rax
-
     align       32
     GLOBAL_FUNCTION(jsimd_huff_encode_one_block_sse2)
 
+; Notes:
+; When shuffling data we try to avoid pinsrw as much as possible as it is slow on many processors.
+; Its reciprocal throughput (issue latency) is 1 even on modern cpus, so chains
+; even with different outputs can limit performance. pinsrw is a vectorpath instruction
+; on amd K8 and requires 2 µops (with mem operand) on intel. In either case only one pinsrw
+; instruction can be decoded per cycle (and nothing else if they are back to back) so out-of-order
+; execution cannot be used to work around long pinsrw chains, though for Sandy Bridge and later
+; this may be less of a problem if the code runs out of the µop cache.
+;
+; We use tzcnt instead of bsf without checking for support, the instruction is executed
+; as bsf on processors that don't support tzcnt (encoding is equivalent to rep bsf).
+; bsf (and tzcnt on some processors) carries an input dependency on its first operand
+; (although formally undefinied, intel processors usually leave the destination
+; unmodified, if source is zero). This can prevent out-of-order execution, therefore we
+; clear dst before tzcnt.
+
+; initial register allocation
+; rax - buffer
+; rbx - temp
+; rcx - last_dc_val(unix)  -> nbits
+; rdx - block              -> free_bits
+; rsi - nbits_base
+; rdi - t
+; rbp - code
+; r8  - dctbl              -> code_temp
+; r9  - actbl
+; r10 - state
+; r11 - index
+; r12 - put_buffer
+
+
+%define tempq           rbx
+%define tempd           ebx
+%define temph           bh
+%define tempb           bl
+%define nbits           ecx
+%define nbitsq          rcx
+%define nbitsb          cl
+%define nbits_base      rsi
+%define t               rdi
+%define td              edi
+%define code            ebp
+%define codeq           rbp
+%define index           r11
+%define indexd          r11d
+%define put_buffer      r12
+%define put_bufferd     r12d
+
+; step 1: arrange input data according to jpeg_natural_order
+;  0                       d3 d2 b6 b5 a5 a4 a0 xx a b   d             a7 a6 a5 a4 a3 a2 a1 a0
+;  8                    f1 d4 d1 b7 b4 a6 a3 a1    a b   d   f         b7 b6 b5 b4 b3 b2 b1 b0
+; 16                 f2 f0 d5 d0 c0 b3 a7 a2       a b c d   f         c7 c6 c5 c4 c3 c2 c1 c0
+; 24              g4 f3 e7 d6 c7 c1 b2 b0            b c d e f g   ==> d7 d6 d5 d4 d3 d2 d1 d0
+; 32           g5 g3 f4 e6 d7 c6 c2 b1               b c d e f g       e7 e6 e5 e4 e3 e2 e1 e0
+; 40        h3 g6 g2 f5 e5 e0 c5 c3                    c   e f g h     f7 f6 f5 f4 f3 f2 f1 f0
+; 48     h4 h2 g7 g1 f6 e4 e1 c4                       c   e f g h     g7 g6 g5 g4 g3 g2 g1 g0
+; 56  h6 h5 h1 h0 g0 f7 e3 e2                              e f g h     00 h6 h5 h4 h3 h2 h1 h0
+                                                        ; i: 0..7
 EXTN(jsimd_huff_encode_one_block_sse2):
-    push        rbp
-    mov         rax, rsp                     ; rax = original rbp
-    sub         rsp, byte 4
-    and         rsp, byte (-SIZEOF_XMMWORD)  ; align to 128 bits
-    mov         [rsp], rax
-    mov         rbp, rsp                     ; rbp = aligned rbp
-    lea         rsp, [t2]
-    push_xmm    4
-    collect_args 6
+%ifdef WIN64
+%define state         rcx
+%define buffer        rdx
+%define block         r8
+%define last_dc_val   r9d
+    mov         rax, buffer
+%define bufferp       rax
+%define buffer        rax
+    mov         rdx, block
+%define block         rdx
+    movups      xmm3, XMMWORD [block +  0 * SIZEOF_WORD] ; w3: d3 d2 b6 b5 a5 a4 a0 xx
     push        rbx
+    push        rbp
+    movdqa      xmm0, xmm3                               ; w0: d3 d2 b6 b5 a5 a4 a0 xx
+    push        rsi
+    push        rdi
+    push        r12
+    movups      xmm1, XMMWORD [block +  8 * SIZEOF_WORD] ; w1: f1 d4 d1 b7 b4 a6 a3 a1
+%define dctbl         POINTER [rsp+6*8+4*8]
+%define actbl         POINTER [rsp+6*8+5*8]
+    mov         r10, state
+%define state         r10
+    movsx       code, word [block]                                                     ; code = block[0];
+    pxor        xmm4, xmm4
+    sub         code, last_dc_val                                                      ; code -= last_dc_val;
+%undef last_dc_val
+    mov         r8, dctbl
+%define dctbl         r8
+    mov         r9, actbl
+    punpckldq   xmm0, xmm1                               ; w0: b4 a6 a5 a4 a3 a1 a0 xx
+%define actbl         r9
+    lea         nbits_base, [rel jpeg_nbits_table]
+    add         rsp, -DCTSIZE2 * SIZEOF_WORD
+    mov         t, rsp
+%else
+%define state         rdi
+%define buffer        rsi
+%define block         rdx
+%define last_dc_val   rcx
+%define dctbl         r8
+%define actbl         r9
+    movups      xmm3, XMMWORD [block +  0 * SIZEOF_WORD] ; w3: d3 d2 b6 b5 a5 a4 a0 xx
+    push        rbx
+    push        rbp
+    movdqa      xmm0, xmm3                               ; w0: d3 d2 b6 b5 a5 a4 a0 xx
+    push        r12
+    mov         r10, state
+%define state         r10
+    mov         rax, buffer
+%define bufferp       raxp
+%define buffer        rax
+    movups      xmm1, XMMWORD [block +  8 * SIZEOF_WORD] ; w1: f1 d4 d1 b7 b4 a6 a3 a1
+    movsx       codeq, word [block]                                                    ; code = block[0];
+    lea         nbits_base, [rel jpeg_nbits_table]
+    pxor        xmm4, xmm4                               ; w4[i] = 0
+    sub         codeq, last_dc_val                                                     ; code -= last_dc_val;
+%undef last_dc_val
+    punpckldq   xmm0, xmm1                               ; w0: b4 a6 a5 a4 a3 a1 a0 xx
+    lea         t, [rsp - DCTSIZE2 * SIZEOF_WORD] ; use red zone for t_
+%endif
 
-    mov         buffer, r11                  ; r11 is now sratch
-
-    mov         put_buffer, MMWORD [r10+SIZEOF_POINTER*2]    ; put_buffer = state->cur.put_buffer;
-    mov         put_bits, 64
-    sub         put_bits,    DWORD [r10+SIZEOF_POINTER*2+8]  ; put_bits = state->cur.put_bits;
-    push        r10                          ; r10 is now scratch
-
-    ; Encode the DC coefficient difference per section F.1.2.1
-    movsx       edi, word [r12]         ; temp = temp2 = block[0] - last_dc_val;
-    sub         edi, r13d               ; r13 is not used anymore
-    mov         ebx, edi
-
-    ; This is a well-known technique for obtaining the absolute value
-    ; without a branch.  It is derived from an assembly language technique
-    ; presented in "How to Optimize for the Pentium Processors",
-    ; Copyright (c) 1996, 1997 by Agner Fog.
-    mov         esi, edi
-    sar         esi, 31                 ; temp3 = temp >> (CHAR_BIT * sizeof(int) - 1);
-    xor         edi, esi                ; temp ^= temp3;
-    sub         edi, esi                ; temp -= temp3;
-
-    ; For a negative input, want temp2 = bitwise complement of abs(input)
-    ; This code assumes we are on a two's complement machine
-    add         ebx, esi                ; temp2 += temp3;
-
-    ; Find the number of bits needed for the magnitude of the coefficient
-    lea         r11, [rel jpeg_nbits_table]
-    movzx       rdi, byte [r11 + rdi]         ; nbits = JPEG_NBITS(temp);
-    ; Emit the Huffman-coded symbol for the number of bits
-    mov         r11d,  INT [r14 + rdi * 4]    ; code = dctbl->ehufco[nbits];
-    movzx       esi, byte [r14 + rdi + 1024]  ; size = dctbl->ehufsi[nbits];
-    EMIT_BITS   r11, esi                      ; EMIT_BITS(code, size)
-
-    ; Mask off any extra bits in code
-    mov         esi, 1
-    mov         ecx, edi
-    shl         esi, cl
-    dec         esi
-    and         ebx, esi                ; temp2 &= (((JLONG)1)<<nbits) - 1;
-
-    ; Emit that number of bits of the value, if positive,
-    ; or the complement of its magnitude, if negative.
-    EMIT_BITS   rbx, edi                ; EMIT_BITS(temp2, nbits)
-
-    ; Prepare data
-    xor         ebx, ebx
-    kloop_prepare  0,  1,  8,  16, 9,  2,  3,  10, 17, 24, 32, 25, \
-                   18, 11, 4,  5,  12, 19, 26, 33, 40, 48, 41, 34, \
-                   27, 20, 13, 6,  7,  14, 21, 28, 35, \
-                   xmm0, xmm1, xmm2, xmm3
-    kloop_prepare  32, 42, 49, 56, 57, 50, 43, 36, 29, 22, 15, 23, \
-                   30, 37, 44, 51, 58, 59, 52, 45, 38, 31, 39, 46, \
-                   53, 60, 61, 54, 47, 55, 62, 63, 63, \
-                   xmm4, xmm5, xmm6, xmm7
-
-    pxor        xmm8, xmm8
-    pcmpeqw     xmm0, xmm8              ; tmp0 = _mm_cmpeq_epi16(tmp0, zero);
-    pcmpeqw     xmm1, xmm8              ; tmp1 = _mm_cmpeq_epi16(tmp1, zero);
-    pcmpeqw     xmm2, xmm8              ; tmp2 = _mm_cmpeq_epi16(tmp2, zero);
-    pcmpeqw     xmm3, xmm8              ; tmp3 = _mm_cmpeq_epi16(tmp3, zero);
-    pcmpeqw     xmm4, xmm8              ; tmp4 = _mm_cmpeq_epi16(tmp4, zero);
-    pcmpeqw     xmm5, xmm8              ; tmp5 = _mm_cmpeq_epi16(tmp5, zero);
-    pcmpeqw     xmm6, xmm8              ; tmp6 = _mm_cmpeq_epi16(tmp6, zero);
-    pcmpeqw     xmm7, xmm8              ; tmp7 = _mm_cmpeq_epi16(tmp7, zero);
-    packsswb    xmm0, xmm1              ; tmp0 = _mm_packs_epi16(tmp0, tmp1);
-    packsswb    xmm2, xmm3              ; tmp2 = _mm_packs_epi16(tmp2, tmp3);
-    packsswb    xmm4, xmm5              ; tmp4 = _mm_packs_epi16(tmp4, tmp5);
-    packsswb    xmm6, xmm7              ; tmp6 = _mm_packs_epi16(tmp6, tmp7);
-    pmovmskb    r11d, xmm0              ; index  = ((uint64_t)_mm_movemask_epi8(tmp0)) << 0;
-    pmovmskb    r12d, xmm2              ; index  = ((uint64_t)_mm_movemask_epi8(tmp2)) << 16;
-    pmovmskb    r13d, xmm4              ; index  = ((uint64_t)_mm_movemask_epi8(tmp4)) << 32;
-    pmovmskb    r14d, xmm6              ; index  = ((uint64_t)_mm_movemask_epi8(tmp6)) << 48;
-    shl         r12, 16
-    shl         r14, 16
-    or          r11, r12
-    or          r13, r14
-    shl         r13, 32
-    or          r11, r13
-    not         r11                     ; index = ~index;
-
-    ;mov MMWORD [ t1 + DCTSIZE2 * SIZEOF_WORD ], r11
-    ;jmp .EFN
-
-    mov         r13d,  INT [r15 + 240 * 4]     ; code_0xf0 = actbl->ehufco[0xf0];
-    movzx       r14d, byte [r15 + 1024 + 240]  ; size_0xf0 = actbl->ehufsi[0xf0];
-    lea         rsi, [t1]
-.BLOOP:
-    bsf         r12, r11                     ; r = __builtin_ctzl(index);
-    jz          .ELOOP
-    mov         rcx, r12
-    lea         rsi, [rsi+r12*2]             ; k += r;
-    shr         r11, cl                      ; index >>= r;
-    movzx       rdi, word [rsi]              ; temp = t1[k];
-    lea         rbx, [rel jpeg_nbits_table]
-    movzx       rdi, byte [rbx + rdi]        ; nbits = JPEG_NBITS(temp);
-.BRLOOP:
-    cmp         r12, 16                 ; while (r > 15) {
-    jl          .ERLOOP
-    EMIT_BITS   r13, r14d               ; EMIT_BITS(code_0xf0, size_0xf0)
-    sub         r12, 16                 ; r -= 16;
-    jmp         .BRLOOP
-.ERLOOP:
-    ; Emit Huffman symbol for run length / number of bits
-    CHECKBUF31  ; uses rcx, rdx
-
-    shl         r12, 4                        ; temp3 = (r << 4) + nbits;
-    add         r12, rdi
-    mov         ebx,  INT [r15 + r12 * 4]     ; code = actbl->ehufco[temp3];
-    movzx       ecx, byte [r15 + r12 + 1024]  ; size = actbl->ehufsi[temp3];
-    PUT_BITS    rbx
-
-    ;EMIT_CODE(code, size)
-
-    movsx       ebx, word [rsi-DCTSIZE2*2]    ; temp2 = t2[k];
-    ; Mask off any extra bits in code
-    mov         rcx, rdi
-    mov         rdx, 1
-    shl         rdx, cl
-    dec         rdx
-    and         rbx, rdx                ; temp2 &= (((JLONG)1)<<nbits) - 1;
-    PUT_BITS    rbx                     ; PUT_BITS(temp2, nbits)
-
-    shr         r11, 1                  ; index >>= 1;
-    add         rsi, 2                  ; ++k;
-    jmp         .BLOOP
-.ELOOP:
-    ; If the last coef(s) were zero, emit an end-of-block code
-    lea         rdi, [t1 + (DCTSIZE2-1) * 2]  ; r = DCTSIZE2-1-k;
-    cmp         rdi, rsi                      ; if (r > 0) {
-    je          .EFN
-    mov         ebx,  INT [r15]               ; code = actbl->ehufco[0];
-    movzx       r12d, byte [r15 + 1024]       ; size = actbl->ehufsi[0];
-    EMIT_BITS   rbx, r12d
-.EFN:
-    pop         r10
-    ; Save put_buffer & put_bits
-    mov         MMWORD [r10+SIZEOF_POINTER*2], put_buffer  ; state->cur.put_buffer = put_buffer;
-    sub         put_bits, 64
-    neg         put_bits
-    mov         DWORD  [r10+SIZEOF_POINTER*2+8], put_bits  ; state->cur.put_bits = put_bits;
-
-    pop         rbx
-    uncollect_args 6
-    pop_xmm     4
-    mov         rsp, rbp                ; rsp <- aligned rbp
-    pop         rsp                     ; rsp <- original rbp
+    pshuflw     xmm0, xmm0, 11001001b                    ; w0: b4 a6 a5 a4 a3 xx a1 a0
+    pinsrw      xmm0, word [block + 16 * SIZEOF_WORD], 2 ; w0: b4 a6 a5 a4 a3 a2 a1 a0
+    punpckhdq   xmm3, xmm1                               ; w3: f1 d4 d3 d2 d1 b7 b6 b5
+    punpcklqdq  xmm1, xmm3                               ; w1: d1 b7 b6 b5 b4 a6 a3 a1
+    pinsrw      xmm0, word [block + 17 * SIZEOF_WORD], 7 ; w0: a7 a6 a5 a4 a3 a2 a1 a0
+    pcmpgtw     xmm4, xmm0                               ; w4[i] = -(w4[i] > w0[i])
+    paddw       xmm0, xmm4                               ; w0[i] += w4[i]
+    movaps      XMMWORD [t + 0  * SIZEOF_WORD], xmm0     ; t[i] = w0[i]
+    movq        xmm2, qword [block + 24 * SIZEOF_WORD]   ; w2: 00 00 00 00 c7 c1 b2 b0
+    pshuflw     xmm2, xmm2, 11011000b                    ; w2: 00 00 00 00 c7 b2 c1 b0
+    pslldq      xmm1, 1 * SIZEOF_WORD                    ; w1: b7 b6 b5 b4 a6 a3 a1 00
+    movups      xmm5, XMMWORD [block + 48 * SIZEOF_WORD] ; w5: h4 h2 g7 g1 f6 e4 e1 c4
+    movsd       xmm1, xmm2                               ; w1: b7 b6 b5 b4 c7 b2 c1 b0
+    punpcklqdq  xmm2, xmm5                               ; w2: f6 e4 e1 c4 c7 b2 c1 b0
+    pinsrw      xmm1, word [block + 32 * SIZEOF_WORD], 1 ; w1: b7 b6 b5 b4 c7 b2 b1 b0
+    pxor        xmm4, xmm4                               ; w4[i] = 0
+    psrldq      xmm3, 2 * SIZEOF_WORD                    ; w3: 00 00 f1 d4 d3 d2 d1 b7
+    pcmpeqw     xmm0, xmm4                               ; w0[i] = -(w0[i] == w4[i])
+    pinsrw      xmm1, word [block + 18 * SIZEOF_WORD], 3 ; w1: b7 b6 b5 b4 b3 b2 b1 b0
+    pcmpgtw     xmm4, xmm1                               ; w4[i] = -(w4[i] > w1[i])
+    paddw       xmm1, xmm4                               ; w1[i] += w4[i]
+    movaps      XMMWORD [t + 8  * SIZEOF_WORD], xmm1     ; t[i+8] = w1[i]
+    pxor        xmm4, xmm4                               ; w4[i] = 0
+    pcmpeqw     xmm1, xmm4                               ; w1[i] = -(w1[i] == w4[i])
+    packsswb    xmm0, xmm1                               ; b0[i] = w0[i], b0[i+8] = w1[i], sign saturated
+    pinsrw      xmm3, word [block + 20 * SIZEOF_WORD], 0 ; w3: 00 00 f1 d4 d3 d2 d1 d0
+    pinsrw      xmm3, word [block + 21 * SIZEOF_WORD], 5 ; w3: 00 00 d5 d4 d3 d2 d1 d0
+    pinsrw      xmm3, word [block + 28 * SIZEOF_WORD], 6 ; w3: 00 f6 d5 d4 d3 d2 d1 d0
+    pinsrw      xmm3, word [block + 35 * SIZEOF_WORD], 7 ; w3: d7 d6 d5 d4 d3 d2 d1 d0
+    pcmpgtw     xmm4, xmm3                               ; w4[i] = -(w4[i] > w3[i])
+    paddw       xmm3, xmm4                               ; w3[i] += w4[i]
+    movaps      XMMWORD [t + 24 * SIZEOF_WORD], xmm3     ; t[i+24] = w3[i]
+    pxor        xmm4, xmm4                               ; w4[i] = 0
+    pcmpeqw     xmm3, xmm4                               ; w3[i] = -(w3[i] == w4[i])
+    pinsrw      xmm2, word [block + 19 * SIZEOF_WORD], 0 ; w2: f6 e4 e1 c4 c7 b2 c1 c0
+    cmp         code, 1 << 31                                                          ; code - (1u << 31) ?
+    pinsrw      xmm2, word [block + 33 * SIZEOF_WORD], 2 ; w2: f6 e4 e1 c4 c7 c2 c1 c0
+    pinsrw      xmm2, word [block + 40 * SIZEOF_WORD], 3 ; w2: f6 e4 e1 c4 c3 c2 c1 c0
+    adc         code, -1                                                               ; code += -1 + (code < (1u << 31))
+    pinsrw      xmm2, word [block + 41 * SIZEOF_WORD], 5 ; w2: f6 e4 c5 c4 c3 c2 c1 c0
+    pinsrw      xmm2, word [block + 34 * SIZEOF_WORD], 6 ; w2: f6 c6 c5 c4 c3 c2 c1 c0
+    movsxd      codeq, code                                                            ; sign extend
+    pinsrw      xmm2, word [block + 27 * SIZEOF_WORD], 7 ; w2: c7 c6 c5 c4 c3 c2 c1 c0
+    pcmpgtw     xmm4, xmm2                               ; w4[i] = -(w4[i] > w2[i])
+    paddw       xmm2, xmm4                               ; w2[i] += w4[i]
+    movaps      XMMWORD [t + 16 * SIZEOF_WORD], xmm2     ; t[i+16] = w2[i]
+    pxor        xmm4, xmm4                               ; w4[i] = 0
+    pcmpeqw     xmm2, xmm4                               ; w2[i] = -(w2[i] == w4[i])
+    packsswb    xmm2, xmm3                               ; b2[i] = w2[i], b2[i+8] = w3[i], sign saturated
+    movzx       nbitsq, byte [NBITS(codeq)]                                            ; nbits = JPEG_NBITS(code);
+    movdqa      xmm3, xmm5                               ; w3: h4 h2 g7 g1 f6 e4 e1 c4
+    pmovmskb    tempd, xmm2                                                            ; temp = (((b2[i] >> 7) << i) | ...);
+    pmovmskb    put_bufferd, xmm0                                                      ; put_buffer = (((b0[i] >> 7) << i) | ...);
+    movups      xmm0, XMMWORD [block + 56 * SIZEOF_WORD] ; w0: h6 h5 h1 h0 g0 f7 e3 e2
+    punpckhdq   xmm3, xmm0                               ; w3: h6 h5 h4 h2 h1 h0 g7 g1
+    shl         tempd, 16                                                              ; temp <<= 16;
+    psrldq      xmm3, 1 * SIZEOF_WORD                    ; w3: 00 h6 h5 h4 h2 h1 h0 g7
+    pxor        xmm2, xmm2                               ; w2[i] = 0
+    or          put_bufferd, tempd                                                     ; put_buffer |= temp
+    pshuflw     xmm3, xmm3, 00111001b                    ; w3: 00 h6 h5 h4 g7 h2 h1 h0
+    movq        xmm1, qword [block + 44 * SIZEOF_WORD]   ; w1: 00 00 00 00 h3 g6 g2 f5
+    unpcklps    xmm5, xmm0                               ; w5: g0 f7 f6 e4 e3 e2 e1 c4
+    pxor        xmm0, xmm0                               ; w0[i] = 0
+    pinsrw      xmm3, word [block + 47 * SIZEOF_WORD], 3 ; w3: 00 h6 h5 h4 h3 h2 h1 h0
+    pcmpgtw     xmm2, xmm3                               ; w2[i] = -(w2[i] > w3[i])
+    paddw       xmm3, xmm2                               ; w3[i] += w2[i]
+    movaps      XMMWORD [t + 56 * SIZEOF_WORD], xmm3     ; t[i+56] = w3[i]
+    movq        xmm4, qword [block + 36 * SIZEOF_WORD]   ; w4: 00 00 00 00 g5 g3 f4 e6
+    pcmpeqw     xmm3, xmm0                               ; w3[i] = -(w3[i] == w[0])
+    punpckldq   xmm4, xmm1                               ; w4: h3 g6 g5 g3 g2 f5 f4 e6
+    mov         tempd, [dctbl + c_derived_tbl.ehufco + nbitsq * 4]                     ; temp = dctbl->ehufco[nbits];
+    movdqa      xmm1, xmm4                               ; w1: h3 g6 g5 g3 g2 f5 f4 e6
+    psrldq      xmm4, 1 * SIZEOF_WORD                    ; w4: 00 h3 g6 g5 g3 g2 f5 f4
+    shufpd      xmm1, xmm5, 10b                          ; w1: g0 f7 f6 e4 g2 f5 f4 e6
+    and         code, dword [MASK_BITS(nbitsq)]                                        ; code &= (1 << nbits) - 1;
+    pshufhw     xmm4, xmm4, 11010011b                    ; w4: 00 g6 g5 00 g3 g2 f5 f4
+    pslldq      xmm1, 1 * SIZEOF_WORD                    ; w1: f7 f6 e4 g2 f5 f4 e6 00
+    shl         tempq, nbitsb                                                          ; temp <<= nbits;
+    pinsrw      xmm4, word [block + 59 * SIZEOF_WORD], 0 ; w4: 00 g6 g5 00 g3 g2 f5 g0
+    pshufd      xmm1, xmm1, 11011000b                    ; w1: f7 f6 f5 f4 e4 g2 e6 00
+    pinsrw      xmm4, word [block + 52 * SIZEOF_WORD], 1 ; w4: 00 g6 g5 00 g3 g2 g1 g0
+    or          code, tempd                                                            ; code |= temp;
+    movlps      xmm1, qword [block + 20 * SIZEOF_WORD]   ; w1: f7 f6 f5 f4 f2 f0 d5 d0
+    pinsrw      xmm4, word [block + 31 * SIZEOF_WORD], 4 ; w4: 00 g6 g5 g4 g3 g2 g1 g0
+    pshuflw     xmm1, xmm1, 01110010b                    ; w1: f7 f6 f5 f4 d5 f2 d0 f0
+    pinsrw      xmm4, word [block + 53 * SIZEOF_WORD], 7 ; w4: g7 g6 g5 g4 g3 g2 g1 g0
+    pxor        xmm2, xmm2                               ; w2[i] = 0
+    pcmpgtw     xmm0, xmm4                               ; w0[i] = -(w0[i] < w4[i])
+    pinsrw      xmm1, word [block + 15 * SIZEOF_WORD], 1 ; w1: f7 f6 f5 f4 d5 f2 f1 f0
+    paddw       xmm4, xmm0                               ; w4[i] += w0[i]
+    movaps      XMMWORD [t + 48 * SIZEOF_WORD], xmm4     ; t[48+i] = w4[i]
+    pinsrw      xmm1, word [block + 30 * SIZEOF_WORD], 3 ; w1: f7 f6 f5 f4 f3 f2 f1 f0
+    pcmpeqw     xmm4, xmm2                               ; w4[i] = -(w4[i] == w2[i])
+    pinsrw      xmm5, word [block + 42 * SIZEOF_WORD], 0 ; w5: g0 f7 f6 e4 e3 e2 e1 e0
+    packsswb    xmm4, xmm3                               ; b4[i] = w4[i], b4[i+8] = w3[i], sign saturated
+    pxor        xmm0, xmm0                               ; w0[i] = 0
+    pinsrw      xmm5, word [block + 43 * SIZEOF_WORD], 5 ; w5: g0 f7 e5 e4 e3 e2 e1 e0
+    pcmpgtw     xmm2, xmm1                               ; w2[i] = -(w2[i] < w1[i])
+    pmovmskb    tempd, xmm4                                                            ; temp = (((b4[i] >> 7) << i) | ...);
+    pinsrw      xmm5, word [block + 36 * SIZEOF_WORD], 6 ; w5: g0 e6 e5 e4 e3 e2 e1 e0
+    paddw       xmm1, xmm2                               ; w1[i] += w2[i]
+    movaps      XMMWORD [t + 40 * SIZEOF_WORD], xmm1     ; t[40+i] = w1[i]
+    pinsrw      xmm5, word [block + 29 * SIZEOF_WORD], 7 ; w5: e7 e6 e5 e4 e3 e2 e1 e0
+%undef block
+%define free_bitsb      dl
+%define free_bitsd      edx
+%define free_bitsq      rdx
+    pcmpeqw     xmm1, xmm0                               ; w1[i] = -(w1[i] == w0[i])
+    shl         tempq, 48                                                              ; temp <<= 48;
+    pxor        xmm2, xmm2                               ; w2[i] = 0
+    pcmpgtw     xmm0, xmm5                               ; w5[i] = -(w5[i] < w0[i])
+    paddw       xmm5, xmm0                               ; w5[i] += w0[i]
+    or          tempq, put_buffer                                                      ; temp |= put_buffer;
+    movaps      XMMWORD [t + 32 * SIZEOF_WORD], xmm5     ; t[32+i] = w5[i]
+    lea         t, [dword t - 2]                                                       ; t = &t[-1];
+    pcmpeqw     xmm5, xmm2                               ; w5[i] = -(w5[i] == w2[i])
+    packsswb    xmm5, xmm1                               ; b5[i] = w5[i], b5[i+8] = w1[i], sign saturated
+    add         nbitsb, byte [dctbl + c_derived_tbl.ehufsi + nbitsq]                   ; nbits += dctbl->ehufsi[nbits];
+%undef dctbl
+%define code_temp r8d
+    pmovmskb    indexd, xmm5                                                           ; index = (((b5[i] >> 7) << i) | ...);
+    mov         free_bitsd, [state+working_state.cur.free_bits]                        ; free_bits = state->cur.free_bits;
+    pcmpeqw     xmm1, xmm1                                ; b1[i] = 0xff
+    shl         index, 32                                                              ; index <<= 32;
+    mov         put_buffer, [state+working_state.cur.put.buffer_simd]                  ; put_buffer = state->cur.put.buffer_simd;
+    or          index, tempq                                                           ; index |= temp;
+    not         index                                                                  ; index = ~index;
+    sub         free_bitsb, nbitsb                                                     ; if ((free_bits -= nbits) >= 0)
+    jnl         .ENTRY_SKIP_EMIT_CODE                                                  ;     goto .ENTRY_SKIP_EMIT_CODE;
+    align       16
+.EMIT_CODE:                                                                            ; .EMIT_CODE:
+    EMIT_QWORD        .BLOOP_COND                                                      ;     insert code, flush buffer, goto .BLOOP_COND
+;-------------------------------------------
+    align       16
+.BRLOOP:                                                                    ; .BRLOOP: do {
+    lea         code_temp, [nbitsq - 16]                                    ;     code_temp = nbits - 16;
+    movzx       nbits, byte [actbl + c_derived_tbl.ehufsi + 0xf0]           ;     nbits -= actbl->ehufsi[0xf0];
+    mov         code, [actbl + c_derived_tbl.ehufco + 0xf0 * 4]             ;     code = actbl->ehufco[0xf0];
+    sub         free_bitsb, nbitsb                                          ;     if ((free_bits - nbits) <= 0)
+    jle         .EMIT_BRLOOP_CODE                                           ;         goto .EMIT_BRLOOP_CODE
+    shl         put_buffer, nbitsb                                          ;     put_buffer <<= nbits;
+    mov         nbits, code_temp                                            ;     nbits = code_temp;
+    or          put_buffer, codeq                                           ;     put_buffer |= code;
+    cmp         nbits, 16                                                   ;     if (nbits <= 16)
+    jle         .ERLOOP                                                     ;         goto .ERLOOP;
+    jmp         .BRLOOP                                                     ; } while(1);
+;-------------------------------------------
+    align       16
+    times 5 nop
+.ENTRY_SKIP_EMIT_CODE:                                                                 ; .ENTRY_SKIP_EMIT_CODE:
+    shl         put_buffer, nbitsb                                                     ;     put_buffer <<= nbits;
+    or          put_buffer, codeq                                                      ;     put_buffer |= code;
+.BLOOP_COND:                                                                           ; .BLOOP_COND:
+    test        index, index                                                           ;     index & index ?
+    jz          .ELOOP                                                                 ;     if (index == 0) goto .ELOOP
+.BLOOP:                                                                                ; do {
+    xor         nbits, nbits ; kill tzcnt input dependency                             ;     nbits = 0;
+    tzcnt       nbitsq, index                                                          ;     nbits = #trailing 0-bits in index
+    inc         nbits                                                                  ;     ++nbits;
+    lea         t, [t + nbitsq * 2]                                                    ;     t = &t[nbits];
+    shr         index, nbitsb                                                          ;     index >>= nbits;
+.EMIT_BRLOOP_CODE_END:                                                                 ; .EMIT_BRLOOP_CODE_END:
+    cmp         nbits, 16                                                              ;     if (nbits > 16)
+    jg          .BRLOOP                                                                ;         goto .BRLOOP;
+.ERLOOP:                                                                               ; .ERLOOP:
+    movsx       codeq, word [t]                                                        ;     code = *t;
+    lea         tempd, [nbitsq * 2]                                                    ;     temp = nbits * 2;
+    movzx       nbits, byte [NBITS(codeq)]                                             ;     nbits = JPEG_NBITS(code);
+    lea         tempd, [nbitsq + tempq * 8]                                            ;     temp = temp * 8 + nbits;
+    mov         code_temp, [actbl + c_derived_tbl.ehufco + (tempq - 16) * 4]           ;     code_temp = actbl->ehufco[temp-16];
+    shl         code_temp, nbitsb                                                      ;     code_temp <<= nbits;
+    and         code, dword [MASK_BITS(nbitsq)]                                        ;     code &= (1 << nbits) - 1;
+    add         nbitsb, [actbl + c_derived_tbl.ehufsi + (tempq - 16)]                  ;     free_bits -= actbl->ehufsi[temp-16];
+    or          code, code_temp                                                        ;     code |= code_temp;
+    sub         free_bitsb, nbitsb                                                     ;     if ((free_bits -= nbits) <= 0)
+    jle         .EMIT_CODE                                                             ;         goto .EMIT_CODE
+    shl         put_buffer, nbitsb                                                     ;     put_buffer <<= nbits;
+    or          put_buffer, codeq                                                      ;     put_buffer |= code;
+    test        index, index                                                           ;     index & index ?
+    jnz         .BLOOP                                                                 ; } while (index != 0);
+.ELOOP:                                                                                ; .ELOOP:
+    sub         td, esp                                                                ; t -= (WIN64: &t_[0]  UNIX: &t_[64]);
+%ifdef WIN64
+    cmp         td, (DCTSIZE2 - 2) * SIZEOF_WORD                                       ; if (t == 62)
+%else
+    cmp         td, -2 * SIZEOF_WORD                                                   ; if (t == -2)
+%endif
+    je          .EFN                                                                   ;     goto .EFN;
+    movzx       nbits, byte [actbl + c_derived_tbl.ehufsi + 0]                         ; nbits = actbl->ehufsi[0];
+    mov         code, [actbl + c_derived_tbl.ehufco + 0]                               ; code = actbl->ehufco[0];
+    sub         free_bitsb, nbitsb                                                     ; if ((free_bits -= nbits) > 0)
+    jg          .EFN_SKIP_EMIT_CODE                                                    ;     goto .EFN_SKIP_EMIT_CODE
+    EMIT_QWORD  .EFN                                                                   ; insert code, flush put_buffer, goto .EFN
+    align       16
+.EFN_SKIP_EMIT_CODE:                                                                   ; .EFN_SKIP_EMIT_CODE:
+    shl         put_buffer, nbitsb                                                     ;     put_buffer <<= nbits;
+    or          put_buffer, codeq                                                      ;     put_buffer |= code;
+.EFN:                                                                                  ; .EFN:
+    mov         [state + working_state.cur.put.buffer_simd], put_buffer                ; state->cur.put.buffer_simd = put_buffer;
+    mov         byte [state + working_state.cur.free_bits], free_bitsb                 ; state->cur.free_bits = free_bits;
+%ifdef WIN64
+    sub         rsp, -DCTSIZE2 * SIZEOF_WORD
+    pop         r12
+    pop         rdi
+    pop         rsi
     pop         rbp
+    pop         rbx
+%else
+    pop         r12
+    pop         rbp
+    pop         rbx
+%endif
     ret
+
+    align       16
+.EMIT_BRLOOP_CODE:                                                                     ; insert code, flush buffer,
+    EMIT_QWORD        .EMIT_BRLOOP_CODE_END, {mov nbits, code_temp}                    ; nbits = code_temp, goto .EMIT_BRLOOP_CODE_END
 
 ; For some reason, the OS X linker does not honor the request to align the
 ; segment unless we do this.

--- a/tjbench.c
+++ b/tjbench.c
@@ -472,6 +472,8 @@ int fullTest(unsigned char *srcBuf, int w, int h, int subsamp, int jpegQual,
       if (decomp(srcBuf, jpegBuf, jpegSize, tmpBuf, w, h, subsamp, jpegQual,
                  fileName, tilew, tileh) == -1)
         goto bailout;
+    } else if (quiet) {
+      printf("N/A\n");
     }
 
     for (i = 0; i < ntilesw * ntilesh; i++) {


### PR DESCRIPTION
I've tried optimizing jsimd_huff_encode_one_block_sse2 (64-bit); testing on both a N330 atom and Q9650 (Wolfdale) shows that compressor speeds for large images/tiles tend to improve by about 6-8% for quality 50 and 8-10% for quality 100. Based on on these figures, I'd like to inquire if - after some clean up/+comments - this has a chance to be merged, in which case I'd also look at the 32-bit and C-versions. I'd expect the relative speed up for 32-bit to be slightly higher.

A number of transformations/optimizations have been done (non exhaustive):
- reduce used xmm-registers to 8, there is no actual pressure to use more, this leads to better function entry/exit on win64 and shorter code, as rex-prefixes can be avoided (atom's decoder fetch can be a bottleneck)
- change register assignments so that fewer rex-prefixes and register-register moves are needed
- keep the bit_counter as number of free_bits instead of put_bits; this changes the the method to put a code into the put_buffer to (put_buffer |= code << (free_bits -= code_size)); this way only one bit count needs to stay in a register (and we just keep it in cl); the put_buffer contents is already properly aligned to be written out (after byte swap)
- adjusting free_bits and checking if the buffer is full is a single op and we can actually wait until put_buffer is really full (not just in danger of becoming so), so that 8-byte can be flushed at a time (this optimization would probably be even more beneficial for 32-bit).
- speed is quite sensitive to the alignment of branch target labels, so some padding has been inserted and the flush code is branchless (flushing this way isn't actually faster when compared to using jumps but the code doesn't need extra alignment for this and becomes smaller)
- try it write out the put_buffer as a single write of 8-bytes and only do it byte for byte if there are any 0xff bytes in it (controlled by SPECULATIVE_PUT_BUFFER_STORES)
- overall function code size is slightly smaller
- a few SSE instructions can be combined or eliminated
- some minor scheduling improvements (could be improved further, though probably not within the loop that dominates performance)

other notes:
- flush_bits in jchuff.c needs to be adjusted to handle cases where the put_buffer has less than 7 free bits (apparently that couldn''t happen before)
- win64 hasn't been tested yet
- performance figures for other processors might be of interest