### PR TITLE
Fix unused variable & functions in ARM SIMD

### DIFF
--- a/simd/arm/jsimd.c
+++ b/simd/arm/jsimd.c
@@ -5,6 +5,7 @@
  * Copyright (C) 2011, Nokia Corporation and/or its subsidiary(-ies).
  * Copyright (C) 2009-2011, 2013-2014, 2016, 2018, D. R. Commander.
  * Copyright (C) 2015-2016, 2018, Matthieu Darbois.
+ * Copyright 2019 Google LLC.
  *
  * Based on the x86 SIMD extension for IJG JPEG library,
  * Copyright (C) 1999-2006, MIYASAKA Masaru.
@@ -30,7 +31,7 @@
 static unsigned int simd_support = ~0;
 static unsigned int simd_huffman = 1;
 
-#if defined(__linux__) || defined(ANDROID) || defined(__ANDROID__)
+#if !defined(__ARM_NEON__) && (defined(__linux__) || defined(ANDROID) || defined(__ANDROID__))
 
 #define SOMEWHAT_SANE_PROC_CPUINFO_SIZE_LIMIT  (1024 * 1024)
 
@@ -105,9 +106,6 @@ init_simd(void)
 #ifndef NO_GETENV
   char *env = NULL;
 #endif
-#if !defined(__ARM_NEON__) && defined(__linux__) || defined(ANDROID) || defined(__ANDROID__)
-  int bufsize = 1024; /* an initial guess for the line buffer size limit */
-#endif
 
   if (simd_support != ~0U)
     return;
@@ -117,6 +115,8 @@ init_simd(void)
 #if defined(__ARM_NEON__)
   simd_support |= JSIMD_NEON;
 #elif defined(__linux__) || defined(ANDROID) || defined(__ANDROID__)
+  int bufsize = 1024; /* an initial guess for the line buffer size limit */
+
   /* We still have a chance to use NEON regardless of globally used
    * -mcpu/-mfpu options passed to gcc by performing runtime detection via
    * /proc/cpuinfo parsing on linux/android */

--- a/simd/arm/jsimd.c
+++ b/simd/arm/jsimd.c
@@ -106,6 +106,9 @@ init_simd(void)
 #ifndef NO_GETENV
   char *env = NULL;
 #endif
+#if !defined(__ARM_NEON__) && (defined(__linux__) || defined(ANDROID) || defined(__ANDROID__))
+  int bufsize = 1024; /* an initial guess for the line buffer size limit */
+#endif
 
   if (simd_support != ~0U)
     return;
@@ -115,8 +118,6 @@ init_simd(void)
 #if defined(__ARM_NEON__)
   simd_support |= JSIMD_NEON;
 #elif defined(__linux__) || defined(ANDROID) || defined(__ANDROID__)
-  int bufsize = 1024; /* an initial guess for the line buffer size limit */
-
   /* We still have a chance to use NEON regardless of globally used
    * -mcpu/-mfpu options passed to gcc by performing runtime detection via
    * /proc/cpuinfo parsing on linux/android */


### PR DESCRIPTION
When simd/arm/jsimd.c is compiled with __ARM_NEON__ defined there
is a bufsize variable which is defined but never used.

Additionally, parse_proc_cpuinfo() is never used. That function is the
only one which calls check_feature() so it is also never used.

This commit puts all of these under the appropriate #if defined() so
there are no longer unused variables and functions.