### PR TITLE
Provide memory manager overriding api

### DIFF
--- a/jpeglib.h
+++ b/jpeglib.h
@@ -903,10 +903,21 @@ EXTERN(struct jpeg_error_mgr *) jpeg_std_error(struct jpeg_error_mgr *err);
 #define jpeg_create_decompress(cinfo) \
   jpeg_CreateDecompress((cinfo), JPEG_LIB_VERSION, \
                         (size_t)sizeof(struct jpeg_decompress_struct))
+#define jpeg_create_compress_with_mem(cinfo) \
+  jpeg_CreateCompressWithMem((cinfo), JPEG_LIB_VERSION, \
+                             (size_t)sizeof(struct jpeg_compress_struct))
+#define jpeg_create_decompress_with_mem(cinfo) \
+  jpeg_CreateDecompressWithMem((cinfo), JPEG_LIB_VERSION, \
+                               (size_t)sizeof(struct jpeg_decompress_struct))
+
 EXTERN(void) jpeg_CreateCompress(j_compress_ptr cinfo, int version,
                                  size_t structsize);
 EXTERN(void) jpeg_CreateDecompress(j_decompress_ptr cinfo, int version,
                                    size_t structsize);
+EXTERN(void) jpeg_CreateCompressWithMem(j_compress_ptr cinfo, int version,
+                                        size_t structsize);
+EXTERN(void) jpeg_CreateDecompressWithMem(j_decompress_ptr cinfo, int version,
+                                          size_t structsize);
 /* Destruction of JPEG compression objects */
 EXTERN(void) jpeg_destroy_compress(j_compress_ptr cinfo);
 EXTERN(void) jpeg_destroy_decompress(j_decompress_ptr cinfo);

--- a/libjpeg.txt
+++ b/libjpeg.txt
@@ -52,6 +52,7 @@ Advanced features:
         Really raw data: DCT coefficients
         Progress monitoring
         Memory management
+        Custom memory management
         Memory usage
         Library compile-time options
         Portability considerations
@@ -3000,6 +3001,23 @@ malloc()s and free()s virtual arrays, and an error occurs if the required
 memory exceeds the limit specified in cinfo->mem->max_memory_to_use.
 
 
+Custom memory management
+------------------------
+
+The default memory manager can be replaced with a custom one for special cases
+where the default memory manager is not sufficient. This is done by filling out
+the jpeg_memory_manager structure before calling one of the jpeg_create_
+functions. When the jpeg_create_ function is called it needs to be one of the
+_with_mem versions (jpeg_create_compress_with_mem or
+jpeg_create_decompress_with_mem).  If one of the jpeg_create_ functions that
+does not have _with_mem is called the custom memory manager will be replaced
+with the standard one, so it is important to call the _with_mem versions.
+
+The custom memory manager must fill out the jpeg_memory_manager structure with
+functions for all of the callbacks in the jpeg_memory_mgr structure, as these
+will all be called by libjpeg.
+
+
 Memory usage
 ------------
 
@@ -3044,7 +3062,6 @@ requested.
 
 If you need more detailed information about memory usage in a particular
 situation, you can enable the MEM_STATS code in jmemmgr.c.
-
 
 Library compile-time options
 ----------------------------

--- a/win/jpeg62-memsrcdst.def
+++ b/win/jpeg62-memsrcdst.def
@@ -106,3 +106,5 @@ EXPORTS
   jpeg_crop_scanline @ 105 ;
   jpeg_read_icc_profile @ 106 ;
   jpeg_write_icc_profile @ 107 ;
+  jpeg_CreateCompressWithMem @ 108 ;
+  jpeg_CreateDecompressWithMem @ 109 ;

--- a/win/jpeg62.def
+++ b/win/jpeg62.def
@@ -104,3 +104,5 @@ EXPORTS
   jpeg_crop_scanline @ 103 ;
   jpeg_read_icc_profile @ 104 ;
   jpeg_write_icc_profile @ 105 ;
+  jpeg_CreateCompressWithMem @ 106 ;
+  jpeg_CreateDecompressWithMem @ 107 ;

--- a/win/jpeg7-memsrcdst.def
+++ b/win/jpeg7-memsrcdst.def
@@ -108,3 +108,5 @@ EXPORTS
   jpeg_crop_scanline @ 107 ;
   jpeg_read_icc_profile @ 108 ;
   jpeg_write_icc_profile @ 109 ;
+  jpeg_CreateCompressWithMem @ 110 ;
+  jpeg_CreateDecompressWithMem @ 111 ;

--- a/win/jpeg7.def
+++ b/win/jpeg7.def
@@ -106,3 +106,5 @@ EXPORTS
   jpeg_crop_scanline @ 105 ;
   jpeg_read_icc_profile @ 106 ;
   jpeg_write_icc_profile @ 107 ;
+  jpeg_CreateCompressWithMem @ 108 ;
+  jpeg_CreateDecompressWithMem @ 109 ;

--- a/win/jpeg8.def
+++ b/win/jpeg8.def
@@ -109,3 +109,5 @@ EXPORTS
   jpeg_crop_scanline @ 108 ;
   jpeg_read_icc_profile @ 109 ;
   jpeg_write_icc_profile @ 110 ;
+  jpeg_CreateCompressWithMem @ 111 ;
+  jpeg_CreateDecompressWithMem @ 112 ;


### PR DESCRIPTION
I know that, with the state of funding for this project at the moment, this might
not be considered but I thought I would share this anyway.

This provides a new interface for creating compress and decompress
streams with an already initialized memory manager. By adding a new
function this doesn't break compatability with old clients. The new api
assumes that either mem has been initialized and is ready to go or that
it is NULL and will be initialized as normal.

Without this it is problematic to actually fully override the default
memory manager. The main issue is that the memory manager is that the
jpeg_create_* functions initialize the default memory manager and then
use it to allocate some items before returning. If the memory manager is
replaced after this the original memory manager will never have the
destruct called. If the destruct is called manually it will free memory
that is still in use by structures in cinfo.