### PR TITLE
Check maximum CPUID leaf

### DIFF
--- a/simd/i386/jsimdcpu.asm
+++ b/simd/i386/jsimdcpu.asm
@@ -57,7 +57,7 @@ EXTN(jpeg_simd_cpu_support):
     test        eax, eax
     jz          near .return
     cmp         eax, 7                  ; Skip AVX2 check if its leaf
-                                        ; isn't supported
+                                        ; is not supported
     jl          short .no_avx2
 
     ; Check for AVX2 instruction support

--- a/simd/x86_64/jsimdcpu.asm
+++ b/simd/x86_64/jsimdcpu.asm
@@ -38,14 +38,24 @@ EXTN(jpeg_simd_cpu_support):
 
     xor         rdi, rdi                ; simd support flag
 
+    ; Assume SSE & SSE2 support for x86-64 processors
+    or          rdi, JSIMD_SSE2
+    or          rdi, JSIMD_SSE
+
+    ; Check maximum supported CPUID leaf
+    mov         rax, 0
+    xor         rcx, rcx
+    cpuid
+    cmp         rax, 7                  ; Exit if the maximum leaf < AVX2's
+                                        ; leaf
+    jl          short .return
+
     ; Check for AVX2 instruction support
     mov         rax, 7
     xor         rcx, rcx
     cpuid
     mov         rax, rbx                ; rax = Extended feature flags
 
-    or          rdi, JSIMD_SSE2
-    or          rdi, JSIMD_SSE
     test        rax, 1<<5               ; bit5:AVX2
     jz          short .return
 

--- a/simd/x86_64/jsimdcpu.asm
+++ b/simd/x86_64/jsimdcpu.asm
@@ -44,7 +44,6 @@ EXTN(jpeg_simd_cpu_support):
 
     ; Check maximum supported CPUID leaf
     mov         rax, 0
-    xor         rcx, rcx
     cpuid
     cmp         rax, 7                  ; Exit if the maximum leaf < AVX2's
                                         ; leaf

--- a/simd/x86_64/jsimdcpu.asm
+++ b/simd/x86_64/jsimdcpu.asm
@@ -38,7 +38,7 @@ EXTN(jpeg_simd_cpu_support):
 
     xor         rdi, rdi                ; simd support flag
 
-    ; Assume SSE & SSE2 support for x86-64 processors
+    ; Assume SSE & SSE2 support in all x86-64 processors
     or          rdi, JSIMD_SSE2
     or          rdi, JSIMD_SSE
 


### PR DESCRIPTION
According to Intel's manual [1] page 3-192, "If a value entered for
CPUID.EAX is higher than the maximum input value for basic or extended
function for that processor then the data for the highest basic
information leaf is returned."

Right now, libjpeg-turbo doesn't first check that leaf 7 is supported
before checking the AVX2 bit of the results. This means we could
potentially be checking that bit in leaf 6 or 5, for example.

This commit fixes this by first checking that CPUID leaf 7 is supported
before making the AVX2 check.

[1]
https://software.intel.com/sites/default/files/managed/a4/60/325383-sdm-vol-2abcd.pdf