### PR TITLE
bugfix: add bias pattern for h1v2_fancy_upsample

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,8 @@ addons:
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/537f3703aa41c550edbaaf28dd280c6ec929f946/Formula/yasm.rb &&
+      brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/e54bdbab6fa2903d4c27984ca9858f546293880c/Formula/gcc@5.rb &&
       ln -fs /usr/local/bin/gpg1 /usr/local/bin/gpg &&
       git clone --depth=1 https://github.com/libjpeg-turbo/gas-preprocessor.git ~/src/gas-preprocessor &&
       ln -fs /Applications/Xcode.app /Applications/Xcode72.app;

--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,2 @@
-brew 'yasm'
-brew 'gcc@5'
 brew 'md5sha1sum'
 cask 'Caskroom/versions/java6'

--- a/jdsample.c
+++ b/jdsample.c
@@ -315,9 +315,9 @@ h1v2_fancy_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
   JSAMPARRAY output_data = *output_data_ptr;
   JSAMPROW inptr0, inptr1, outptr;
 #if BITS_IN_JSAMPLE == 8
-  int thiscolsum;
+  int thiscolsum, bias;
 #else
-  JLONG thiscolsum;
+  JLONG thiscolsum, bias;
 #endif
   JDIMENSION colctr;
   int inrow, outrow, v;
@@ -327,15 +327,18 @@ h1v2_fancy_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
     for (v = 0; v < 2; v++) {
       /* inptr0 points to nearest input row, inptr1 points to next nearest */
       inptr0 = input_data[inrow];
-      if (v == 0)               /* next nearest is row above */
+      if (v == 0) {             /* next nearest is row above */
         inptr1 = input_data[inrow - 1];
-      else                      /* next nearest is row below */
+        bias = 1;
+      } else {                  /* next nearest is row below */
         inptr1 = input_data[inrow + 1];
+        bias = 2;
+      }
       outptr = output_data[outrow++];
 
       for (colctr = 0; colctr < compptr->downsampled_width; colctr++) {
         thiscolsum = GETJSAMPLE(*inptr0++) * 3 + GETJSAMPLE(*inptr1++);
-        *outptr++ = (JSAMPLE)((thiscolsum + 1) >> 2);
+        *outptr++ = (JSAMPLE)((thiscolsum + bias) >> 2);
       }
     }
     inrow++;


### PR DESCRIPTION
Adds an ordered dither pattern for h1v2_fancy_upsample such that 0.5
will be rounded up or down at alternate pixel locations. Currently
0.5 is always rounded down.

This ordered dither pattern is already used for h2v1_fancy_upsample
and h2v2_fancy_upsample.