### PR TITLE
Implement MSA optimization codes for MIPS platform on dev branch

### DIFF
--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -279,8 +279,8 @@ message(STATUS "CMAKE_ASM_FLAGS = ${EFFECTIVE_ASM_FLAGS}")
 set(CMAKE_REQUIRED_FLAGS -mdspr2)
 
 check_c_source_compiles("
-  #if !(defined(__mips__) && __mips_isa_rev >= 2)
-  #error MIPS DSPr2 is currently only available on MIPS32r2 platforms.
+  #if !(defined(__mips__) && __mips_isa_rev == 2)
+  #error MIPS DSPr2 is currently only available on MIPS32r2/MIPS64r2 platforms.
   #endif
   int main(void) {
     int c = 0, a = 0, b = 0;
@@ -294,7 +294,7 @@ check_c_source_compiles("
 
 unset(CMAKE_REQUIRED_FLAGS)
 
-set(CMAKE_REQUIRED_FLAGS "-mmsa ${CMAKE_C_FLAGS}")
+set(CMAKE_REQUIRED_FLAGS -mmsa)
 
 check_c_source_compiles("
   #include <msa.h>

--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -268,7 +268,7 @@ endif()
 # MIPS (GAS)
 ###############################################################################
 
-elseif(CPU_TYPE STREQUAL "mips" OR CPU_TYPE STREQUAL "mipsel")
+elseif(CPU_TYPE STREQUAL "mips" OR CPU_TYPE STREQUAL "mipsel" OR CPU_TYPE STREQUAL "mips64" OR CPU_TYPE STREQUAL "mips64el")
 
 enable_language(ASM)
 
@@ -294,12 +294,38 @@ check_c_source_compiles("
 
 unset(CMAKE_REQUIRED_FLAGS)
 
-if(NOT HAVE_DSPR2)
+set(CMAKE_REQUIRED_FLAGS "-mmsa ${CMAKE_C_FLAGS}")
+
+check_c_source_compiles("
+  #include <msa.h>
+  #if !(defined(__mips__) && __mips_isa_rev >= 5)
+  #error MIPS MSA is currently only available on release 5 or later platforms.
+  #endif
+  int main (void) {
+    v8i16 a0 = {0}, a1 = {0};
+    a0 = a0 + a1;
+    return 0;
+  }" HAVE_MSA)
+
+unset(CMAKE_REQUIRED_FLAGS)
+
+if(HAVE_MSA)
+  set(SIMD_SOURCES mips/jccolor_msa.c mips/jcgray_msa.c
+    mips/jcsample_msa.c mips/jdcol565_msa.c mips/jdcolor_msa.c
+    mips/jdmerge_msa.c mips/jdsample_msa.c mips/jfdctfst_msa.c
+    mips/jfdctint_msa.c mips/jidctfst_msa.c mips/jidctint_msa.c
+    mips/jidctred_msa.c mips/jquanti_msa.c)
+
+  set_source_files_properties(${SIMD_SOURCES} PROPERTIES
+    COMPILE_FLAGS -mmsa)
+
+  add_library(simd OBJECT ${SIMD_SOURCES} mips/jsimd_msa.c)
+elseif(HAVE_DSPR2)
+  add_library(simd OBJECT mips/jsimd_dspr2.S mips/jsimd_dspr2.c)
+else()
   simd_fail("SIMD extensions not available for this CPU")
   return()
 endif()
-
-add_library(simd OBJECT mips/jsimd_dspr2.S mips/jsimd.c)
 
 if(CMAKE_POSITION_INDEPENDENT_CODE OR ENABLE_SHARED)
   set_target_properties(simd PROPERTIES POSITION_INDEPENDENT_CODE 1)

--- a/simd/jsimd.h
+++ b/simd/jsimd.h
@@ -26,6 +26,7 @@
 #define JSIMD_ALTIVEC  0x40
 #define JSIMD_AVX2     0x80
 #define JSIMD_MMI      0x100
+#define JSIMD_MSA      0x200
 
 /* SIMD Ext: retrieve SIMD/CPU information */
 EXTERN(unsigned int) jpeg_simd_cpu_support(void);
@@ -147,6 +148,28 @@ EXTERN(void) jsimd_extxbgr_ycc_convert_dspr2
   (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
    JDIMENSION output_row, int num_rows);
 EXTERN(void) jsimd_extxrgb_ycc_convert_dspr2
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+   JDIMENSION output_row, int num_rows);
+
+EXTERN(void) jsimd_rgb_ycc_convert_msa
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+   JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extrgb_ycc_convert_msa
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+   JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extrgbx_ycc_convert_msa
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+   JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extbgr_ycc_convert_msa
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+   JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extbgrx_ycc_convert_msa
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+   JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extxbgr_ycc_convert_msa
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+   JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extxrgb_ycc_convert_msa
   (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
    JDIMENSION output_row, int num_rows);
 
@@ -282,6 +305,28 @@ EXTERN(void) jsimd_extxbgr_gray_convert_dspr2
   (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
    JDIMENSION output_row, int num_rows);
 EXTERN(void) jsimd_extxrgb_gray_convert_dspr2
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+   JDIMENSION output_row, int num_rows);
+
+EXTERN(void) jsimd_rgb_gray_convert_msa
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+   JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extrgb_gray_convert_msa
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+   JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extrgbx_gray_convert_msa
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+   JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extbgr_gray_convert_msa
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+   JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extbgrx_gray_convert_msa
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+   JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extxbgr_gray_convert_msa
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+   JDIMENSION output_row, int num_rows);
+EXTERN(void) jsimd_extxrgb_gray_convert_msa
   (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
    JDIMENSION output_row, int num_rows);
 
@@ -452,6 +497,31 @@ EXTERN(void) jsimd_ycc_extxrgb_convert_dspr2
   (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
    JSAMPARRAY output_buf, int num_rows);
 
+EXTERN(void) jsimd_ycc_rgb_convert_msa
+  (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
+   JSAMPARRAY output_buf, int num_rows);
+EXTERN(void) jsimd_ycc_extrgb_convert_msa
+  (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
+   JSAMPARRAY output_buf, int num_rows);
+EXTERN(void) jsimd_ycc_extrgbx_convert_msa
+  (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
+   JSAMPARRAY output_buf, int num_rows);
+EXTERN(void) jsimd_ycc_extbgr_convert_msa
+  (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
+   JSAMPARRAY output_buf, int num_rows);
+EXTERN(void) jsimd_ycc_extbgrx_convert_msa
+  (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
+   JSAMPARRAY output_buf, int num_rows);
+EXTERN(void) jsimd_ycc_extxbgr_convert_msa
+  (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
+   JSAMPARRAY output_buf, int num_rows);
+EXTERN(void) jsimd_ycc_extxrgb_convert_msa
+  (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
+   JSAMPARRAY output_buf, int num_rows);
+EXTERN(void) jsimd_ycc_rgb565_convert_msa
+  (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
+   JSAMPARRAY output_buf, int num_rows);
+
 EXTERN(void) jsimd_ycc_rgb_convert_mmi
   (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row,
    JSAMPARRAY output_buf, int num_rows);
@@ -522,6 +592,10 @@ EXTERN(void) jsimd_h2v1_downsample_dspr2
   (JDIMENSION image_width, int max_v_samp_factor, JDIMENSION v_samp_factor,
    JDIMENSION width_in_blocks, JSAMPARRAY input_data, JSAMPARRAY output_data);
 
+EXTERN(void) jsimd_h2v1_downsample_msa
+  (JDIMENSION image_width, int max_v_samp_factor, JDIMENSION v_samp_factor,
+   JDIMENSION width_blocks, JSAMPARRAY input_data, JSAMPARRAY output_data);
+
 EXTERN(void) jsimd_h2v1_downsample_altivec
   (JDIMENSION image_width, int max_v_samp_factor, JDIMENSION v_samp_factor,
    JDIMENSION width_in_blocks, JSAMPARRAY input_data, JSAMPARRAY output_data);
@@ -546,6 +620,10 @@ EXTERN(void) jsimd_h2v2_downsample_neon
 EXTERN(void) jsimd_h2v2_downsample_dspr2
   (JDIMENSION image_width, int max_v_samp_factor, JDIMENSION v_samp_factor,
    JDIMENSION width_in_blocks, JSAMPARRAY input_data, JSAMPARRAY output_data);
+
+EXTERN(void) jsimd_h2v2_downsample_msa
+  (JDIMENSION image_width, int max_v_samp_factor, JDIMENSION v_samp_factor,
+   JDIMENSION width_blocks, JSAMPARRAY input_data, JSAMPARRAY output_data);
 
 EXTERN(void) jsimd_h2v2_downsample_mmi
   (JDIMENSION image_width, int max_v_samp_factor, JDIMENSION v_samp_factor,
@@ -588,6 +666,13 @@ EXTERN(void) jsimd_h2v1_upsample_dspr2
   (int max_v_samp_factor, JDIMENSION output_width, JSAMPARRAY input_data,
    JSAMPARRAY *output_data_ptr);
 EXTERN(void) jsimd_h2v2_upsample_dspr2
+  (int max_v_samp_factor, JDIMENSION output_width, JSAMPARRAY input_data,
+   JSAMPARRAY *output_data_ptr);
+
+EXTERN(void) jsimd_h2v1_upsample_msa
+  (int max_v_samp_factor, JDIMENSION output_width, JSAMPARRAY input_data,
+   JSAMPARRAY *output_data_ptr);
+EXTERN(void) jsimd_h2v2_upsample_msa
   (int max_v_samp_factor, JDIMENSION output_width, JSAMPARRAY input_data,
    JSAMPARRAY *output_data_ptr);
 
@@ -637,6 +722,13 @@ EXTERN(void) jsimd_h2v1_fancy_upsample_dspr2
 EXTERN(void) jsimd_h2v2_fancy_upsample_dspr2
   (int max_v_samp_factor, JDIMENSION downsampled_width, JSAMPARRAY input_data,
    JSAMPARRAY *output_data_ptr);
+
+EXTERN(void) jsimd_h2v1_fancy_upsample_msa
+  (int max_v_samp_factor, JDIMENSION downsampled_width,
+   JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr);
+EXTERN(void) jsimd_h2v2_fancy_upsample_msa
+  (int max_v_samp_factor, JDIMENSION downsampled_width,
+   JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr);
 
 EXTERN(void) jsimd_h2v1_fancy_upsample_mmi
   (int max_v_samp_factor, JDIMENSION downsampled_width, JSAMPARRAY input_data,
@@ -831,6 +923,50 @@ EXTERN(void) jsimd_h2v2_extxrgb_merged_upsample_dspr2
   (JDIMENSION output_width, JSAMPIMAGE input_buf, JDIMENSION in_row_group_ctr,
    JSAMPARRAY output_buf, JSAMPLE *range);
 
+EXTERN(void) jsimd_h2v1_merged_upsample_msa
+  (JDIMENSION output_width, JSAMPIMAGE input_buf,
+   JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v1_extrgb_merged_upsample_msa
+  (JDIMENSION output_width, JSAMPIMAGE input_buf,
+   JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v1_extrgbx_merged_upsample_msa
+  (JDIMENSION output_width, JSAMPIMAGE input_buf,
+   JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v1_extbgr_merged_upsample_msa
+  (JDIMENSION output_width, JSAMPIMAGE input_buf,
+   JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v1_extbgrx_merged_upsample_msa
+  (JDIMENSION output_width, JSAMPIMAGE input_buf,
+   JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v1_extxbgr_merged_upsample_msa
+  (JDIMENSION output_width, JSAMPIMAGE input_buf,
+   JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v1_extxrgb_merged_upsample_msa
+  (JDIMENSION output_width, JSAMPIMAGE input_buf,
+   JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+
+EXTERN(void) jsimd_h2v2_merged_upsample_msa
+  (JDIMENSION output_width, JSAMPIMAGE input_buf,
+   JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v2_extrgb_merged_upsample_msa
+  (JDIMENSION output_width, JSAMPIMAGE input_buf,
+   JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v2_extrgbx_merged_upsample_msa
+  (JDIMENSION output_width, JSAMPIMAGE input_buf,
+   JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v2_extbgr_merged_upsample_msa
+  (JDIMENSION output_width, JSAMPIMAGE input_buf,
+   JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v2_extbgrx_merged_upsample_msa
+  (JDIMENSION output_width, JSAMPIMAGE input_buf,
+   JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v2_extxbgr_merged_upsample_msa
+  (JDIMENSION output_width, JSAMPIMAGE input_buf,
+   JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+EXTERN(void) jsimd_h2v2_extxrgb_merged_upsample_msa
+  (JDIMENSION output_width, JSAMPIMAGE input_buf,
+   JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+
 EXTERN(void) jsimd_h2v1_merged_upsample_mmi
   (JDIMENSION output_width, JSAMPIMAGE input_buf, JDIMENSION in_row_group_ctr,
    JSAMPARRAY output_buf);
@@ -935,6 +1071,9 @@ EXTERN(void) jsimd_convsamp_neon
 EXTERN(void) jsimd_convsamp_dspr2
   (JSAMPARRAY sample_data, JDIMENSION start_col, DCTELEM *workspace);
 
+EXTERN(void) jsimd_convsamp_msa
+  (JSAMPARRAY sample_data, JDIMENSION start_col, DCTELEM *workspace);
+
 EXTERN(void) jsimd_convsamp_altivec
   (JSAMPARRAY sample_data, JDIMENSION start_col, DCTELEM *workspace);
 
@@ -964,6 +1103,8 @@ EXTERN(void) jsimd_fdct_islow_neon(DCTELEM *data);
 
 EXTERN(void) jsimd_fdct_islow_dspr2(DCTELEM *data);
 
+EXTERN(void) jsimd_fdct_islow_msa(DCTELEM *data);
+
 EXTERN(void) jsimd_fdct_islow_mmi(DCTELEM *data);
 
 EXTERN(void) jsimd_fdct_islow_altivec(DCTELEM *data);
@@ -977,6 +1118,8 @@ EXTERN(void) jsimd_fdct_ifast_sse2(DCTELEM *data);
 EXTERN(void) jsimd_fdct_ifast_neon(DCTELEM *data);
 
 EXTERN(void) jsimd_fdct_ifast_dspr2(DCTELEM *data);
+
+EXTERN(void) jsimd_fdct_ifast_msa(DCTELEM *data);
 
 EXTERN(void) jsimd_fdct_ifast_mmi(DCTELEM *data);
 
@@ -1002,6 +1145,9 @@ EXTERN(void) jsimd_quantize_neon
   (JCOEFPTR coef_block, DCTELEM *divisors, DCTELEM *workspace);
 
 EXTERN(void) jsimd_quantize_dspr2
+  (JCOEFPTR coef_block, DCTELEM *divisors, DCTELEM *workspace);
+
+EXTERN(void) jsimd_quantize_msa
   (JCOEFPTR coef_block, DCTELEM *divisors, DCTELEM *workspace);
 
 EXTERN(void) jsimd_quantize_mmi
@@ -1060,6 +1206,13 @@ EXTERN(void) jsimd_idct_12x12_pass1_dspr2
 EXTERN(void) jsimd_idct_12x12_pass2_dspr2
   (int *workspace, int *output);
 
+EXTERN(void) jsimd_idct_2x2_msa
+  (j_decompress_ptr cinfo, jpeg_component_info *compptr,
+   JCOEFPTR coef_block, JSAMPARRAY output_buf, JDIMENSION output_col);
+EXTERN(void) jsimd_idct_4x4_msa
+  (j_decompress_ptr cinfo, jpeg_component_info *compptr,
+   JCOEFPTR coef_block, JSAMPARRAY output_buf, JDIMENSION output_col);
+
 /* Slow Integer Inverse DCT */
 EXTERN(void) jsimd_idct_islow_mmx
   (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
@@ -1081,6 +1234,10 @@ EXTERN(void) jsimd_idct_islow_neon
 
 EXTERN(void) jsimd_idct_islow_dspr2
   (void *dct_table, JCOEFPTR coef_block, int *output_buf, JSAMPLE *output_col);
+
+EXTERN(void) jsimd_idct_islow_msa
+  (j_decompress_ptr cinfo, jpeg_component_info *compptr,
+   JCOEFPTR coef_block, JSAMPARRAY output_buf, JDIMENSION output_col);
 
 EXTERN(void) jsimd_idct_islow_mmi
   (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
@@ -1110,6 +1267,10 @@ EXTERN(void) jsimd_idct_ifast_cols_dspr2
 EXTERN(void) jsimd_idct_ifast_rows_dspr2
   (DCTELEM *wsptr, JSAMPARRAY output_buf, JDIMENSION output_col,
    const int *idct_coefs);
+
+EXTERN(void) jsimd_idct_ifast_msa
+  (j_decompress_ptr cinfo, jpeg_component_info *compptr,
+   JCOEFPTR coef_block, JSAMPARRAY output_buf, JDIMENSION output_col);
 
 EXTERN(void) jsimd_idct_ifast_mmi
   (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,

--- a/simd/mips/jccolext_msa.c
+++ b/simd/mips/jccolext_msa.c
@@ -1,0 +1,287 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* RGB --> YCC CONVERSION */
+
+#if RGB_RED == 0 || RGB_RED == 1
+#define var_c  rg0_r
+#define var_d  rg0_l
+#define var_e  rg1_r
+#define var_f  rg1_l
+#define var_g  gb0_r
+#define var_h  gb0_l
+#define var_i  gb1_r
+#define var_j  gb1_l
+#if RGB_RED == 0
+#define var_a  r0
+#define var_b  b0
+#else /* RGB_RED == 1 */
+#define var_a  b0
+#define var_b  r0
+#endif
+#else /* RGB_RED == 2 || RGB_RED == 3 */
+#define var_c  gb0_r
+#define var_d  gb0_l
+#define var_e  gb1_r
+#define var_f  gb1_l
+#define var_g  rg0_r
+#define var_h  rg0_l
+#define var_i  rg1_r
+#define var_j  rg1_l
+#if RGB_RED == 2
+#define var_a  b0
+#define var_b  r0
+#else /* RGB_RED == 3 */
+#define var_a  r0
+#define var_b  b0
+#endif
+#endif
+
+#if RGB_PIXELSIZE == 4
+#if RGB_RED == 0 || RGB_RED == 2
+#define var_k  rg0
+#define var_l  rg1
+#define var_m  gb0
+#define var_n  gb1
+#define fun_a  PCKEV_H2_SH
+#define fun_b  __msa_pckev_b
+#define fun_c  __msa_pckod_b
+#define fun_d  __msa_pckev_h
+#else /* RGB_RED == 1 || RGB_RED == 3 */
+#define var_k  gb0
+#define var_l  gb1
+#define var_m  rg0
+#define var_n  rg1
+#define fun_a  PCKOD_H2_SH
+#define fun_b  __msa_pckod_b
+#define fun_c  __msa_pckev_b
+#define fun_d  __msa_pckod_h
+#endif
+#endif
+
+GLOBAL(void)
+jsimd_rgb_ycc_convert_msa(JDIMENSION img_width, JSAMPARRAY input_buf,
+                          JSAMPIMAGE output_buf, JDIMENSION output_row,
+                          int num_rows)
+{
+  register JSAMPROW inptr;
+  register JSAMPROW p_out_y, p_out_cb, p_out_cr;
+  JDIMENSION r, g, b;
+  JDIMENSION col, width_mul_16 = img_width & 0xFFF0;
+  v16u8 in0, in1, in2, out_y, out_cb, out_cr;
+  v8i16 r0, b0, r1, b1, rg0, gb0, rg1, gb1, mult, zero = { 0 };
+  v8i16 rg0_r, gb0_r, rg1_r, gb1_r, rg0_l, gb0_l, rg1_l, gb1_l;
+  v4i32 r0_r, r0_l, r1_r, r1_l, b0_r, b0_l, b1_r, b1_l;
+  v4i32 tmp0, tmp1, tmp2, tmp3;
+  const v8i16 coeff = COEFF_CONST;
+  v4i32 offset_minus = __msa_fill_w(((128 << SCALE) - 1));
+#if RGB_PIXELSIZE == 3
+  const v16i8 rg0_mask =
+    { 0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16, 18, 19, 21, 22 };
+  v16i8 rg1_mask, gb0_mask, gb1_mask;
+#else /* RGB_PIXELSIZE == 4 */
+  v16u8 in3;
+#endif
+
+  while (--num_rows >= 0) {
+    p_out_y = output_buf[0][output_row];
+    p_out_cb = output_buf[1][output_row];
+    p_out_cr = output_buf[2][output_row];
+    inptr = *input_buf++;
+    output_row++;
+
+    LD_UB2(inptr, 16, in0, in1);
+
+    for (col = 0; col < width_mul_16; col += 16) {
+#if RGB_PIXELSIZE == 3
+      rg1_mask = MSA_ADDVI_B(rg0_mask, 8);
+      gb0_mask = MSA_ADDVI_B(rg0_mask, 1);
+      gb1_mask = MSA_ADDVI_B(gb0_mask, 8);
+
+      in2 = LD_UB(inptr + 32);
+
+      VSHF_B2_SH(in0, in1, in1, in2, rg0_mask, rg1_mask, rg0, rg1);
+      VSHF_B2_SH(in0, in1, in1, in2, gb0_mask, gb1_mask, gb0, gb1);
+
+      var_a = (v8i16)__msa_pckev_b((v16i8)rg1, (v16i8)rg0);
+      var_b = (v8i16)__msa_pckod_b((v16i8)gb1, (v16i8)gb0);
+#else /* RGB_PIXELSIZE == 4 */
+      LD_UB2((inptr + 32), 16, in2, in3);
+
+      fun_a(in1, in0, in3, in2, var_k, var_l);
+      var_a = (v8i16)fun_b((v16i8)var_l, (v16i8)var_k);
+
+      in0 = (v16u8)__msa_sldi_b((v16i8)in0, (v16i8)in0, 1);
+      in1 = (v16u8)__msa_sldi_b((v16i8)in1, (v16i8)in1, 1);
+      in2 = (v16u8)__msa_sldi_b((v16i8)in2, (v16i8)in2, 1);
+      in3 = (v16u8)__msa_sldi_b((v16i8)in3, (v16i8)in3, 1);
+
+      PCKEV_H2_SH(in1, in0, in3, in2, var_m, var_n);
+      var_b = (v8i16)fun_c((v16i8)var_n, (v16i8)var_m);
+#endif
+
+      UNPCK_UB_SH(rg0, rg0_r, rg0_l);
+      UNPCK_UB_SH(rg1, rg1_r, rg1_l);
+      UNPCK_UB_SH(gb0, gb0_r, gb0_l);
+      UNPCK_UB_SH(gb1, gb1_r, gb1_l);
+      ILVL_B2_SH(zero, r0, zero, b0, r1, b1);
+      ILVR_B2_SH(zero, r0, zero, b0, r0, b0);
+      ILVRL_H2_SW(zero, r0, r0_r, r0_l);
+      ILVRL_H2_SW(zero, b0, b0_r, b0_l);
+      ILVRL_H2_SW(zero, r1, r1_r, r1_l);
+      ILVRL_H2_SW(zero, b1, b1_r, b1_l);
+      SLLI_W4_SW(r0_r, r1_r, b0_r, b1_r, 15);
+      SLLI_W4_SW(r0_l, r1_l, b0_l, b1_l, 15);
+
+      /* RGB --> Y */
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 0);
+      DOTP_SH4_SW(rg0_r, rg0_l, rg1_r, rg1_l, mult, mult, mult, mult,
+                  tmp0, tmp1, tmp2, tmp3);
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 1);
+      DPADD_SH4_SW(gb0_r, gb0_l, gb1_r, gb1_l, mult, mult, mult, mult,
+                   tmp0, tmp1, tmp2, tmp3);
+      SRARI_W4_SW(tmp0, tmp1, tmp2, tmp3, SCALE);
+      PCKEV_H2_SW(tmp1, tmp0, tmp3, tmp2, tmp0, tmp2);
+      out_y = (v16u8)__msa_pckev_b((v16i8)tmp2, (v16i8)tmp0);
+      ST_UB(out_y, (p_out_y + col));
+
+      /* RGB --> Cb */
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 2);
+      DPADD_SH4_SW(var_c, var_d, var_e, var_f, mult, mult, mult, mult,
+                   b0_r, b0_l, b1_r, b1_l);
+      ADD4(b0_r, offset_minus, b0_l, offset_minus, b1_r, offset_minus,
+           b1_l, offset_minus, tmp0, tmp1, tmp2, tmp3);
+      SRARI_W4_SW(tmp0, tmp1, tmp2, tmp3, SCALE);
+      PCKEV_H2_SW(tmp1, tmp0, tmp3, tmp2, tmp0, tmp2);
+      out_cb = (v16u8)__msa_pckev_b((v16i8)tmp2, (v16i8)tmp0);
+      ST_UB(out_cb, (p_out_cb + col));
+
+      /* RGB --> Cr */
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 3);
+      DPADD_SH4_SW(var_g, var_h, var_i, var_j, mult, mult, mult, mult,
+                   r0_r, r0_l, r1_r, r1_l);
+      ADD4(r0_r, offset_minus, r0_l, offset_minus, r1_r, offset_minus,
+           r1_l, offset_minus, tmp0, tmp1, tmp2, tmp3);
+      SRARI_W4_SW(tmp0, tmp1, tmp2, tmp3, SCALE);
+      PCKEV_H2_SW(tmp1, tmp0, tmp3, tmp2, tmp0, tmp2);
+      out_cr = (v16u8)__msa_pckev_b((v16i8)tmp2, (v16i8)tmp0);
+      ST_UB(out_cr, (p_out_cr + col));
+
+      inptr += 16 * RGB_PIXELSIZE;
+      LD_UB2(inptr, 16, in0, in1);
+    }
+
+    if (img_width - width_mul_16 >= 8) {
+#if RGB_PIXELSIZE == 3
+      gb0_mask = MSA_ADDVI_B(rg0_mask, 1);
+
+      VSHF_B2_SH(in0, in1, in0, in1, rg0_mask, gb0_mask, rg0, gb0);
+
+      var_a = (v8i16)__msa_pckev_b((v16i8)zero, (v16i8)rg0);
+      var_b = (v8i16)__msa_pckod_b((v16i8)zero, (v16i8)gb0);
+#else /* RGB_PIXELSIZE == 4 */
+      var_k = fun_d((v8i16)in1, (v8i16)in0);
+      var_a = (v8i16)fun_b((v16i8)zero, (v16i8)var_k);
+
+      in0 = (v16u8)__msa_sldi_b((v16i8)in0, (v16i8)in0, 1);
+      in1 = (v16u8)__msa_sldi_b((v16i8)in1, (v16i8)in1, 1);
+
+      var_m = __msa_pckev_h((v8i16)in1, (v8i16)in0);
+      var_b = (v8i16)fun_c((v16i8)zero, (v16i8)var_m);
+#endif
+
+      UNPCK_UB_SH(rg0, rg0_r, rg0_l);
+      UNPCK_UB_SH(gb0, gb0_r, gb0_l);
+      ILVR_B2_SH(zero, r0, zero, b0, r0, b0);
+      ILVRL_H2_SW(zero, r0, r0_r, r0_l);
+      ILVRL_H2_SW(zero, b0, b0_r, b0_l);
+      SLLI_W4_SW(r0_r, r0_l, b0_r, b0_l, 15);
+
+      /* RGB --> Y */
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 0);
+      DOTP_SH2_SW(rg0_r, rg0_l, mult, mult, tmp0, tmp1);
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 1);
+      DPADD_SH2_SW(gb0_r, gb0_l, mult, mult, tmp0, tmp1);
+      SRARI_W2_SW(tmp0, tmp1, SCALE);
+      tmp0 = (v4i32)__msa_pckev_h((v8i16)tmp1, (v8i16)tmp0);
+      out_y = (v16u8)__msa_pckev_b((v16i8)zero, (v16i8)tmp0);
+      ST8x1_UB(out_y, (p_out_y + col));
+
+      /* RGB --> Cb */
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 2);
+      DPADD_SH2_SW(var_c, var_d, mult, mult, b0_r, b0_l);
+      ADD2(b0_r, offset_minus, b0_l, offset_minus, tmp0, tmp1);
+      SRARI_W2_SW(tmp0, tmp1, SCALE);
+      tmp0 = (v4i32)__msa_pckev_h((v8i16)tmp1, (v8i16)tmp0);
+      out_cb = (v16u8)__msa_pckev_b((v16i8)zero, (v16i8)tmp0);
+      ST8x1_UB(out_cb, (p_out_cb + col));
+
+      /* RGB --> Cr */
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 3);
+      DPADD_SH2_SW(var_g, var_h, mult, mult, r0_r, r0_l);
+      ADD2(r0_r, offset_minus, r0_l, offset_minus, tmp0, tmp1);
+      SRARI_W2_SW(tmp0, tmp1, SCALE);
+      tmp0 = (v4i32)__msa_pckev_h((v8i16)tmp1, (v8i16)tmp0);
+      out_cr = (v16u8)__msa_pckev_b((v16i8)zero, (v16i8)tmp0);
+      ST8x1_UB(out_cr, (p_out_cr + col));
+
+      col += 8;
+      inptr += 8 * RGB_PIXELSIZE;
+    }
+
+    for (; col < img_width; col++) {
+      r = GETSAMPLE(inptr[RGB_RED]);
+      g = GETSAMPLE(inptr[RGB_GREEN]);
+      b = GETSAMPLE(inptr[RGB_BLUE]);
+      inptr += RGB_PIXELSIZE;
+
+      p_out_y[col] = (uint8_t)((19595 * r + 38470 * g + 7471 * b +
+                                ONE_HALF) >> SCALE);
+      p_out_cb[col] = (uint8_t)((-11059 * r + -21709 * g + 32768 * b +
+                                 CBCR_OFFSET - 1 + ONE_HALF) >> SCALE);
+      p_out_cr[col] = (uint8_t)((32768 * r + -27439 * g + -5329 * b +
+                                 CBCR_OFFSET - 1 + ONE_HALF) >> SCALE);
+    }
+  }
+}
+
+#undef var_a
+#undef var_b
+#undef var_c
+#undef var_d
+#undef var_e
+#undef var_f
+#undef var_g
+#undef var_h
+#undef var_i
+#undef var_j
+#if RGB_PIXELSIZE == 4
+#undef var_k
+#undef var_l
+#undef var_m
+#undef var_n
+#undef fun_a
+#undef fun_b
+#undef fun_c
+#undef fun_d
+#endif

--- a/simd/mips/jccolor_msa.c
+++ b/simd/mips/jccolor_msa.c
@@ -1,0 +1,130 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#define JPEG_INTERNALS
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "../../jsimd.h"
+#include "jmacros_msa.h"
+
+
+#define SCALE  16
+#define ONE_HALF  (1 << (SCALE - 1))
+#define CBCR_OFFSET  (128 << SCALE)
+#define GETSAMPLE(value)  ((int)(value))
+#define RGB_CONVERT_COEFF \
+  { 19595, 16384, 22086, 7471, -11059, -21709, -27439, -5329 }
+#define BGR_CONVERT_COEFF \
+  { 7471, 22086, 16384, 19595, -21709, -11059, -5329, -27439 }
+
+#define COEFF_CONST  RGB_CONVERT_COEFF
+#include "jccolext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef COEFF_CONST
+
+#define RGB_RED        EXT_RGB_RED
+#define RGB_GREEN      EXT_RGB_GREEN
+#define RGB_BLUE       EXT_RGB_BLUE
+#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
+#define COEFF_CONST    RGB_CONVERT_COEFF
+#define jsimd_rgb_ycc_convert_msa  jsimd_extrgb_ycc_convert_msa
+#include "jccolext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef COEFF_CONST
+#undef jsimd_rgb_ycc_convert_msa
+
+#define RGB_RED        EXT_BGR_RED
+#define RGB_GREEN      EXT_BGR_GREEN
+#define RGB_BLUE       EXT_BGR_BLUE
+#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
+#define COEFF_CONST    BGR_CONVERT_COEFF
+#define jsimd_rgb_ycc_convert_msa  jsimd_extbgr_ycc_convert_msa
+#include "jccolext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef COEFF_CONST
+#undef jsimd_rgb_ycc_convert_msa
+
+#define RGB_RED        EXT_RGBX_RED
+#define RGB_GREEN      EXT_RGBX_GREEN
+#define RGB_BLUE       EXT_RGBX_BLUE
+#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
+#define COEFF_CONST    RGB_CONVERT_COEFF
+#define jsimd_rgb_ycc_convert_msa  jsimd_extrgbx_ycc_convert_msa
+#include "jccolext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef COEFF_CONST
+#undef jsimd_rgb_ycc_convert_msa
+
+#define RGB_RED        EXT_BGRX_RED
+#define RGB_GREEN      EXT_BGRX_GREEN
+#define RGB_BLUE       EXT_BGRX_BLUE
+#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
+#define COEFF_CONST    BGR_CONVERT_COEFF
+#define jsimd_rgb_ycc_convert_msa  jsimd_extbgrx_ycc_convert_msa
+#include "jccolext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef COEFF_CONST
+#undef jsimd_rgb_ycc_convert_msa
+
+#define RGB_RED        EXT_XRGB_RED
+#define RGB_GREEN      EXT_XRGB_GREEN
+#define RGB_BLUE       EXT_XRGB_BLUE
+#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
+#define COEFF_CONST    RGB_CONVERT_COEFF
+#define jsimd_rgb_ycc_convert_msa  jsimd_extxrgb_ycc_convert_msa
+#include "jccolext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef COEFF_CONST
+#undef jsimd_rgb_ycc_convert_msa
+
+#define RGB_RED        EXT_XBGR_RED
+#define RGB_GREEN      EXT_XBGR_GREEN
+#define RGB_BLUE       EXT_XBGR_BLUE
+#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
+#define COEFF_CONST    BGR_CONVERT_COEFF
+#define jsimd_rgb_ycc_convert_msa  jsimd_extxbgr_ycc_convert_msa
+#include "jccolext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef COEFF_CONST
+#undef jsimd_rgb_ycc_convert_msa

--- a/simd/mips/jcgray_msa.c
+++ b/simd/mips/jcgray_msa.c
@@ -1,0 +1,128 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#define JPEG_INTERNALS
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "../../jsimd.h"
+#include "jmacros_msa.h"
+
+
+#define SCALE  16
+#define ONE_HALF  (1 << (SCALE - 1))
+#define CBCR_OFFSET  (128 << SCALE)
+#define GETSAMPLE(value)  ((int)(value))
+#define RGB_CONVERT_COEFF  { 19595, 16384, 22086, 7471, 0, 0, 0, 0 }
+#define BGR_CONVERT_COEFF  { 7471, 22086, 16384, 19595, 0, 0, 0, 0 }
+
+#define COEFF_CONST  RGB_CONVERT_COEFF
+#include "jcgryext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef COEFF_CONST
+
+#define RGB_RED        EXT_RGB_RED
+#define RGB_GREEN      EXT_RGB_GREEN
+#define RGB_BLUE       EXT_RGB_BLUE
+#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
+#define COEFF_CONST    RGB_CONVERT_COEFF
+#define jsimd_rgb_gray_convert_msa  jsimd_extrgb_gray_convert_msa
+#include "jcgryext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef COEFF_CONST
+#undef jsimd_rgb_gray_convert_msa
+
+#define RGB_RED        EXT_BGR_RED
+#define RGB_GREEN      EXT_BGR_GREEN
+#define RGB_BLUE       EXT_BGR_BLUE
+#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
+#define COEFF_CONST    BGR_CONVERT_COEFF
+#define jsimd_rgb_gray_convert_msa  jsimd_extbgr_gray_convert_msa
+#include "jcgryext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef COEFF_CONST
+#undef jsimd_rgb_gray_convert_msa
+
+#define RGB_RED        EXT_RGBX_RED
+#define RGB_GREEN      EXT_RGBX_GREEN
+#define RGB_BLUE       EXT_RGBX_BLUE
+#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
+#define COEFF_CONST    RGB_CONVERT_COEFF
+#define jsimd_rgb_gray_convert_msa  jsimd_extrgbx_gray_convert_msa
+#include "jcgryext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef COEFF_CONST
+#undef jsimd_rgb_gray_convert_msa
+
+#define RGB_RED        EXT_BGRX_RED
+#define RGB_GREEN      EXT_BGRX_GREEN
+#define RGB_BLUE       EXT_BGRX_BLUE
+#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
+#define COEFF_CONST    BGR_CONVERT_COEFF
+#define jsimd_rgb_gray_convert_msa  jsimd_extbgrx_gray_convert_msa
+#include "jcgryext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef COEFF_CONST
+#undef jsimd_rgb_gray_convert_msa
+
+#define RGB_RED        EXT_XRGB_RED
+#define RGB_GREEN      EXT_XRGB_GREEN
+#define RGB_BLUE       EXT_XRGB_BLUE
+#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
+#define COEFF_CONST    RGB_CONVERT_COEFF
+#define jsimd_rgb_gray_convert_msa  jsimd_extxrgb_gray_convert_msa
+#include "jcgryext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef COEFF_CONST
+#undef jsimd_rgb_gray_convert_msa
+
+#define RGB_RED        EXT_XBGR_RED
+#define RGB_GREEN      EXT_XBGR_GREEN
+#define RGB_BLUE       EXT_XBGR_BLUE
+#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
+#define COEFF_CONST    BGR_CONVERT_COEFF
+#define jsimd_rgb_gray_convert_msa  jsimd_extxbgr_gray_convert_msa
+#include "jcgryext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef COEFF_CONST
+#undef jsimd_rgb_gray_convert_msa

--- a/simd/mips/jcgryext_msa.c
+++ b/simd/mips/jcgryext_msa.c
@@ -1,0 +1,252 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* RGB --> GRAYSCALE CONVERSION */
+
+#if RGB_PIXELSIZE == 4
+#if RGB_RED == 0 || RGB_RED == 2
+#define var_a  rg0
+#define var_b  rg1
+#define var_c  gb0
+#define var_d  gb1
+#define fun_a  PCKEV_H2_SH
+#define fun_b  __msa_pckev_h
+#else /* RGB_RED == 1 || RGB_RED == 3 */
+#define var_a  gb0
+#define var_b  gb1
+#define var_c  rg0
+#define var_d  rg1
+#define fun_a  PCKOD_H2_SH
+#define fun_b  __msa_pckod_h
+#endif
+#endif
+
+GLOBAL(void)
+jsimd_rgb_gray_convert_msa(JDIMENSION img_width, JSAMPARRAY input_buf,
+                           JSAMPIMAGE output_buf, JDIMENSION output_row,
+                           int num_rows)
+{
+  JSAMPROW inptr;
+  JSAMPROW p_out_y = output_buf[0][output_row];
+  JDIMENSION col, r, g, b;
+  v16u8 in0, in1, in2, in3, in4, in5, out_y, out_y1;
+  v8i16 rg0, gb0, rg1, gb1, mult, zero = { 0 };
+  v8i16 rg0_r, gb0_r, rg1_r, gb1_r, rg0_l, gb0_l, rg1_l, gb1_l;
+  v4i32 tmp0, tmp1, tmp2, tmp3;
+  const v8i16 coeff = COEFF_CONST;
+#if RGB_PIXELSIZE == 3
+  const v16i8 rg0_mask =
+    { 0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16, 18, 19, 21, 22 };
+  const v16i8 gb0_mask =
+    { 1, 2, 4, 5, 7, 8, 10, 11, 13, 14, 16, 17, 19, 20, 22, 23 };
+  const v16i8 rg1_mask =
+    { 8, 9, 11, 12, 14, 15, 17, 18, 20, 21, 23, 24, 26, 27, 29, 30 };
+  const v16i8 gb1_mask =
+    { 9, 10, 12, 13, 15, 16, 18, 19, 21, 22, 24, 25, 27, 28, 30, 31 };
+#else /* RGB_PIXELSIZE == 4 */
+  v16u8 in6, in7;
+#endif
+
+  while (--num_rows >= 0) {
+    inptr = *input_buf++;
+
+    for (col = 0; col < (img_width & ~0x1F); col += 32) {
+#if RGB_PIXELSIZE == 3
+      LD_UB6(inptr, 16, in0, in1, in2, in3, in4, in5);
+
+      VSHF_B2_SH(in0, in1, in1, in2, rg0_mask, rg1_mask, rg0, rg1);
+      VSHF_B2_SH(in0, in1, in1, in2, gb0_mask, gb1_mask, gb0, gb1);
+#else /* RGB_PIXELSIZE == 4 */
+      LD_UB8(inptr, 16, in0, in1, in2, in3, in4, in5, in6, in7);
+
+      fun_a(in1, in0, in3, in2, var_a, var_b);
+
+      SLDI_B2_UB(in0, in1, in0, in1, in0, in1, 1);
+      SLDI_B2_UB(in2, in3, in2, in3, in2, in3, 1);
+      PCKEV_H2_SH(in1, in0, in3, in2, var_c, var_d);
+#endif
+
+      UNPCK_UB_SH(rg0, rg0_r, rg0_l);
+      UNPCK_UB_SH(rg1, rg1_r, rg1_l);
+      UNPCK_UB_SH(gb0, gb0_r, gb0_l);
+      UNPCK_UB_SH(gb1, gb1_r, gb1_l);
+
+      /* RGB --> Y */
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 0);
+      DOTP_SH4_SW(rg0_r, rg0_l, rg1_r, rg1_l, mult, mult, mult, mult,
+                  tmp0, tmp1, tmp2, tmp3);
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 1);
+      DPADD_SH4_SW(gb0_r, gb0_l, gb1_r, gb1_l, mult, mult, mult, mult,
+                   tmp0, tmp1, tmp2, tmp3);
+      SRARI_W4_SW(tmp0, tmp1, tmp2, tmp3, SCALE);
+      PCKEV_H2_SW(tmp1, tmp0, tmp3, tmp2, tmp0, tmp2);
+      out_y = (v16u8)__msa_pckev_b((v16i8)tmp2, (v16i8)tmp0);
+
+#if RGB_PIXELSIZE == 3
+      VSHF_B2_SH(in3, in4, in4, in5, rg0_mask, rg1_mask, rg0, rg1);
+      VSHF_B2_SH(in3, in4, in4, in5, gb0_mask, gb1_mask, gb0, gb1);
+#else /* RGB_PIXELSIZE == 4 */
+      fun_a(in5, in4, in7, in6, var_a, var_b);
+
+      SLDI_B2_UB(in4, in5, in4, in5, in4, in5, 1);
+      SLDI_B2_UB(in6, in7, in6, in7, in6, in7, 1);
+      PCKEV_H2_SH(in5, in4, in7, in6, var_c, var_d);
+#endif
+
+      UNPCK_UB_SH(rg0, rg0_r, rg0_l);
+      UNPCK_UB_SH(rg1, rg1_r, rg1_l);
+      UNPCK_UB_SH(gb0, gb0_r, gb0_l);
+      UNPCK_UB_SH(gb1, gb1_r, gb1_l);
+
+      /* RGB --> Y */
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 0);
+      DOTP_SH4_SW(rg0_r, rg0_l, rg1_r, rg1_l, mult, mult, mult, mult,
+                  tmp0, tmp1, tmp2, tmp3);
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 1);
+      DPADD_SH4_SW(gb0_r, gb0_l, gb1_r, gb1_l, mult, mult, mult, mult,
+                   tmp0, tmp1, tmp2, tmp3);
+      SRARI_W4_SW(tmp0, tmp1, tmp2, tmp3, SCALE);
+      PCKEV_H2_SW(tmp1, tmp0, tmp3, tmp2, tmp0, tmp2);
+      out_y1 = (v16u8)__msa_pckev_b((v16i8)tmp2, (v16i8)tmp0);
+
+      ST_UB2(out_y, out_y1, (p_out_y + col), 16);
+
+      inptr += 32 * RGB_PIXELSIZE;
+    }
+
+    for (; col < (img_width & ~0xF); col += 16) {
+#if RGB_PIXELSIZE == 3
+      LD_UB3(inptr, 16, in0, in1, in2);
+
+      VSHF_B2_SH(in0, in1, in1, in2, rg0_mask, rg1_mask, rg0, rg1);
+      VSHF_B2_SH(in0, in1, in1, in2, gb0_mask, gb1_mask, gb0, gb1);
+#else /* RGB_PIXELSIZE == 4 */
+      LD_UB4(inptr, 16, in0, in1, in2, in3);
+
+      fun_a(in1, in0, in3, in2, var_a, var_b);
+
+      SLDI_B2_UB(in0, in1, in0, in1, in0, in1, 1);
+      SLDI_B2_UB(in2, in3, in2, in3, in2, in3, 1);
+      PCKEV_H2_SH(in1, in0, in3, in2, var_c, var_d);
+#endif
+
+      UNPCK_UB_SH(rg0, rg0_r, rg0_l);
+      UNPCK_UB_SH(rg1, rg1_r, rg1_l);
+      UNPCK_UB_SH(gb0, gb0_r, gb0_l);
+      UNPCK_UB_SH(gb1, gb1_r, gb1_l);
+
+      /* RGB --> Y */
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 0);
+      DOTP_SH4_SW(rg0_r, rg0_l, rg1_r, rg1_l, mult, mult, mult, mult,
+                  tmp0, tmp1, tmp2, tmp3);
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 1);
+      DPADD_SH4_SW(gb0_r, gb0_l, gb1_r, gb1_l, mult, mult, mult, mult,
+                   tmp0, tmp1, tmp2, tmp3);
+      SRARI_W4_SW(tmp0, tmp1, tmp2, tmp3, SCALE);
+      PCKEV_H2_SW(tmp1, tmp0, tmp3, tmp2, tmp0, tmp2);
+      out_y = (v16u8)__msa_pckev_b((v16i8)tmp2, (v16i8)tmp0);
+      ST_UB(out_y, (p_out_y + col));
+
+      inptr += 16 * RGB_PIXELSIZE;
+    }
+
+    if ((img_width & 0xF) >= 8) {
+      LD_UB2(inptr, 16, in0, in1);
+
+#if RGB_PIXELSIZE == 3
+      VSHF_B2_SH(in0, in1, in0, in1, rg0_mask, gb0_mask, rg0, gb0);
+#else /* RGB_PIXELSIZE == 4 */
+      var_a = fun_b((v8i16)in1, (v8i16)in0);
+
+      SLDI_B2_UB(in0, in1, in0, in1, in0, in1, 1);
+      var_b = __msa_pckev_h((v8i16)in1, (v8i16)in0);
+#endif
+
+      UNPCK_UB_SH(rg0, rg0_r, rg0_l);
+      UNPCK_UB_SH(gb0, gb0_r, gb0_l);
+
+      /* RGB --> Y */
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 0);
+      DOTP_SH2_SW(rg0_r, rg0_l, mult, mult, tmp0, tmp1);
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 1);
+      DPADD_SH2_SW(gb0_r, gb0_l, mult, mult, tmp0, tmp1);
+      SRARI_W2_SW(tmp0, tmp1, SCALE);
+      tmp0 = (v4i32)__msa_pckev_h((v8i16)tmp1, (v8i16)tmp0);
+      out_y = (v16u8)__msa_pckev_b((v16i8)zero, (v16i8)tmp0);
+      ST8x1_UB(out_y, (p_out_y + col));
+
+      col += 8;
+      inptr += 8 * RGB_PIXELSIZE;
+    }
+
+    if ((img_width & 0x7) >= 4) {
+      int out_val;
+      in0 = LD_UB(inptr);
+
+#if RGB_PIXELSIZE == 3
+      VSHF_B2_SH(in0, in0, in0, in0, rg0_mask, gb0_mask, rg0, gb0);
+#else /* RGB_PIXELSIZE == 4 */
+      var_a = fun_b((v8i16)in0, (v8i16)in0);
+
+      in0 = (v16u8)__msa_sldi_b((v16i8)in0, (v16i8)in0, 1);
+      var_b = __msa_pckev_h((v8i16)in0, (v8i16)in0);
+#endif
+
+      rg0_r = (v8i16)__msa_ilvr_b((v16i8)zero, (v16i8)rg0);
+      gb0_r = (v8i16)__msa_ilvr_b((v16i8)zero, (v16i8)gb0);
+
+      /* RGB --> Y */
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 0);
+      tmp0 = __msa_dotp_s_w((v8i16)rg0_r, (v8i16)mult);
+      mult = (v8i16)__msa_splati_w((v4i32)coeff, 1);
+      tmp0 = __msa_dpadd_s_w(tmp0, (v8i16)gb0_r, (v8i16)mult);
+      tmp0 = __msa_srari_w(tmp0, SCALE);
+      tmp0 = (v4i32)__msa_pckev_h((v8i16)zero, (v8i16)tmp0);
+      out_y = (v16u8)__msa_pckev_b((v16i8)zero, (v16i8)tmp0);
+      out_val = __msa_copy_s_w((v4i32)out_y, 0);
+      SW(out_val, (p_out_y + col));
+
+      col += 4;
+      inptr += 4 * RGB_PIXELSIZE;
+    }
+
+    for (; col < img_width; col++) {
+      r = GETSAMPLE(inptr[RGB_RED]);
+      g = GETSAMPLE(inptr[RGB_GREEN]);
+      b = GETSAMPLE(inptr[RGB_BLUE]);
+      inptr += RGB_PIXELSIZE;
+
+      p_out_y[col] = (uint8_t)((19595 * r + 38470 * g + 7471 * b +
+                                ONE_HALF) >> SCALE);
+    }
+  }
+}
+
+#if RGB_PIXELSIZE == 4
+#undef var_a
+#undef var_b
+#undef var_c
+#undef var_d
+#undef fun_a
+#undef fun_b
+#endif

--- a/simd/mips/jcsample_msa.c
+++ b/simd/mips/jcsample_msa.c
@@ -1,0 +1,255 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* CHROMA DOWNSAMPLING */
+
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "jmacros_msa.h"
+
+
+GLOBAL(void)
+jsimd_h2v1_downsample_msa(JDIMENSION image_width, int max_v_samp_factor,
+                          JDIMENSION v_samp_factor, JDIMENSION width_blocks,
+                          JSAMPARRAY input_data, JSAMPARRAY output_data)
+{
+  unsigned char end_pixel;
+  int outcol, outrow;
+  JSAMPROW inptr, outptr;
+  unsigned short *tmp_ptr;
+  v16i8 src0, src1, src2, src3, src4, src5, src6, src7, dst0, dst1;
+  v8i16 tmp0_r, tmp0_l, tmp1_r, tmp1_l;
+  const v8i16 bias = { 0, 1, 0, 1, 0, 1, 0, 1 };
+  JDIMENSION out_width = width_blocks * 8;
+
+  for (outrow = 0; outrow < v_samp_factor; outrow++) {
+    outptr = output_data[outrow];
+    inptr = input_data[outrow];
+
+    outcol = 0;
+
+    for (; outcol < (out_width & ~0x3F); outcol += 64) {
+      LD_SB8(inptr, 16, src0, src1, src2, src3, src4, src5, src6, src7);
+      inptr += 128;
+
+      HADD_UB2_SH(src0, src1, tmp0_r, tmp0_l);
+      HADD_UB2_SH(src2, src3, tmp1_r, tmp1_l);
+      ADD4(tmp0_r, bias, tmp0_l, bias, tmp1_r, bias, tmp1_l, bias,
+           tmp0_r, tmp0_l, tmp1_r, tmp1_l);
+      SRAI_H4_SH(tmp0_r, tmp0_l, tmp1_r, tmp1_l, 1);
+      dst0 = __msa_pckev_b((v16i8)tmp0_l, (v16i8)tmp0_r);
+      dst1 = __msa_pckev_b((v16i8)tmp1_l, (v16i8)tmp1_r);
+      ST_SB2(dst0, dst1, outptr, 16);
+      outptr += 32;
+
+      HADD_UB2_SH(src4, src5, tmp0_r, tmp0_l);
+      HADD_UB2_SH(src6, src7, tmp1_r, tmp1_l);
+      ADD4(tmp0_r, bias, tmp0_l, bias, tmp1_r, bias, tmp1_l, bias,
+           tmp0_r, tmp0_l, tmp1_r, tmp1_l);
+      SRAI_H4_SH(tmp0_r, tmp0_l, tmp1_r, tmp1_l, 1);
+      dst0 = __msa_pckev_b((v16i8)tmp0_l, (v16i8)tmp0_r);
+      dst1 = __msa_pckev_b((v16i8)tmp1_l, (v16i8)tmp1_r);
+
+      ST_SB2(dst0, dst1, outptr, 16);
+      outptr += 32;
+    }
+
+    if (outcol < (out_width & ~0x1F)) {
+      LD_SB4(inptr, 16, src0, src1, src2, src3);
+      inptr += 64;
+
+      HADD_UB2_SH(src0, src1, tmp0_r, tmp0_l);
+      HADD_UB2_SH(src2, src3, tmp1_r, tmp1_l);
+      ADD4(tmp0_r, bias, tmp0_l, bias, tmp1_r, bias, tmp1_l, bias,
+           tmp0_r, tmp0_l, tmp1_r, tmp1_l);
+      SRAI_H4_SH(tmp0_r, tmp0_l, tmp1_r, tmp1_l, 1);
+      dst0 = __msa_pckev_b((v16i8)tmp0_l, (v16i8)tmp0_r);
+      dst1 = __msa_pckev_b((v16i8)tmp1_l, (v16i8)tmp1_r);
+
+      ST_SB2(dst0, dst1, outptr, 16);
+      outptr += 32;
+      outcol += 32;
+    }
+
+    if (outcol < (out_width & ~0xF)) {
+      LD_SB2(inptr, 16, src0, src1);
+      inptr += 32;
+
+      HADD_UB2_SH(src0, src1, tmp0_r, tmp0_l);
+      ADD2(tmp0_r, bias, tmp0_l, bias, tmp0_r, tmp0_l);
+      SRAI_H2_SH(tmp0_r, tmp0_l, 1);
+      dst0 = __msa_pckev_b((v16i8)tmp0_l, (v16i8)tmp0_r);
+
+      ST_SB(dst0, outptr);
+      outptr += 16;
+      outcol += 16;
+    }
+
+    if (outcol < out_width) {
+      src0 = LD_SB(inptr);
+      tmp0_r = (v8i16)__msa_hadd_u_h((v16u8)src0, (v16u8)src0);
+      tmp0_r = tmp0_r + bias;
+      tmp0_r = MSA_SRAI_H(tmp0_r, 1);
+      dst0 = __msa_pckev_b((v16i8)tmp0_r, (v16i8)tmp0_r);
+
+      ST8x1_UB(dst0, outptr);
+    }
+
+    outptr = output_data[outrow] + (image_width >> 1);
+    end_pixel = *(input_data[outrow] + image_width - 1);
+
+    if (image_width & 0x2) {
+      *outptr++ = end_pixel;
+    }
+
+    tmp_ptr = (unsigned short *)outptr;
+
+    for (outcol = (image_width >> 1); outcol < out_width; outcol += 2) {
+      *tmp_ptr++ = (end_pixel << 8) + end_pixel;
+    }
+  }
+}
+
+GLOBAL(void)
+jsimd_h2v2_downsample_msa(JDIMENSION image_width, int max_v_samp_factor,
+                          JDIMENSION v_samp_factor, JDIMENSION width_blocks,
+                          JSAMPARRAY input_data, JSAMPARRAY output_data)
+{
+  int inrow = 0, outrow, end_pixel0, end_pixel1, sum, outcol;
+  JSAMPROW inptr0, inptr1, outptr;
+  unsigned short *tmp_ptr;
+  v16i8 src0, src1, src2, src3, src4, src5, src6, src7, dst0, dst1;
+  v16i8 src8, src9, src10, src11, src12, src13, src14, src15, dst2, dst3;
+  v8i16 tmp0_r, tmp0_l, tmp1_r, tmp1_l, tmp2_r, tmp2_l, tmp3_r, tmp3_l;
+  const v8i16 bias = { 1, 2, 1, 2, 1, 2, 1, 2 };
+  JDIMENSION out_width = width_blocks * 8;
+
+  for (outrow = 0; outrow < v_samp_factor; outrow++) {
+    outptr = output_data[outrow];
+    inptr0 = input_data[inrow];
+    inptr1 = input_data[inrow + 1];
+
+    outcol = 0;
+
+    for (; outcol < (out_width & ~0x3F); outcol += 64) {
+      LD_SB8(inptr0, 16, src0, src1, src2, src3, src4, src5, src6, src7);
+      LD_SB8(inptr1, 16, src8, src9, src10, src11, src12, src13, src14, src15);
+      inptr0 += 128;
+      inptr1 += 128;
+
+      HADD_UB4_SH(src0, src1, src2, src3, tmp0_r, tmp0_l, tmp1_r, tmp1_l);
+      HADD_UB4_SH(src8, src9, src10, src11, tmp2_r, tmp2_l, tmp3_r, tmp3_l);
+      ADD4(tmp0_r, tmp2_r, tmp0_l, tmp2_l, tmp1_r, tmp3_r, tmp1_l, tmp3_l,
+           tmp0_r, tmp0_l, tmp1_r, tmp1_l);
+      ADD4(tmp0_r, bias, tmp0_l, bias, tmp1_r, bias, tmp1_l, bias,
+           tmp0_r, tmp0_l, tmp1_r, tmp1_l);
+      SRAI_H4_SH(tmp0_r, tmp0_l, tmp1_r, tmp1_l, 2);
+      PCKEV_B2_SB(tmp0_l, tmp0_r, tmp1_l, tmp1_r, dst0, dst1);
+
+      HADD_UB4_SH(src4, src5, src6, src7, tmp0_r, tmp0_l, tmp1_r, tmp1_l);
+      HADD_UB4_SH(src12, src13, src14, src15, tmp2_r, tmp2_l, tmp3_r, tmp3_l);
+      ADD4(tmp0_r, tmp2_r, tmp0_l, tmp2_l, tmp1_r, tmp3_r, tmp1_l, tmp3_l,
+           tmp0_r, tmp0_l, tmp1_r, tmp1_l);
+      ADD4(tmp0_r, bias, tmp0_l, bias, tmp1_r, bias, tmp1_l, bias,
+           tmp0_r, tmp0_l, tmp1_r, tmp1_l);
+      SRAI_H4_SH(tmp0_r, tmp0_l, tmp1_r, tmp1_l, 2);
+      PCKEV_B2_SB(tmp0_l, tmp0_r, tmp1_l, tmp1_r, dst2, dst3);
+
+      ST_SB4(dst0, dst1, dst2, dst3, outptr, 16);
+      outptr += 64;
+    }
+
+    if (outcol < (out_width & ~0x1F)) {
+      LD_SB4(inptr0, 16, src0, src1, src4, src5);
+      LD_SB4(inptr1, 16, src2, src3, src6, src7);
+      inptr0 += 64;
+      inptr1 += 64;
+
+      HADD_UB2_SH(src0, src1, tmp0_r, tmp0_l);
+      HADD_UB2_SH(src2, src3, tmp1_r, tmp1_l);
+      ADD2(tmp0_r, tmp1_r, tmp0_l, tmp1_l, tmp0_r, tmp0_l);
+      ADD2(tmp0_r, bias, tmp0_l, bias, tmp0_r, tmp0_l);
+      SRAI_H2_SH(tmp0_r, tmp0_l, 2);
+      dst0 = __msa_pckev_b((v16i8)tmp0_l, (v16i8)tmp0_r);
+
+      HADD_UB2_SH(src4, src5, tmp0_r, tmp0_l);
+      HADD_UB2_SH(src6, src7, tmp1_r, tmp1_l);
+      ADD2(tmp0_r, tmp1_r, tmp0_l, tmp1_l, tmp0_r, tmp0_l);
+      ADD2(tmp0_r, bias, tmp0_l, bias, tmp0_r, tmp0_l);
+      SRAI_H2_SH(tmp0_r, tmp0_l, 2);
+      dst1 = __msa_pckev_b((v16i8)tmp0_l, (v16i8)tmp0_r);
+
+      ST_SB2(dst0, dst1, outptr, 16);
+      outptr += 32;
+      outcol += 32;
+    }
+
+    if (outcol < (out_width & ~0xF)) {
+      LD_SB2(inptr0, 16, src0, src1);
+      LD_SB2(inptr1, 16, src2, src3);
+      inptr0 += 32;
+      inptr1 += 32;
+
+      HADD_UB2_SH(src0, src1, tmp0_r, tmp0_l);
+      HADD_UB2_SH(src2, src3, tmp1_r, tmp1_l);
+      ADD2(tmp0_r, tmp1_r, tmp0_l, tmp1_l, tmp0_r, tmp0_l);
+      ADD2(tmp0_r, bias, tmp0_l, bias, tmp0_r, tmp0_l);
+      SRAI_H2_SH(tmp0_r, tmp0_l, 2);
+      dst0 = __msa_pckev_b((v16i8)tmp0_l, (v16i8)tmp0_r);
+
+      ST_SB(dst0, outptr);
+      outptr += 16;
+      outcol += 16;
+    }
+
+    if (outcol < out_width) {
+      src0 = LD_SB(inptr0);
+      src2 = LD_SB(inptr1);
+
+      HADD_UB2_SH(src0, src2, tmp0_r, tmp1_r);
+      tmp0_r += tmp1_r;
+      tmp0_r = tmp0_r + bias;
+      tmp0_r = MSA_SRAI_H(tmp0_r, 2);
+      dst0 = __msa_pckev_b((v16i8)tmp0_r, (v16i8)tmp0_r);
+
+      ST8x1_UB(dst0, outptr);
+    }
+
+    outptr = output_data[outrow] + (image_width >> 1);
+    end_pixel0 = (int)(*(input_data[inrow] + image_width - 1));
+    end_pixel1 = (int)(*(input_data[inrow + 1] + image_width - 1));
+    sum = end_pixel0 + end_pixel1;
+
+    if (image_width & 0x2) {
+      *outptr++ = (unsigned char)((sum + 1) >> 1);
+    }
+
+    tmp_ptr = (unsigned short *)outptr;
+
+    for (outcol = (image_width >> 1); outcol < out_width; outcol += 2) {
+      *tmp_ptr++ = (((sum + 1) >> 1) << 8) + (sum >> 1);
+    }
+
+    inrow += 2;
+  }
+}

--- a/simd/mips/jdcol565_msa.c
+++ b/simd/mips/jdcol565_msa.c
@@ -1,0 +1,263 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* YCC --> RGB565 CONVERSION */
+
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "jconfigint.h"
+#include "jmacros_msa.h"
+
+
+#define FIX_1_40200  0x166e9
+#define FIX_0_34414  0x581a
+#define FIX_0_71414  0xb6d2
+#define FIX_1_77200  0x1c5a2
+#define FIX_0_28586  (65536 - FIX_0_71414)
+
+/* Original            ::: G = Y - 0.34414 * Cb - 0.71414 * Cr
+   This implementation ::: G = Y - 0.34414 * Cb + 0.28586 * Cr - Cr */
+
+#define CALC_G4_FRM_YCC(y_h0, y_h1, cb_h0, cb_h1, cr_h0, cr_h1, \
+out_g0, out_g1) { \
+  v8i16 tmp0_m, tmp1_m; \
+  v4i32 out0_m, out1_m, out2_m, out3_m; \
+  v8i16 const0_m = { -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586, \
+                     -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586 \
+                   }; \
+  \
+  ILVRL_H2_SH(cr_h0, cb_h0, tmp0_m, tmp1_m); \
+  UNPCK_SH_SW((-cr_h0), out0_m, out1_m); \
+  out0_m = MSA_SLLI_W(out0_m, 16); \
+  out1_m = MSA_SLLI_W(out1_m, 16); \
+  DPADD_SH2_SW(tmp0_m, tmp1_m, const0_m, const0_m, out0_m, out1_m); \
+  ILVRL_H2_SH(cr_h1, cb_h1, tmp0_m, tmp1_m); \
+  UNPCK_SH_SW((-cr_h1), out2_m, out3_m); \
+  out2_m = MSA_SLLI_W(out2_m, 16); \
+  out3_m = MSA_SLLI_W(out3_m, 16); \
+  DPADD_SH2_SW(tmp0_m, tmp1_m, const0_m, const0_m, out2_m, out3_m); \
+  SRARI_W4_SW(out0_m, out1_m, out2_m, out3_m, 16); \
+  PCKEV_H2_SH(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m); \
+  ADD2(y_h0, tmp0_m, y_h1, tmp1_m, out_g0, out_g1); \
+  CLIP_SH2_0_255(out_g0, out_g1); \
+}
+
+#define CALC_G2_FRM_YCC(y_h0, cb_h0, cr_h0, out_g0) { \
+  v8i16 tmp0_m, tmp1_m; \
+  v4i32 out0_m, out1_m; \
+  v8i16 const0_m = { -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586, \
+                     -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586 \
+                   }; \
+  \
+  ILVRL_H2_SH(cr_h0, cb_h0, tmp0_m, tmp1_m); \
+  UNPCK_SH_SW((-cr_h0), out0_m, out1_m); \
+  out0_m = MSA_SLLI_W(out0_m, 16); \
+  out1_m = MSA_SLLI_W(out1_m, 16); \
+  DPADD_SH2_SW(tmp0_m, tmp1_m, const0_m, const0_m, out0_m, out1_m); \
+  SRARI_W2_SW(out0_m, out1_m, 16); \
+  tmp0_m = __msa_pckev_h((v8i16)out1_m, (v8i16)out0_m); \
+  tmp0_m += y_h0; \
+  out_g0 = CLIP_SH_0_255(tmp0_m); \
+}
+
+#define CALC_R4_FRM_YCC(y_h0, y_h1, cr_w0, cr_w1, cr_w2, cr_w3, \
+out_r0, out_r1) { \
+  v8i16 tmp0_m, tmp1_m; \
+  v4i32 out0_m, out1_m, out2_m, out3_m; \
+  v4i32 const0_m = { FIX_1_40200, FIX_1_40200, FIX_1_40200, FIX_1_40200 }; \
+  \
+  MUL4(const0_m, cr_w0, const0_m, cr_w1, const0_m, cr_w2, const0_m, cr_w3, \
+       out0_m, out1_m, out2_m, out3_m); \
+  SRARI_W4_SW(out0_m, out1_m, out2_m, out3_m, 16); \
+  PCKEV_H2_SH(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m); \
+  ADD2(y_h0, tmp0_m, y_h1, tmp1_m, out_r0, out_r1); \
+  CLIP_SH2_0_255(out_r0, out_r1); \
+}
+
+#define CALC_R2_FRM_YCC(y_h0, cr_w0, cr_w1, out_r0) { \
+  v8i16 tmp0_m; \
+  v4i32 out0_m, out1_m; \
+  v4i32 const0_m = { FIX_1_40200, FIX_1_40200, FIX_1_40200, FIX_1_40200 }; \
+  \
+  MUL2(const0_m, cr_w0, const0_m, cr_w1, out0_m, out1_m); \
+  SRARI_W2_SW(out0_m, out1_m, 16); \
+  tmp0_m = __msa_pckev_h((v8i16)out1_m, (v8i16)out0_m); \
+  tmp0_m += y_h0; \
+  out_r0 = CLIP_SH_0_255(tmp0_m); \
+}
+
+#define CALC_B4_FRM_YCC(y_h0, y_h1, cb_w0, cb_w1, cb_w2, cb_w3, \
+out_b0, out_b1) { \
+  v8i16 tmp0_m, tmp1_m; \
+  v4i32 out0_m, out1_m, out2_m, out3_m; \
+  v4i32 const0_m = { FIX_1_77200, FIX_1_77200, FIX_1_77200, FIX_1_77200 }; \
+  \
+  MUL4(const0_m, cb_w0, const0_m, cb_w1, const0_m, cb_w2, const0_m, cb_w3, \
+       out0_m, out1_m, out2_m, out3_m); \
+  SRARI_W4_SW(out0_m, out1_m, out2_m, out3_m, 16); \
+  PCKEV_H2_SH(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m); \
+  ADD2(y_h0, tmp0_m, y_h1, tmp1_m, out_b0, out_b1); \
+  CLIP_SH2_0_255(out_b0, out_b1); \
+}
+
+#define CALC_B2_FRM_YCC(y_h0, cb_w0, cb_w1, out_b0) { \
+  v8i16 tmp0_m; \
+  v4i32 out0_m, out1_m; \
+  v4i32 const0_m = { FIX_1_77200, FIX_1_77200, FIX_1_77200, FIX_1_77200 }; \
+  \
+  MUL2(const0_m, cb_w0, const0_m, cb_w1, out0_m, out1_m); \
+  SRARI_W2_SW(out0_m, out1_m, 16); \
+  tmp0_m = __msa_pckev_h((v8i16)out1_m, (v8i16)out0_m); \
+  tmp0_m += y_h0; \
+  out_b0 = CLIP_SH_0_255(tmp0_m); \
+}
+
+#define ROUND_POWER_OF_TWO(value, n)  (((value) + (1 << ((n) - 1))) >> (n))
+
+static INLINE unsigned char clip_pixel(int val)
+{
+  return ((val & ~0xFF) ? ((-val) >> 31) & 0xFF : val);
+}
+
+GLOBAL(void)
+jsimd_ycc_rgb565_convert_msa(JDIMENSION out_width,
+                             JSAMPIMAGE input_buf, JDIMENSION input_row,
+                             JSAMPARRAY output_buf, int num_rows)
+{
+  register JSAMPROW p_in_y, p_in_cb, p_in_cr;
+  register JSAMPROW p_rgb;
+  int r, g, b, y, cb, cr;
+  JDIMENSION col, remaining_wd, num_cols_mul_16 = out_width >> 4;
+  v16u8 out0, out1, input_y = { 0 };
+  v16i8 input_cb, input_cr, const_128 = __msa_ldi_b(128);
+  v8i16 out_r0, out_r1, out_g0, out_g1, out_b0, out_b1;
+  v8i16 y_h0, y_h1, cb_h0, cb_h1, cr_h0, cr_h1;
+  v4i32 cb_w0, cb_w1, cb_w2, cb_w3, cr_w0, cr_w1, cr_w2, cr_w3, zero = { 0 };
+
+  while (--num_rows >= 0) {
+    p_in_y = input_buf[0][input_row];
+    p_in_cb = input_buf[1][input_row];
+    p_in_cr = input_buf[2][input_row];
+    p_rgb = *output_buf++;
+    input_row++;
+    remaining_wd = out_width & 0xF;
+
+    for (col = num_cols_mul_16; col--;) {
+      input_y = LD_UB(p_in_y);
+      input_cb = LD_SB(p_in_cb);
+      input_cr = LD_SB(p_in_cr);
+
+      p_in_y += 16;
+      p_in_cb += 16;
+      p_in_cr += 16;
+
+      input_cb -= const_128;
+      input_cr -= const_128;
+
+      UNPCK_UB_SH(input_y, y_h0, y_h1);
+      UNPCK_SB_SH(input_cb, cb_h0, cb_h1);
+      UNPCK_SB_SH(input_cr, cr_h0, cr_h1);
+
+      CALC_G4_FRM_YCC(y_h0, y_h1, cb_h0, cb_h1, cr_h0, cr_h1, out_g0, out_g1);
+
+      UNPCK_SH_SW(cr_h0, cr_w0, cr_w1);
+      UNPCK_SH_SW(cr_h1, cr_w2, cr_w3);
+      CALC_R4_FRM_YCC(y_h0, y_h1, cr_w0, cr_w1, cr_w2, cr_w3, out_r0, out_r1);
+
+      UNPCK_SH_SW(cb_h0, cb_w0, cb_w1);
+      UNPCK_SH_SW(cb_h1, cb_w2, cb_w3);
+      CALC_B4_FRM_YCC(y_h0, y_h1, cb_w0, cb_w1, cb_w2, cb_w3, out_b0, out_b1);
+
+      out_r0 = MSA_SLLI_B(out_r0, 8);
+      out_r1 = MSA_SLLI_B(out_r1, 8);
+      out_g0 = MSA_SLLI_B(out_g0, 3);
+      out_g1 = MSA_SLLI_B(out_g1, 3);
+      out_b0 = MSA_SRAI_B(out_b0, 3);
+      out_b1 = MSA_SRAI_B(out_b1, 3);
+
+      out0 = (v16u8)__msa_binsli_h((v8u16)out_g0, (v8u16)out_r0, 4);
+      out1 = (v16u8)__msa_binsli_h((v8u16)out_g1, (v8u16)out_r1, 4);
+      out0 = (v16u8)__msa_binsli_h((v8u16)out_b0, (v8u16)out0, 10);
+      out1 = (v16u8)__msa_binsli_h((v8u16)out_b1, (v8u16)out1, 10);
+
+      ST_UB(out0, p_rgb);
+      p_rgb += 16;
+      ST_UB(out1, p_rgb);
+      p_rgb += 16;
+    }
+
+    if (remaining_wd >= 8) {
+      uint64_t in_y, in_cb, in_cr;
+      v16i8 input_cbcr = { 0 };
+
+      in_y = LD(p_in_y);
+      in_cb = LD(p_in_cb);
+      in_cr = LD(p_in_cr);
+
+      p_in_y += 8;
+      p_in_cb += 8;
+      p_in_cr += 8;
+
+      input_y = (v16u8)__msa_insert_d((v2i64)input_y, 0, in_y);
+      input_cbcr = (v16i8)__msa_insert_d((v2i64)input_cbcr, 0, in_cb);
+      input_cbcr = (v16i8)__msa_insert_d((v2i64)input_cbcr, 1, in_cr);
+
+      input_cbcr -= const_128;
+
+      y_h0 = (v8i16)__msa_ilvr_b((v16i8)zero, (v16i8)input_y);
+      UNPCK_SB_SH(input_cbcr, cb_h0, cr_h0);
+      UNPCK_SH_SW(cb_h0, cb_w0, cb_w1);
+      UNPCK_SH_SW(cr_h0, cr_w0, cr_w1);
+
+      CALC_R2_FRM_YCC(y_h0, cr_w0, cr_w1, out_r0);
+      CALC_G2_FRM_YCC(y_h0, cb_h0, cr_h0, out_g0);
+      CALC_B2_FRM_YCC(y_h0, cb_w0, cb_w1, out_b0);
+
+      out_r0 = MSA_SLLI_B(out_r0, 8);
+      out_g0 = MSA_SLLI_B(out_g0, 3);
+      out_b0 = MSA_SRAI_B(out_b0, 3);
+
+      out0 = (v16u8)__msa_binsli_h((v8u16)out_g0, (v8u16)out_r0, 4);
+      out0 = (v16u8)__msa_binsli_h((v8u16)out_b0, (v8u16)out0, 10);
+
+      ST_UB(out0, p_rgb);
+      p_rgb += 16;
+
+      remaining_wd -= 8;
+    }
+
+    for (col = 0; col < remaining_wd; col++) {
+      y  = (int)(p_in_y[col]);
+      cb = (int)(p_in_cb[col]) - 128;
+      cr = (int)(p_in_cr[col]) - 128;
+
+      /* Range-limiting is essential due to noise introduced by DCT losses. */
+      r = clip_pixel(y + ROUND_POWER_OF_TWO(FIX_1_40200 * cr, 16));
+      g = clip_pixel(y + ROUND_POWER_OF_TWO(((-FIX_0_34414) * cb -
+                                             FIX_0_71414 * cr), 16));
+      b = clip_pixel(y + ROUND_POWER_OF_TWO(FIX_1_77200 * cb, 16));
+      *p_rgb++ = ((g << 3) & 0xE0) | (b >> 3);
+      *p_rgb++ = (r & 0xF8) | (g >> 5);
+    }
+  }
+}

--- a/simd/mips/jdcolext_msa.c
+++ b/simd/mips/jdcolext_msa.c
@@ -1,0 +1,223 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* YCC --> RGB CONVERSION */
+
+#if RGB_RED == 0
+#define var_a  out_r0
+#define var_b  out_b0
+#elif RGB_RED == 1 || RGB_RED == 3
+#define var_a  out_g0
+#define var_b  alpha
+#else /* RGB_RED == 2 */
+#define var_a  out_b0
+#define var_b  out_r0
+#endif
+
+#if RGB_PIXELSIZE == 4
+#if RGB_RED == 0 || RGB_RED == 2
+#define var_c  out_g0
+#define var_d  alpha
+#define var_e  out_rgb0
+#define var_f  out_rgb1
+#define var_g  out_ba0
+#define var_h  out_ba1
+#else /* RGB_RED == 1 || RGB_RED == 3 */
+#define var_e  out_ba0
+#define var_f  out_ba1
+#define var_g  out_rgb0
+#define var_h  out_rgb1
+#if RGB_RED == 1
+#define var_c  out_b0
+#define var_d  out_r0
+#else /* RGB_RED == 3 */
+#define var_c  out_r0
+#define var_d  out_b0
+#endif
+#endif
+#endif
+
+GLOBAL(void)
+jsimd_ycc_rgb_convert_msa(JDIMENSION out_width,
+                          JSAMPIMAGE input_buf, JDIMENSION input_row,
+                          JSAMPARRAY output_buf, int num_rows)
+{
+  register JSAMPROW p_in_y, p_in_cb, p_in_cr;
+  register JSAMPROW p_rgb;
+  int y, cb, cr;
+  JDIMENSION col, remaining_wd, num_cols_mul_16 = out_width >> 4;
+  v16u8 out0, out1, out2, input_y = { 0 };
+  v16i8 input_cb, input_cr, out_rgb0, out_rgb1, const_128 = __msa_ldi_b(128);
+  v8i16 y_h0, y_h1, cb_h0, cb_h1, cr_h0, cr_h1;
+  v4i32 cb_w0, cb_w1, cb_w2, cb_w3, cr_w0, cr_w1, cr_w2, cr_w3, zero = { 0 };
+  v16i8 out_r0, out_g0, out_b0;
+#if RGB_PIXELSIZE == 3
+  v16u8 tmp0, tmp1;
+  const v16u8 mask_rgb0 =
+    { 0, 1, 16, 2, 3, 17, 4, 5, 18, 6, 7, 19, 8, 9, 20, 10 };
+  const v16u8 mask_rgb1 =
+    { 11, 21, 12, 13, 22, 14, 15, 23, 0, 1, 24, 2, 3, 25, 4, 5 };
+  const v16u8 mask_rgb2 =
+    { 26, 6, 7, 27, 8, 9, 28, 10, 11, 29, 12, 13, 30, 14, 15, 31 };
+#else /* RGB_PIXELSIZE == 4 */
+  v16u8 out3;
+  v16i8 out_ba0, out_ba1, alpha = __msa_ldi_b(0xFF);
+#endif
+
+  while (--num_rows >= 0) {
+    p_in_y = input_buf[0][input_row];
+    p_in_cb = input_buf[1][input_row];
+    p_in_cr = input_buf[2][input_row];
+    p_rgb = *output_buf++;
+    input_row++;
+    remaining_wd = out_width & 0xF;
+
+    for (col = num_cols_mul_16; col--;) {
+      input_y = LD_UB(p_in_y);
+      input_cb = LD_SB(p_in_cb);
+      input_cr = LD_SB(p_in_cr);
+
+      p_in_y += 16;
+      p_in_cb += 16;
+      p_in_cr += 16;
+
+      input_cb -= const_128;
+      input_cr -= const_128;
+
+      UNPCK_UB_SH(input_y, y_h0, y_h1);
+      UNPCK_SB_SH(input_cb, cb_h0, cb_h1);
+      UNPCK_SB_SH(input_cr, cr_h0, cr_h1);
+      CALC_G4_FRM_YCC(y_h0, y_h1, cb_h0, cb_h1, cr_h0, cr_h1, out_g0);
+
+      UNPCK_SH_SW(cr_h0, cr_w0, cr_w1);
+      UNPCK_SH_SW(cr_h1, cr_w2, cr_w3);
+      CALC_R4_FRM_YCC(y_h0, y_h1, cr_w0, cr_w1, cr_w2, cr_w3, out_r0);
+
+      UNPCK_SH_SW(cb_h0, cb_w0, cb_w1);
+      UNPCK_SH_SW(cb_h1, cb_w2, cb_w3);
+      CALC_B4_FRM_YCC(y_h0, y_h1, cb_w0, cb_w1, cb_w2, cb_w3, out_b0);
+
+#if RGB_PIXELSIZE == 3
+      ILVRL_B2_SB(out_g0, var_a, out_rgb0, out_rgb1);
+      VSHF_B2_UB(out_rgb0, var_b, out_rgb0, var_b, mask_rgb0, mask_rgb1,
+                 out0, tmp0);
+      VSHF_B2_UB(out_rgb1, var_b, out_rgb1, var_b, mask_rgb1, mask_rgb2,
+                 tmp1, out2);
+
+      out1 = (v16u8)__msa_sldi_b((v16i8)zero, (v16i8)tmp1, 8);
+      out1 = (v16u8)__msa_pckev_d((v2i64)out1, (v2i64)tmp0);
+
+      ST_UB(out0, p_rgb);
+      p_rgb += 16;
+      ST_UB(out1, p_rgb);
+      p_rgb += 16;
+      ST_UB(out2, p_rgb);
+      p_rgb += 16;
+#else /* RGB_PIXELSIZE == 4 */
+      ILVRL_B2_SB(var_c, var_a, out_rgb0, out_rgb1);
+      ILVRL_B2_SB(var_d, var_b, out_ba0, out_ba1);
+      ILVRL_H2_UB(var_g, var_e, out0, out1);
+      ILVRL_H2_UB(var_h, var_f, out2, out3);
+
+      ST_UB4(out0, out1, out2, out3, p_rgb, 16);
+      p_rgb += 16 * 4;
+#endif
+    }
+
+    if (remaining_wd >= 8) {
+      uint64_t in_y, in_cb, in_cr;
+      v16i8 input_cbcr = { 0 };
+
+      in_y = LD(p_in_y);
+      in_cb = LD(p_in_cb);
+      in_cr = LD(p_in_cr);
+
+      p_in_y += 8;
+      p_in_cb += 8;
+      p_in_cr += 8;
+
+      input_y = (v16u8)__msa_insert_d((v2i64)input_y, 0, in_y);
+      input_cbcr = (v16i8)__msa_insert_d((v2i64)input_cbcr, 0, in_cb);
+      input_cbcr = (v16i8)__msa_insert_d((v2i64)input_cbcr, 1, in_cr);
+      input_cbcr -= const_128;
+
+      y_h0 = (v8i16)__msa_ilvr_b((v16i8)zero, (v16i8)input_y);
+      UNPCK_SB_SH(input_cbcr, cb_h0, cr_h0);
+      UNPCK_SH_SW(cb_h0, cb_w0, cb_w1);
+      UNPCK_SH_SW(cr_h0, cr_w0, cr_w1);
+
+      CALC_R2_FRM_YCC(y_h0, cr_w0, cr_w1, out_r0);
+      CALC_G2_FRM_YCC(y_h0, cb_h0, cr_h0, out_g0);
+      CALC_B2_FRM_YCC(y_h0, cb_w0, cb_w1, out_b0);
+
+#if RGB_PIXELSIZE == 3
+      out_rgb0 = (v16i8)__msa_ilvr_b((v16i8)out_g0, (v16i8)var_a);
+      VSHF_B2_UB(out_rgb0, var_b, out_rgb0, var_b, mask_rgb0, mask_rgb1,
+                 out0, out1);
+
+      ST_UB(out0, p_rgb);
+      p_rgb += 16;
+      ST8x1_UB(out1, p_rgb);
+      p_rgb += 8;
+#else /* RGB_PIXELSIZE == 4 */
+      out_rgb0 = (v16i8)__msa_ilvr_b((v16i8)var_c, (v16i8)var_a);
+      out_ba0 = (v16i8)__msa_ilvr_b(var_d, (v16i8)var_b);
+      ILVRL_H2_UB(var_g, var_e, out0, out1);
+
+      ST_UB2(out0, out1, p_rgb, 16);
+      p_rgb += 16 * 2;
+#endif
+
+      remaining_wd -= 8;
+    }
+
+    for (col = 0; col < remaining_wd; col++) {
+      y  = (int)(p_in_y[col]);
+      cb = (int)(p_in_cb[col]) - 128;
+      cr = (int)(p_in_cr[col]) - 128;
+
+      /* Range-limiting is essential due to noise introduced by DCT losses. */
+      p_rgb[RGB_RED] = clip_pixel(y + ROUND_POWER_OF_TWO(FIX_1_40200 *
+                                  cr, 16));
+      p_rgb[RGB_GREEN] = clip_pixel(y + ROUND_POWER_OF_TWO(((-FIX_0_34414) *
+                                    cb - FIX_0_71414 * cr), 16));
+      p_rgb[RGB_BLUE] = clip_pixel(y + ROUND_POWER_OF_TWO(FIX_1_77200 *
+                                   cb, 16));
+#ifdef RGB_ALPHA
+      p_rgb[RGB_ALPHA] = 0xFF;
+#endif
+      p_rgb += RGB_PIXELSIZE;
+    }
+  }
+}
+
+#undef var_a
+#undef var_b
+#if RGB_PIXELSIZE == 4
+#undef var_c
+#undef var_d
+#undef var_e
+#undef var_f
+#undef var_g
+#undef var_h
+#endif

--- a/simd/mips/jdcolor_msa.c
+++ b/simd/mips/jdcolor_msa.c
@@ -1,0 +1,231 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#define JPEG_INTERNALS
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "../../jsimd.h"
+#include "jconfigint.h"
+#include "jmacros_msa.h"
+
+
+#define FIX_1_40200  0x166e9
+#define FIX_0_34414  0x581a
+#define FIX_0_71414  0xb6d2
+#define FIX_1_77200  0x1c5a2
+#define FIX_0_28586  (65536 - FIX_0_71414)
+
+/* Original
+    G = Y - 0.34414 * Cb - 0.71414 * Cr */
+/* This implementation
+    G = Y - 0.34414 * Cb + 0.28586 * Cr - Cr */
+
+#define CALC_G4_FRM_YCC(y_h0, y_h1, cb_h0, cb_h1, cr_h0, cr_h1, out_g0) { \
+  v8i16 tmp0_m, tmp1_m; \
+  v4i32 out0_m, out1_m, out2_m, out3_m; \
+  v8i16 const0_m = { -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586, \
+                     -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586 \
+                   }; \
+  \
+  ILVRL_H2_SH(cr_h0, cb_h0, tmp0_m, tmp1_m); \
+  UNPCK_SH_SW((-cr_h0), out0_m, out1_m); \
+  out0_m = MSA_SLLI_W(out0_m, 16); \
+  out1_m = MSA_SLLI_W(out1_m, 16); \
+  DPADD_SH2_SW(tmp0_m, tmp1_m, const0_m, const0_m, out0_m, out1_m); \
+  ILVRL_H2_SH(cr_h1, cb_h1, tmp0_m, tmp1_m); \
+  UNPCK_SH_SW((-cr_h1), out2_m, out3_m); \
+  out2_m = MSA_SLLI_W(out2_m, 16); \
+  out3_m = MSA_SLLI_W(out3_m, 16); \
+  DPADD_SH2_SW(tmp0_m, tmp1_m, const0_m, const0_m, out2_m, out3_m); \
+  SRARI_W4_SW(out0_m, out1_m, out2_m, out3_m, 16); \
+  PCKEV_H2_SH(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m); \
+  ADD2(y_h0, tmp0_m, y_h1, tmp1_m, tmp0_m, tmp1_m); \
+  CLIP_SH2_0_255(tmp0_m, tmp1_m); \
+  out_g0 = __msa_pckev_b((v16i8)tmp1_m, (v16i8)tmp0_m); \
+}
+
+#define CALC_G2_FRM_YCC(y_h0, cb_h0, cr_h0, out_g0) { \
+  v8i16 tmp0_m, tmp1_m; \
+  v4i32 out0_m, out1_m; \
+  v8i16 const0_m = { -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586, \
+                     -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586 \
+                   }; \
+  \
+  ILVRL_H2_SH(cr_h0, cb_h0, tmp0_m, tmp1_m); \
+  UNPCK_SH_SW((-cr_h0), out0_m, out1_m); \
+  out0_m = MSA_SLLI_W(out0_m, 16); \
+  out1_m = MSA_SLLI_W(out1_m, 16); \
+  DPADD_SH2_SW(tmp0_m, tmp1_m, const0_m, const0_m, out0_m, out1_m); \
+  SRARI_W2_SW(out0_m, out1_m, 16); \
+  tmp0_m = __msa_pckev_h((v8i16)out1_m, (v8i16)out0_m); \
+  tmp0_m += y_h0; \
+  tmp0_m = CLIP_SH_0_255(tmp0_m); \
+  out_g0 = __msa_pckev_b((v16i8)tmp0_m, (v16i8)tmp0_m); \
+}
+
+#define CALC_R4_FRM_YCC(y_h0, y_h1, cr_w0, cr_w1, cr_w2, cr_w3, out_r0) { \
+  v8i16 tmp0_m, tmp1_m; \
+  v4i32 out0_m, out1_m, out2_m, out3_m; \
+  v4i32 const0_m = { FIX_1_40200, FIX_1_40200, FIX_1_40200, FIX_1_40200 }; \
+  \
+  MUL4(const0_m, cr_w0, const0_m, cr_w1, const0_m, cr_w2, const0_m, cr_w3, \
+       out0_m, out1_m, out2_m, out3_m); \
+  SRARI_W4_SW(out0_m, out1_m, out2_m, out3_m, 16); \
+  PCKEV_H2_SH(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m); \
+  ADD2(y_h0, tmp0_m, y_h1, tmp1_m, tmp0_m, tmp1_m); \
+  CLIP_SH2_0_255(tmp0_m, tmp1_m); \
+  out_r0 = __msa_pckev_b((v16i8)tmp1_m, (v16i8)tmp0_m); \
+}
+
+#define CALC_R2_FRM_YCC(y_h0, cr_w0, cr_w1, out_r0) { \
+  v8i16 tmp0_m; \
+  v4i32 out0_m, out1_m; \
+  v4i32 const0_m = { FIX_1_40200, FIX_1_40200, FIX_1_40200, FIX_1_40200 }; \
+  \
+  MUL2(const0_m, cr_w0, const0_m, cr_w1, out0_m, out1_m); \
+  SRARI_W2_SW(out0_m, out1_m, 16); \
+  tmp0_m = __msa_pckev_h((v8i16)out1_m, (v8i16)out0_m); \
+  tmp0_m += y_h0; \
+  tmp0_m = CLIP_SH_0_255(tmp0_m); \
+  out_r0 = __msa_pckev_b((v16i8)tmp0_m, (v16i8)tmp0_m); \
+}
+
+#define CALC_B4_FRM_YCC(y_h0, y_h1, cb_w0, cb_w1, cb_w2, cb_w3, out_b0) { \
+  v8i16 tmp0_m, tmp1_m; \
+  v4i32 out0_m, out1_m, out2_m, out3_m; \
+  v4i32 const0_m = { FIX_1_77200, FIX_1_77200, FIX_1_77200, FIX_1_77200 }; \
+  \
+  MUL4(const0_m, cb_w0, const0_m, cb_w1, const0_m, cb_w2, const0_m, cb_w3, \
+       out0_m, out1_m, out2_m, out3_m); \
+  SRARI_W4_SW(out0_m, out1_m, out2_m, out3_m, 16); \
+  PCKEV_H2_SH(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m); \
+  ADD2(y_h0, tmp0_m, y_h1, tmp1_m, tmp0_m, tmp1_m); \
+  CLIP_SH2_0_255(tmp0_m, tmp1_m); \
+  out_b0 = __msa_pckev_b((v16i8)tmp1_m, (v16i8)tmp0_m); \
+}
+
+#define CALC_B2_FRM_YCC(y_h0, cb_w0, cb_w1, out_b0) { \
+  v8i16 tmp0_m; \
+  v4i32 out0_m, out1_m; \
+  v4i32 const0_m = { FIX_1_77200, FIX_1_77200, FIX_1_77200, FIX_1_77200 }; \
+  \
+  MUL2(const0_m, cb_w0, const0_m, cb_w1, out0_m, out1_m); \
+  SRARI_W2_SW(out0_m, out1_m, 16); \
+  tmp0_m = __msa_pckev_h((v8i16)out1_m, (v8i16)out0_m); \
+  tmp0_m += y_h0; \
+  tmp0_m = CLIP_SH_0_255(tmp0_m); \
+  out_b0 = __msa_pckev_b((v16i8)tmp0_m, (v16i8)tmp0_m); \
+}
+
+#define ROUND_POWER_OF_TWO(value, n)  (((value) + (1 << ((n) - 1))) >> (n))
+
+static INLINE unsigned char clip_pixel(int val)
+{
+  return ((val & ~0xFF) ? ((-val) >> 31) & 0xFF : val);
+}
+
+#include "jdcolext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+
+#define RGB_RED        EXT_RGB_RED
+#define RGB_GREEN      EXT_RGB_GREEN
+#define RGB_BLUE       EXT_RGB_BLUE
+#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
+#define jsimd_ycc_rgb_convert_msa  jsimd_ycc_extrgb_convert_msa
+#include "jdcolext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef jsimd_ycc_rgb_convert_msa
+
+#define RGB_RED        EXT_BGR_RED
+#define RGB_GREEN      EXT_BGR_GREEN
+#define RGB_BLUE       EXT_BGR_BLUE
+#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
+#define jsimd_ycc_rgb_convert_msa  jsimd_ycc_extbgr_convert_msa
+#include "jdcolext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef jsimd_ycc_rgb_convert_msa
+
+#define RGB_RED        EXT_RGBX_RED
+#define RGB_GREEN      EXT_RGBX_GREEN
+#define RGB_BLUE       EXT_RGBX_BLUE
+#define RGB_ALPHA      3
+#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
+#define jsimd_ycc_rgb_convert_msa  jsimd_ycc_extrgbx_convert_msa
+#include "jdcolext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_ALPHA
+#undef RGB_PIXELSIZE
+#undef jsimd_ycc_rgb_convert_msa
+
+#define RGB_RED        EXT_BGRX_RED
+#define RGB_GREEN      EXT_BGRX_GREEN
+#define RGB_BLUE       EXT_BGRX_BLUE
+#define RGB_ALPHA      3
+#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
+#define jsimd_ycc_rgb_convert_msa  jsimd_ycc_extbgrx_convert_msa
+#include "jdcolext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_ALPHA
+#undef RGB_PIXELSIZE
+#undef jsimd_ycc_rgb_convert_msa
+
+#define RGB_RED        EXT_XRGB_RED
+#define RGB_GREEN      EXT_XRGB_GREEN
+#define RGB_BLUE       EXT_XRGB_BLUE
+#define RGB_ALPHA      0
+#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
+#define jsimd_ycc_rgb_convert_msa  jsimd_ycc_extxrgb_convert_msa
+#include "jdcolext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_ALPHA
+#undef RGB_PIXELSIZE
+#undef jsimd_ycc_rgb_convert_msa
+
+#define RGB_RED        EXT_XBGR_RED
+#define RGB_GREEN      EXT_XBGR_GREEN
+#define RGB_BLUE       EXT_XBGR_BLUE
+#define RGB_ALPHA      0
+#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
+#define jsimd_ycc_rgb_convert_msa  jsimd_ycc_extxbgr_convert_msa
+#include "jdcolext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_ALPHA
+#undef RGB_PIXELSIZE
+#undef jsimd_ycc_rgb_convert_msa

--- a/simd/mips/jdmerge_msa.c
+++ b/simd/mips/jdmerge_msa.c
@@ -1,0 +1,371 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#define JPEG_INTERNALS
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "../../jsimd.h"
+#include "jconfigint.h"
+#include "jmacros_msa.h"
+
+
+#define FIX_1_40200  0x166e9
+#define FIX_0_34414  0x581a
+#define FIX_0_71414  0xb6d2
+#define FIX_1_77200  0x1c5a2
+#define FIX_0_28586  (65536 - FIX_0_71414)
+#define GETSAMPLE(value)  ((int)(value))
+
+/* Original
+    G = Y - 0.34414 * Cb - 0.71414 * Cr */
+/* This implementation
+    G = Y - 0.34414 * Cb + 0.28586 * Cr - Cr */
+
+#define CALC_G4_FRM_YCC(y_h0, y_h1, y_h2, y_h3, cb_h0, cb_h1, cr_h0, cr_h1, \
+out_g0, out_g1) { \
+  v8i16 tmp0_m, tmp1_m, tmp2_m, tmp3_m; \
+  v4i32 out0_m, out1_m, out2_m, out3_m; \
+  v8i16 const0_m = { -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586, \
+                     -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586 \
+                   }; \
+  \
+  ILVRL_H2_SH(cr_h0, cb_h0, tmp0_m, tmp1_m); \
+  UNPCK_SH_SW((-cr_h0), out0_m, out1_m); \
+  out0_m = MSA_SLLI_W(out0_m, 16); \
+  out1_m = MSA_SLLI_W(out1_m, 16); \
+  DPADD_SH2_SW(tmp0_m, tmp1_m, const0_m, const0_m, out0_m, out1_m); \
+  ILVRL_H2_SH(cr_h1, cb_h1, tmp0_m, tmp1_m); \
+  UNPCK_SH_SW((-cr_h1), out2_m, out3_m); \
+  out2_m = MSA_SLLI_W(out2_m, 16); \
+  out3_m = MSA_SLLI_W(out3_m, 16); \
+  DPADD_SH2_SW(tmp0_m, tmp1_m, const0_m, const0_m, out2_m, out3_m); \
+  SRARI_W4_SW(out0_m, out1_m, out2_m, out3_m, 16); \
+  PCKEV_H2_SH(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m); \
+  ADD4(y_h2, tmp0_m, y_h3, tmp1_m, y_h0, tmp0_m, y_h1, tmp1_m, \
+       tmp2_m, tmp3_m, tmp0_m, tmp1_m); \
+  CLIP_SH4_0_255(tmp0_m, tmp1_m, tmp2_m, tmp3_m); \
+  PCKEV_B2_SB(tmp1_m, tmp0_m, tmp3_m, tmp2_m, out_g0, out_g1); \
+}
+
+#define CALC_G2_FRM_YCC(y_h0, y_h1, cb_h0, cr_h0, out_g0, out_g1) { \
+  v8i16 tmp0_m, tmp1_m, tmp2_m; \
+  v4i32 out0_m, out1_m; \
+  v8i16 const0_m = { -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586, \
+                     -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586 \
+                   }; \
+  \
+  ILVRL_H2_SH(cr_h0, cb_h0, tmp0_m, tmp1_m); \
+  UNPCK_SH_SW((-cr_h0), out0_m, out1_m); \
+  out0_m = MSA_SLLI_W(out0_m, 16); \
+  out1_m = MSA_SLLI_W(out1_m, 16); \
+  DPADD_SH2_SW(tmp0_m, tmp1_m, const0_m, const0_m, out0_m, out1_m); \
+  SRARI_W2_SW(out0_m, out1_m, 16); \
+  tmp0_m = __msa_pckev_h((v8i16)out1_m, (v8i16)out0_m); \
+  ADD2(y_h1, tmp0_m, y_h0, tmp0_m, tmp2_m, tmp0_m); \
+  CLIP_SH2_0_255(tmp0_m, tmp2_m); \
+  PCKEV_B2_SB(tmp0_m, tmp0_m, tmp2_m, tmp2_m, out_g0, out_g1); \
+}
+
+#define CALC_R4_FRM_YCC(y_h0, y_h1, y_h2, y_h3, cr_w0, cr_w1, cr_w2, cr_w3, \
+out_r0, out_r1) { \
+  v8i16 tmp0_m, tmp1_m, tmp2_m, tmp3_m; \
+  v4i32 out0_m, out1_m, out2_m, out3_m; \
+  v4i32 const0_m = { FIX_1_40200, FIX_1_40200, FIX_1_40200, FIX_1_40200 }; \
+  \
+  MUL4(const0_m, cr_w0, const0_m, cr_w1, const0_m, cr_w2, const0_m, cr_w3, \
+       out0_m, out1_m, out2_m, out3_m); \
+  SRARI_W4_SW(out0_m, out1_m, out2_m, out3_m, 16); \
+  PCKEV_H2_SH(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m); \
+  ADD4(y_h2, tmp0_m, y_h3, tmp1_m, y_h0, tmp0_m, y_h1, tmp1_m, \
+       tmp2_m, tmp3_m, tmp0_m, tmp1_m); \
+  CLIP_SH4_0_255(tmp0_m, tmp1_m, tmp2_m, tmp3_m); \
+  PCKEV_B2_SB(tmp1_m, tmp0_m, tmp3_m, tmp2_m, out_r0, out_r1); \
+}
+
+#define CALC_R2_FRM_YCC(y_h0, y_h1, cr_w0, cr_w1, out_r0, out_r1) { \
+  v8i16 tmp0_m, tmp2_m; \
+  v4i32 out0_m, out1_m; \
+  v4i32 const0_m = { FIX_1_40200, FIX_1_40200, FIX_1_40200, FIX_1_40200 }; \
+  \
+  MUL2(const0_m, cr_w0, const0_m, cr_w1, out0_m, out1_m); \
+  SRARI_W2_SW(out0_m, out1_m, 16); \
+  tmp0_m = __msa_pckev_h((v8i16)out1_m, (v8i16)out0_m); \
+  ADD2(y_h1, tmp0_m, y_h0, tmp0_m, tmp2_m, tmp0_m); \
+  CLIP_SH2_0_255(tmp0_m, tmp2_m); \
+  PCKEV_B2_SB(tmp0_m, tmp0_m, tmp2_m, tmp2_m, out_r0, out_r1); \
+}
+
+#define CALC_B4_FRM_YCC(y_h0, y_h1, y_h2, y_h3, cb_w0, cb_w1, cb_w2, cb_w3, \
+out_b0, out_b1) { \
+  v8i16 tmp0_m, tmp1_m, tmp2_m, tmp3_m; \
+  v4i32 out0_m, out1_m, out2_m, out3_m; \
+  v4i32 const0_m = { FIX_1_77200, FIX_1_77200, FIX_1_77200, FIX_1_77200 }; \
+  \
+  MUL4(const0_m, cb_w0, const0_m, cb_w1, const0_m, cb_w2, const0_m, cb_w3, \
+       out0_m, out1_m, out2_m, out3_m); \
+  SRARI_W4_SW(out0_m, out1_m, out2_m, out3_m, 16); \
+  PCKEV_H2_SH(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m); \
+  ADD4(y_h2, tmp0_m, y_h3, tmp1_m, y_h0, tmp0_m, y_h1, tmp1_m, \
+       tmp2_m, tmp3_m, tmp0_m, tmp1_m); \
+  CLIP_SH4_0_255(tmp0_m, tmp1_m, tmp2_m, tmp3_m); \
+  PCKEV_B2_SB(tmp1_m, tmp0_m, tmp3_m, tmp2_m, out_b0, out_b1); \
+}
+
+#define CALC_B2_FRM_YCC(y_h0, y_h1, cb_w0, cb_w1, out_b0, out_b1) { \
+  v8i16 tmp0_m, tmp2_m; \
+  v4i32 out0_m, out1_m; \
+  v4i32 const0_m = { FIX_1_77200, FIX_1_77200, FIX_1_77200, FIX_1_77200 }; \
+  \
+  MUL2(const0_m, cb_w0, const0_m, cb_w1, out0_m, out1_m); \
+  SRARI_W2_SW(out0_m, out1_m, 16); \
+  tmp0_m = __msa_pckev_h((v8i16)out1_m, (v8i16)out0_m); \
+  ADD2(y_h1, tmp0_m, y_h0, tmp0_m, tmp2_m, tmp0_m); \
+  CLIP_SH2_0_255(tmp0_m, tmp2_m); \
+  PCKEV_B2_SB(tmp0_m, tmp0_m, tmp2_m, tmp2_m, out_b0, out_b1); \
+}
+
+#define CALC_G4_FRM_YCC2(y_h0, y_h1, y_h2, y_h3, y_h4, y_h5, y_h6, y_h7, \
+cb_h0, cb_h1, cr_h0, cr_h1, out_g0, out_g1, out_g2, out_g3) { \
+  v8i16 tmp0_m, tmp1_m, tmp2_m, tmp3_m, tmp4_m, tmp5_m, tmp6_m, tmp7_m; \
+  v4i32 out0_m, out1_m, out2_m, out3_m; \
+  v8i16 const0_m = { -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586, \
+                     -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586 \
+                   }; \
+  \
+  ILVRL_H2_SH(cr_h0, cb_h0, tmp0_m, tmp1_m); \
+  UNPCK_SH_SW((-cr_h0), out0_m, out1_m); \
+  out0_m = MSA_SLLI_W(out0_m, 16); \
+  out1_m = MSA_SLLI_W(out1_m, 16); \
+  DPADD_SH2_SW(tmp0_m, tmp1_m, const0_m, const0_m, out0_m, out1_m); \
+  ILVRL_H2_SH(cr_h1, cb_h1, tmp0_m, tmp1_m); \
+  UNPCK_SH_SW((-cr_h1), out2_m, out3_m); \
+  out2_m = MSA_SLLI_W(out2_m, 16); \
+  out3_m = MSA_SLLI_W(out3_m, 16); \
+  DPADD_SH2_SW(tmp0_m, tmp1_m, const0_m, const0_m, out2_m, out3_m); \
+  SRARI_W4_SW(out0_m, out1_m, out2_m, out3_m, 16); \
+  PCKEV_H2_SH(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m); \
+  ADD4(y_h4, tmp0_m, y_h5, tmp1_m, y_h6, tmp0_m, y_h7, tmp1_m, \
+       tmp4_m, tmp5_m, tmp6_m, tmp7_m); \
+  CLIP_SH4_0_255(tmp4_m, tmp5_m, tmp6_m, tmp7_m); \
+  PCKEV_B2_SB(tmp5_m, tmp4_m, tmp7_m, tmp6_m, out_g2, out_g3); \
+  ADD4(y_h3, tmp1_m, y_h2, tmp0_m, y_h1, tmp1_m, y_h0, tmp0_m, \
+       tmp3_m, tmp2_m, tmp1_m, tmp0_m); \
+  CLIP_SH4_0_255(tmp0_m, tmp1_m, tmp2_m, tmp3_m); \
+  PCKEV_B2_SB(tmp1_m, tmp0_m, tmp3_m, tmp2_m, out_g0, out_g1); \
+}
+
+#define CALC_G2_FRM_YCC2(y_h0, y_h1, y_h2, y_h3, cb_h0, cr_h0, \
+out_g0, out_g1) { \
+  v8i16 tmp0_m, tmp1_m, tmp2_m, tmp3_m; \
+  v4i32 out0_m, out1_m; \
+  v8i16 const0_m = { -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586, \
+                     -FIX_0_34414, FIX_0_28586, -FIX_0_34414, FIX_0_28586 \
+                   }; \
+  \
+  ILVRL_H2_SH(cr_h0, cb_h0, tmp0_m, tmp1_m); \
+  UNPCK_SH_SW((-cr_h0), out0_m, out1_m); \
+  out0_m = MSA_SLLI_W(out0_m, 16); \
+  out1_m = MSA_SLLI_W(out1_m, 16); \
+  DPADD_SH2_SW(tmp0_m, tmp1_m, const0_m, const0_m, out0_m, out1_m); \
+  SRARI_W2_SW(out0_m, out1_m, 16); \
+  tmp0_m = __msa_pckev_h((v8i16)out1_m, (v8i16)out0_m); \
+  ADD4(y_h3, tmp0_m, y_h2, tmp0_m, y_h1, tmp0_m, y_h0, tmp0_m, \
+       tmp3_m, tmp1_m, tmp2_m, tmp0_m); \
+  CLIP_SH4_0_255(tmp0_m, tmp2_m, tmp1_m, tmp3_m); \
+  PCKEV_B2_SB(tmp1_m, tmp0_m, tmp3_m, tmp2_m, out_g0, out_g1); \
+}
+
+#define CALC_R4_FRM_YCC2(y_h0, y_h1, y_h2, y_h3, y_h4, y_h5, y_h6, y_h7, \
+cr_w0, cr_w1, cr_w2, cr_w3, out_r0, out_r1, out_r2, out_r3) { \
+  v8i16 tmp0_m, tmp1_m, tmp2_m, tmp3_m, tmp4_m, tmp5_m, tmp6_m, tmp7_m; \
+  v4i32 out0_m, out1_m, out2_m, out3_m; \
+  v4i32 const0_m = { FIX_1_40200, FIX_1_40200, FIX_1_40200, FIX_1_40200 }; \
+  \
+  MUL4(const0_m, cr_w0, const0_m, cr_w1, const0_m, cr_w2, const0_m, cr_w3, \
+       out0_m, out1_m, out2_m, out3_m); \
+  SRARI_W4_SW(out0_m, out1_m, out2_m, out3_m, 16); \
+  PCKEV_H2_SH(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m); \
+  ADD4(y_h4, tmp0_m, y_h5, tmp1_m, y_h6, tmp0_m, y_h7, tmp1_m, \
+       tmp4_m, tmp5_m, tmp6_m, tmp7_m); \
+  CLIP_SH4_0_255(tmp4_m, tmp5_m, tmp6_m, tmp7_m); \
+  PCKEV_B2_SB(tmp5_m, tmp4_m, tmp7_m, tmp6_m, out_r2, out_r3); \
+  ADD4(y_h3, tmp1_m, y_h2, tmp0_m, y_h1, tmp1_m, y_h0, tmp0_m, \
+       tmp3_m, tmp2_m, tmp1_m, tmp0_m); \
+  CLIP_SH4_0_255(tmp0_m, tmp1_m, tmp2_m, tmp3_m); \
+  PCKEV_B2_SB(tmp1_m, tmp0_m, tmp3_m, tmp2_m, out_r0, out_r1); \
+}
+
+#define CALC_R2_FRM_YCC2(y_h0, y_h1, y_h2, y_h3, cr_w0, cr_w1, \
+out_r0, out_r1) { \
+  v8i16 tmp0_m, tmp1_m, tmp2_m, tmp3_m; \
+  v4i32 out0_m, out1_m; \
+  v4i32 const0_m = { FIX_1_40200, FIX_1_40200, FIX_1_40200, FIX_1_40200 }; \
+  \
+  MUL2(const0_m, cr_w0, const0_m, cr_w1, out0_m, out1_m); \
+  SRARI_W2_SW(out0_m, out1_m, 16); \
+  tmp0_m = __msa_pckev_h((v8i16)out1_m, (v8i16)out0_m); \
+  ADD4(y_h3, tmp0_m, y_h2, tmp0_m, y_h1, tmp0_m, y_h0, tmp0_m, \
+       tmp3_m, tmp1_m, tmp2_m, tmp0_m); \
+  CLIP_SH4_0_255(tmp0_m, tmp2_m, tmp1_m, tmp3_m); \
+  PCKEV_B2_SB(tmp1_m, tmp0_m, tmp3_m, tmp2_m, out_r0, out_r1); \
+}
+
+#define CALC_B4_FRM_YCC2(y_h0, y_h1, y_h2, y_h3, y_h4, y_h5, y_h6, y_h7, \
+cb_w0, cb_w1, cb_w2, cb_w3, out_b0, out_b1, out_b2, out_b3) { \
+  v8i16 tmp0_m, tmp1_m, tmp2_m, tmp3_m, tmp4_m, tmp5_m, tmp6_m, tmp7_m; \
+  v4i32 out0_m, out1_m, out2_m, out3_m; \
+  v4i32 const0_m = { FIX_1_77200, FIX_1_77200, FIX_1_77200, FIX_1_77200 }; \
+  \
+  MUL4(const0_m, cb_w0, const0_m, cb_w1, const0_m, cb_w2, const0_m, cb_w3, \
+       out0_m, out1_m, out2_m, out3_m); \
+  SRARI_W4_SW(out0_m, out1_m, out2_m, out3_m, 16); \
+  PCKEV_H2_SH(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m); \
+  ADD4(y_h4, tmp0_m, y_h5, tmp1_m, y_h6, tmp0_m, y_h7, tmp1_m, \
+       tmp4_m, tmp5_m, tmp6_m, tmp7_m); \
+  CLIP_SH4_0_255(tmp4_m, tmp5_m, tmp6_m, tmp7_m); \
+  PCKEV_B2_SB(tmp5_m, tmp4_m, tmp7_m, tmp6_m, out_b2, out_b3); \
+  ADD4(y_h3, tmp1_m, y_h2, tmp0_m, y_h1, tmp1_m, y_h0, tmp0_m, \
+       tmp3_m, tmp2_m, tmp1_m, tmp0_m); \
+  CLIP_SH4_0_255(tmp0_m, tmp1_m, tmp2_m, tmp3_m); \
+  PCKEV_B2_SB(tmp1_m, tmp0_m, tmp3_m, tmp2_m, out_b0, out_b1); \
+}
+
+#define CALC_B2_FRM_YCC2(y_h0, y_h1, y_h2, y_h3, cb_w0, cb_w1, \
+out_b0, out_b1) { \
+  v8i16 tmp0_m, tmp1_m, tmp2_m, tmp3_m; \
+  v4i32 out0_m, out1_m; \
+  v4i32 const0_m = { FIX_1_77200, FIX_1_77200, FIX_1_77200, FIX_1_77200 }; \
+  \
+  MUL2(const0_m, cb_w0, const0_m, cb_w1, out0_m, out1_m); \
+  SRARI_W2_SW(out0_m, out1_m, 16); \
+  tmp0_m = __msa_pckev_h((v8i16)out1_m, (v8i16)out0_m); \
+  ADD4(y_h3, tmp0_m, y_h2, tmp0_m, y_h1, tmp0_m, y_h0, tmp0_m, \
+       tmp3_m, tmp1_m, tmp2_m, tmp0_m); \
+  CLIP_SH4_0_255(tmp0_m, tmp2_m, tmp1_m, tmp3_m); \
+  PCKEV_B2_SB(tmp1_m, tmp0_m, tmp3_m, tmp2_m, out_b0, out_b1); \
+}
+
+#define ROUND_POWER_OF_TWO(value, n)  (((value) + (1 << ((n) - 1))) >> (n))
+
+static INLINE unsigned char clip_pixel(int val)
+{
+  return ((val & ~0xFF) ? ((-val) >> 31) & 0xFF : val);
+}
+
+#include "jdmrgext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+
+#define RGB_RED        EXT_RGB_RED
+#define RGB_GREEN      EXT_RGB_GREEN
+#define RGB_BLUE       EXT_RGB_BLUE
+#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
+#define jsimd_h2v1_merged_upsample_msa  jsimd_h2v1_extrgb_merged_upsample_msa
+#define jsimd_h2v2_merged_upsample_msa  jsimd_h2v2_extrgb_merged_upsample_msa
+#include "jdmrgext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef jsimd_h2v1_merged_upsample_msa
+#undef jsimd_h2v2_merged_upsample_msa
+
+#define RGB_RED        EXT_BGR_RED
+#define RGB_GREEN      EXT_BGR_GREEN
+#define RGB_BLUE       EXT_BGR_BLUE
+#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
+#define jsimd_h2v1_merged_upsample_msa  jsimd_h2v1_extbgr_merged_upsample_msa
+#define jsimd_h2v2_merged_upsample_msa  jsimd_h2v2_extbgr_merged_upsample_msa
+#include "jdmrgext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#undef jsimd_h2v1_merged_upsample_msa
+#undef jsimd_h2v2_merged_upsample_msa
+
+#define RGB_RED        EXT_RGBX_RED
+#define RGB_GREEN      EXT_RGBX_GREEN
+#define RGB_BLUE       EXT_RGBX_BLUE
+#define RGB_ALPHA      3
+#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
+#define jsimd_h2v1_merged_upsample_msa  jsimd_h2v1_extrgbx_merged_upsample_msa
+#define jsimd_h2v2_merged_upsample_msa  jsimd_h2v2_extrgbx_merged_upsample_msa
+#include "jdmrgext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_ALPHA
+#undef RGB_PIXELSIZE
+#undef jsimd_h2v1_merged_upsample_msa
+#undef jsimd_h2v2_merged_upsample_msa
+
+#define RGB_RED        EXT_BGRX_RED
+#define RGB_GREEN      EXT_BGRX_GREEN
+#define RGB_BLUE       EXT_BGRX_BLUE
+#define RGB_ALPHA      3
+#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
+#define jsimd_h2v1_merged_upsample_msa  jsimd_h2v1_extbgrx_merged_upsample_msa
+#define jsimd_h2v2_merged_upsample_msa  jsimd_h2v2_extbgrx_merged_upsample_msa
+#include "jdmrgext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_ALPHA
+#undef RGB_PIXELSIZE
+#undef jsimd_h2v1_merged_upsample_msa
+#undef jsimd_h2v2_merged_upsample_msa
+
+#define RGB_RED        EXT_XRGB_RED
+#define RGB_GREEN      EXT_XRGB_GREEN
+#define RGB_BLUE       EXT_XRGB_BLUE
+#define RGB_ALPHA      0
+#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
+#define jsimd_h2v1_merged_upsample_msa  jsimd_h2v1_extxrgb_merged_upsample_msa
+#define jsimd_h2v2_merged_upsample_msa  jsimd_h2v2_extxrgb_merged_upsample_msa
+#include "jdmrgext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_ALPHA
+#undef RGB_PIXELSIZE
+#undef jsimd_h2v1_merged_upsample_msa
+#undef jsimd_h2v2_merged_upsample_msa
+
+#define RGB_RED        EXT_XBGR_RED
+#define RGB_GREEN      EXT_XBGR_GREEN
+#define RGB_BLUE       EXT_XBGR_BLUE
+#define RGB_ALPHA      0
+#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
+#define jsimd_h2v1_merged_upsample_msa  jsimd_h2v1_extxbgr_merged_upsample_msa
+#define jsimd_h2v2_merged_upsample_msa  jsimd_h2v2_extxbgr_merged_upsample_msa
+#include "jdmrgext_msa.c"
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_ALPHA
+#undef RGB_PIXELSIZE
+#undef jsimd_h2v1_merged_upsample_msa
+#undef jsimd_h2v2_merged_upsample_msa

--- a/simd/mips/jdmrgext_msa.c
+++ b/simd/mips/jdmrgext_msa.c
@@ -1,0 +1,393 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* Merged upsample: YCC --> RGB CONVERSION + Upsample */
+
+#if RGB_RED == 0
+#define var_a  out_r0
+#define var_b  out_b0
+#define var_c  out_r1
+#define var_d  out_b1
+#elif RGB_RED == 1 || RGB_RED == 3
+#define var_a  out_g0
+#define var_b  alpha
+#define var_c  out_g1
+#define var_d  alpha
+#else /* RGB_RED == 2 */
+#define var_a  out_b0
+#define var_b  out_r0
+#define var_c  out_b1
+#define var_d  out_r1
+#endif
+
+#if RGB_PIXELSIZE == 4
+#if RGB_RED == 0 || RGB_RED == 2
+#define var_e  out_g0
+#define var_f  alpha
+#define var_g  out_g1
+#define var_h  alpha
+#define var_i  out_rgb0
+#define var_j  out_rgb1
+#define var_k  out_rgb2
+#define var_l  out_rgb3
+#define var_m  tmp0
+#define var_n  tmp1
+#define var_o  tmp2
+#define var_p  tmp3
+#else /* RGB_RED == 1 || RGB_RED == 3 */
+#define var_i  tmp0
+#define var_j  tmp1
+#define var_k  tmp2
+#define var_l  tmp3
+#define var_m  out_rgb0
+#define var_n  out_rgb1
+#define var_o  out_rgb2
+#define var_p  out_rgb3
+#if RGB_RED == 1
+#define var_e  out_b0
+#define var_f  out_r0
+#define var_g  out_b1
+#define var_h  out_r1
+#else /* RGB_RED == 3 */
+#define var_e  out_r0
+#define var_f  out_b0
+#define var_g  out_r1
+#define var_h  out_b1
+#endif
+#endif
+#endif
+
+GLOBAL(void)
+jsimd_h2v1_merged_upsample_msa(JDIMENSION output_width, JSAMPIMAGE input_buf,
+                               JDIMENSION in_row_group_ctr,
+                               JSAMPARRAY output_buf)
+{
+  register JSAMPROW p_in_y, p_in_cb, p_in_cr;
+  register JSAMPROW p_out;
+  int y, cb, cr, cred, cgreen, cblue;
+  JDIMENSION col, num_cols_mul_32 = output_width >> 5;
+  JDIMENSION remaining_wd = output_width & 0x1E;
+  v16u8 out0, out1, out2, out3, out4, out5, input_y0 = { 0 }, input_y1;
+  v16i8 tmp0, tmp1, const_128 = __msa_ldi_b(128);
+  v16i8 input_cb, input_cr, out_rgb0, out_rgb1, out_rgb2, out_rgb3;
+  v16i8  out_r0, out_g0, out_b0, out_r1, out_g1, out_b1;
+  v8i16 y_h0, y_h1, y_h2, y_h3, cb_h0, cb_h1, cr_h0, cr_h1;
+  v4i32 cb_w0, cb_w1, cb_w2, cb_w3, cr_w0, cr_w1, cr_w2, cr_w3, zero = { 0 };
+#if RGB_PIXELSIZE == 3
+  const v16u8 mask_rgb0 =
+    { 0, 1, 16, 2, 3, 17, 4, 5, 18, 6, 7, 19, 8, 9, 20, 10 };
+  const v16u8 mask_rgb1 =
+    { 11, 21, 12, 13, 22, 14, 15, 23, 0, 1, 24, 2, 3, 25, 4, 5 };
+  const v16u8 mask_rgb2 =
+    { 26, 6, 7, 27, 8, 9, 28, 10, 11, 29, 12, 13, 30, 14, 15, 31 };
+#else /* RGB_PIXELSIZE == 4 */
+  v16u8 out6, out7;
+  v16i8 tmp2, tmp3, alpha = __msa_ldi_b(0xFF);
+#endif
+
+  p_in_y = input_buf[0][in_row_group_ctr];
+  p_in_cb = input_buf[1][in_row_group_ctr];
+  p_in_cr = input_buf[2][in_row_group_ctr];
+  p_out = output_buf[0];
+
+  for (col = num_cols_mul_32; col--;) {
+    LD_SB2(p_in_y, 16, tmp0, tmp1);
+    input_cb = LD_SB(p_in_cb);
+    input_cr = LD_SB(p_in_cr);
+
+    p_in_y += 32;
+    p_in_cb += 16;
+    p_in_cr += 16;
+
+    input_cb -= const_128;
+    input_cr -= const_128;
+
+    input_y0 = (v16u8)__msa_pckev_b(tmp1, tmp0);
+    input_y1 = (v16u8)__msa_pckod_b(tmp1, tmp0);
+
+    UNPCK_UB_SH(input_y0, y_h0, y_h1);
+    UNPCK_UB_SH(input_y1, y_h2, y_h3);
+    UNPCK_SB_SH(input_cb, cb_h0, cb_h1);
+    UNPCK_SB_SH(input_cr, cr_h0, cr_h1);
+
+    CALC_G4_FRM_YCC(y_h0, y_h1, y_h2, y_h3, cb_h0, cb_h1, cr_h0, cr_h1,
+                    tmp0, tmp1);
+    ILVRL_B2_SB(tmp1, tmp0, out_g0, out_g1);
+
+    UNPCK_SH_SW(cr_h0, cr_w0, cr_w1);
+    UNPCK_SH_SW(cr_h1, cr_w2, cr_w3);
+    CALC_R4_FRM_YCC(y_h0, y_h1, y_h2, y_h3, cr_w0, cr_w1, cr_w2, cr_w3,
+                    tmp0, tmp1);
+    ILVRL_B2_SB(tmp1, tmp0, out_r0, out_r1);
+
+    UNPCK_SH_SW(cb_h0, cb_w0, cb_w1);
+    UNPCK_SH_SW(cb_h1, cb_w2, cb_w3);
+    CALC_B4_FRM_YCC(y_h0, y_h1, y_h2, y_h3, cb_w0, cb_w1, cb_w2, cb_w3,
+                    tmp0, tmp1);
+    ILVRL_B2_SB(tmp1, tmp0, out_b0, out_b1);
+
+#if RGB_PIXELSIZE == 3
+    ILVRL_B2_SB(out_g0, var_a, out_rgb0, out_rgb1);
+    ILVRL_B2_SB(out_g1, var_c, out_rgb2, out_rgb3);
+
+    VSHF_B2_UB(out_rgb0, var_b, out_rgb1, var_b, mask_rgb0, mask_rgb2,
+               out0, out2);
+    VSHF_B2_SB(out_rgb0, var_b, out_rgb1, var_b, mask_rgb1, mask_rgb1,
+               tmp0, tmp1);
+
+    out1 = (v16u8)__msa_sldi_b((v16i8)zero, tmp1, 8);
+    out1 = (v16u8)__msa_pckev_d((v2i64)out1, (v2i64)tmp0);
+
+    VSHF_B2_UB(out_rgb2, var_d, out_rgb3, var_d, mask_rgb0, mask_rgb2,
+               out3, out5);
+    VSHF_B2_SB(out_rgb2, var_d, out_rgb3, var_d, mask_rgb1, mask_rgb1,
+               tmp0, tmp1);
+
+    out4 = (v16u8)__msa_sldi_b((v16i8)zero, tmp1, 8);
+    out4 = (v16u8)__msa_pckev_d((v2i64)out4, (v2i64)tmp0);
+
+    ST_UB4(out0, out1, out2, out3, p_out, 16);
+    p_out += 16 * 4;
+    ST_UB2(out4, out5, p_out, 16);
+    p_out += 16 * 2;
+#else /* RGB_PIXELSIZE == 4 */
+    ILVRL_B2_SB(var_e, var_a, out_rgb0, out_rgb1);
+    ILVRL_B2_SB(var_g, var_c, out_rgb2, out_rgb3);
+    ILVRL_B2_SB(var_f, var_b, tmp0, tmp1);
+    ILVRL_B2_SB(var_h, var_d, tmp2, tmp3);
+
+    ILVRL_H2_UB(var_m, var_i, out0, out1);
+    ILVRL_H2_UB(var_n, var_j, out2, out3);
+    ILVRL_H2_UB(var_o, var_k, out4, out5);
+    ILVRL_H2_UB(var_p, var_l, out6, out7);
+
+    ST_UB8(out0, out1, out2, out3, out4, out5, out6, out7, p_out, 16);
+    p_out += 16 * 8;
+#endif
+  }
+
+  if (remaining_wd >= 16) {
+    uint64_t in_cb, in_cr;
+    v16i8 input_cbcr = { 0 };
+
+    tmp1 = LD_SB(p_in_y);
+    in_cb = LD(p_in_cb);
+    in_cr = LD(p_in_cr);
+
+    p_in_y += 16;
+    p_in_cb += 8;
+    p_in_cr += 8;
+
+    tmp0 = __msa_pckev_b((v16i8)zero, tmp1);
+    tmp1 = __msa_pckod_b((v16i8)zero, tmp1);
+    input_y0 = (v16u8)__msa_pckev_d((v2i64)tmp1, (v2i64)tmp0);
+    UNPCK_UB_SH(input_y0, y_h0, y_h1);
+
+    input_cbcr = (v16i8)__msa_insert_d((v2i64)input_cbcr, 0, in_cb);
+    input_cbcr = (v16i8)__msa_insert_d((v2i64)input_cbcr, 1, in_cr);
+
+    input_cbcr -= const_128;
+
+    UNPCK_SB_SH(input_cbcr, cb_h0, cr_h0);
+    UNPCK_SH_SW(cb_h0, cb_w0, cb_w1);
+    UNPCK_SH_SW(cr_h0, cr_w0, cr_w1);
+
+    CALC_R2_FRM_YCC(y_h0, y_h1, cr_w0, cr_w1, tmp0, tmp1);
+    out_r0 = (v16i8)__msa_ilvr_b((v16i8)tmp1, (v16i8)tmp0);
+    CALC_G2_FRM_YCC(y_h0, y_h1, cb_h0, cr_h0, tmp0, tmp1);
+    out_g0 = (v16i8)__msa_ilvr_b((v16i8)tmp1, (v16i8)tmp0);
+    CALC_B2_FRM_YCC(y_h0, y_h1, cb_w0, cb_w1, tmp0, tmp1);
+    out_b0 = (v16i8)__msa_ilvr_b((v16i8)tmp1, (v16i8)tmp0);
+
+#if RGB_PIXELSIZE == 3
+    ILVRL_B2_SB(out_g0, var_a, out_rgb0, out_rgb1);
+    VSHF_B2_UB(out_rgb0, var_b, out_rgb1, var_b, mask_rgb0, mask_rgb2,
+               out0, out2);
+    VSHF_B2_SB(out_rgb0, var_b, out_rgb1, var_b, mask_rgb1, mask_rgb1,
+               tmp0, tmp1);
+
+    out1 = (v16u8)__msa_sldi_b((v16i8)zero, tmp1, 8);
+    out1 = (v16u8)__msa_pckev_d((v2i64)out1, (v2i64)tmp0);
+
+    ST_UB(out0, p_out);
+    p_out += 16;
+    ST_UB(out1, p_out);
+    p_out += 16;
+    ST_UB(out2, p_out);
+    p_out += 16;
+#else /* RGB_PIXELSIZE == 4 */
+    ILVRL_B2_SB(var_e, var_a, out_rgb0, out_rgb1);
+    ILVRL_B2_SB(var_f, var_b, tmp0, tmp1);
+
+    ILVRL_H2_UB(var_m, var_i, out0, out1);
+    ILVRL_H2_UB(var_n, var_j, out2, out3);
+
+    ST_UB4(out0, out1, out2, out3, p_out, 16);
+    p_out += 16 * 4;
+#endif
+
+    remaining_wd -= 16;
+  }
+
+  if (remaining_wd >= 8) {
+    JDIMENSION in_cb, in_cr;
+    uint64_t in_y;
+    v16i8 input_cbcr = { 0 };
+
+    in_y = LD(p_in_y);
+    in_cb = LW(p_in_cb);
+    in_cr = LW(p_in_cr);
+
+    p_in_y += 8;
+    p_in_cb += 4;
+    p_in_cr += 4;
+
+    input_y0 = (v16u8)__msa_insert_d((v2i64)input_y0, 0, in_y);
+    tmp0 = __msa_pckev_b((v16i8)zero, (v16i8)input_y0);
+    tmp1 = __msa_pckod_b((v16i8)zero, (v16i8)input_y0);
+    input_y0 = (v16u8)__msa_pckev_d((v2i64)tmp1, (v2i64)tmp0);
+    UNPCK_UB_SH(input_y0, y_h0, y_h1);
+
+    input_cbcr = (v16i8)__msa_insert_w((v4i32)input_cbcr, 0, in_cb);
+    input_cbcr = (v16i8)__msa_insert_w((v4i32)input_cbcr, 2, in_cr);
+
+    input_cbcr -= const_128;
+
+    UNPCK_SB_SH(input_cbcr, cb_h0, cr_h0);
+    UNPCK_SH_SW(cb_h0, cb_w0, cb_w1);
+    UNPCK_SH_SW(cr_h0, cr_w0, cr_w1);
+
+    CALC_R2_FRM_YCC(y_h0, y_h1, cr_w0, cr_w1, tmp0, tmp1);
+    out_r0 = (v16i8)__msa_ilvr_b((v16i8)tmp1, (v16i8)tmp0);
+    CALC_G2_FRM_YCC(y_h0, y_h1, cb_h0, cr_h0, tmp0, tmp1);
+    out_g0 = (v16i8)__msa_ilvr_b((v16i8)tmp1, (v16i8)tmp0);
+    CALC_B2_FRM_YCC(y_h0, y_h1, cb_w0, cb_w1, tmp0, tmp1);
+    out_b0 = (v16i8)__msa_ilvr_b((v16i8)tmp1, (v16i8)tmp0);
+
+#if RGB_PIXELSIZE == 3
+    out_rgb0 = (v16i8)__msa_ilvr_b((v16i8)out_g0, (v16i8)var_a);
+    VSHF_B2_UB(out_rgb0, var_b, out_rgb0, var_b, mask_rgb0, mask_rgb1,
+               out0, out1);
+
+    ST_UB(out0, p_out);
+    p_out += 16;
+    ST8x1_UB(out1, p_out);
+    p_out += 8;
+#else /* RGB_PIXELSIZE == 4 */
+    out_rgb0 = (v16i8)__msa_ilvr_b((v16i8)var_e, (v16i8)var_a);
+    tmp0 = (v16i8)__msa_ilvr_b(var_f, (v16i8)var_b);
+
+    ILVRL_H2_UB(var_m, var_i, out0, out1);
+
+    ST_UB2(out0, out1, p_out, 16);
+    p_out += 32;
+#endif
+
+    remaining_wd -= 8;
+  }
+
+  for (col = 0; col < remaining_wd; col += 2) {
+    cb = (int)(*p_in_cb++) - 128;
+    cr = (int)(*p_in_cr++) - 128;
+    cred = ROUND_POWER_OF_TWO(FIX_1_40200 * cr, 16);
+    cgreen = ROUND_POWER_OF_TWO(((-FIX_0_34414) * cb - FIX_0_71414 * cr), 16);
+    cblue = ROUND_POWER_OF_TWO(FIX_1_77200 * cb, 16);
+
+    y = (int)(*p_in_y++);
+    p_out[RGB_RED] = clip_pixel(y + cred);
+    p_out[RGB_GREEN] = clip_pixel(y + cgreen);
+    p_out[RGB_BLUE] = clip_pixel(y + cblue);
+#ifdef RGB_ALPHA
+    p_out[RGB_ALPHA] = 0xFF;
+#endif
+    p_out += RGB_PIXELSIZE;
+
+    y = (int)(*p_in_y++);
+    p_out[RGB_RED] = clip_pixel(y + cred);
+    p_out[RGB_GREEN] = clip_pixel(y + cgreen);
+    p_out[RGB_BLUE] = clip_pixel(y + cblue);
+#ifdef RGB_ALPHA
+    p_out[RGB_ALPHA] = 0xFF;
+#endif
+    p_out += RGB_PIXELSIZE;
+  }
+
+  if (output_width & 1) {
+    cb = (int)(*p_in_cb) - 128;
+    cr = (int)(*p_in_cr) - 128;
+    cred = ROUND_POWER_OF_TWO(FIX_1_40200 * cr, 16);
+    cgreen = ROUND_POWER_OF_TWO(((-FIX_0_34414) * cb - FIX_0_71414 * cr), 16);
+    cblue = ROUND_POWER_OF_TWO(FIX_1_77200 * cb, 16);
+
+    y = (int)(*p_in_y);
+    p_out[RGB_RED] = clip_pixel(y + cred);
+    p_out[RGB_GREEN] = clip_pixel(y + cgreen);
+    p_out[RGB_BLUE] = clip_pixel(y + cblue);
+#ifdef RGB_ALPHA
+    p_out[RGB_ALPHA] = 0xFF;
+#endif
+  }
+}
+
+GLOBAL(void)
+jsimd_h2v2_merged_upsample_msa(JDIMENSION output_width,
+                               JSAMPIMAGE input_buf,
+                               JDIMENSION in_row_group_ctr,
+                               JSAMPARRAY output_buf)
+{
+  JSAMPROW inptr, outptr;
+
+  inptr = input_buf[0][in_row_group_ctr];
+  outptr = output_buf[0];
+
+  input_buf[0][in_row_group_ctr] = input_buf[0][in_row_group_ctr * 2];
+  jsimd_h2v1_merged_upsample_msa(output_width, input_buf, in_row_group_ctr,
+                                 output_buf);
+
+  input_buf[0][in_row_group_ctr] = input_buf[0][in_row_group_ctr * 2 + 1];
+  output_buf[0] = output_buf[1];
+  jsimd_h2v1_merged_upsample_msa(output_width, input_buf, in_row_group_ctr,
+                                 output_buf);
+
+  input_buf[0][in_row_group_ctr] = inptr;
+  output_buf[0] = outptr;
+}
+
+#undef var_a
+#undef var_b
+#undef var_c
+#undef var_d
+#if RGB_PIXELSIZE == 4
+#undef var_e
+#undef var_f
+#undef var_g
+#undef var_h
+#undef var_i
+#undef var_j
+#undef var_k
+#undef var_l
+#undef var_m
+#undef var_n
+#undef var_o
+#undef var_p
+#endif

--- a/simd/mips/jdsample_msa.c
+++ b/simd/mips/jdsample_msa.c
@@ -1,0 +1,360 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#define JPEG_INTERNALS
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "../../jsimd.h"
+#include "jmacros_msa.h"
+
+
+/*
+ * Fancy processing for the common case of 2:1 horizontal and 1:1 vertical.
+ *
+ * The centers of the output pixels are 1/4 and 3/4 of the way between input
+ * pixel centers.
+ *
+ * height = 1 to 4, width = multiple of 16
+*/
+GLOBAL(void)
+jsimd_h2v1_fancy_upsample_msa(int max_v_samp_factor,
+                              JDIMENSION downsampled_width,
+                              JSAMPARRAY input_data,
+                              JSAMPARRAY *output_data_ptr)
+{
+  JDIMENSION col, row, width = downsampled_width;
+  JSAMPARRAY dst = *output_data_ptr;
+  v8i16 left_r, left_l, cur_r, cur_l, right_r, right_l, zero = { 0 };
+  v16i8 out0, out1, src2, src0, src1, left, right;
+
+  for (row = 0; row < max_v_samp_factor; row++) {
+    /* Prepare first 16 width column */
+    src1 = LD_SB(input_data[row]);
+    src2 = LD_SB(input_data[row] + 16);
+    src0 = __msa_splati_b(src1, 0);
+
+    for (col = 0; col < width; col += 16) {
+      left = __msa_sldi_b(src1, src0, 15); /* -1 0 1 2 ... 12 13 14 */
+      right = __msa_sldi_b(src2, src1, 1); /* 1 2 3 4 ... 14 15 16 */
+
+      /* Promote data to 16 bit */
+      ILVRL_B2_SH(zero, left, left_r, left_l);
+      ILVRL_B2_SH(zero, right, right_r, right_l);
+      ILVRL_B2_SH(zero, src1, cur_r, cur_l);
+
+      cur_l += MSA_SLLI_H(cur_l, 1);
+      cur_r += MSA_SLLI_H(cur_r, 1);
+
+      left_l += MSA_ADDVI_H(cur_l, 1);
+      left_r += MSA_ADDVI_H(cur_r, 1);
+
+      right_l += MSA_ADDVI_H(cur_l, 2);
+      right_r += MSA_ADDVI_H(cur_r, 2);
+
+      SRAI_H4_SH(left_r, left_l, right_r, right_l, 2);
+      PCKEV_B2_SB(left_l, left_r, right_l, right_r, left, right);
+      ILVRL_B2_SB(right, left, out0, out1);
+
+      ST_SB2(out0, out1, dst[row] + (col << 1), 16);
+
+      /* Prepare for next 16 width column */
+      src0 = src1;
+      src1 = src2;
+      src2 = LD_SB(input_data[row] + col + 32);
+    }
+
+    /* Re-substitute last pixel */
+    *(dst[row] + 2 * width - 1) = *(input_data[row] + width - 1);
+  }
+}
+
+/*
+ * Fancy processing for the common case of 2:1 horizontal and 2:1 vertical.
+ * Again a triangle filter; see comments for h2v1 case, above.
+ *
+ * It is OK for us to reference the adjacent input rows because we demanded
+ * context from the main buffer controller (see initialization code).
+ */
+GLOBAL(void)
+jsimd_h2v2_fancy_upsample_msa(int max_v_samp_factor,
+                              JDIMENSION downsampled_width,
+                              JSAMPARRAY input_data,
+                              JSAMPARRAY *output_data_ptr)
+{
+  JDIMENSION col, width = downsampled_width;
+  JSAMPARRAY dst = *output_data_ptr;
+  int inrow = 0, outrow = 0;
+  JSAMPROW inptr0, inptr1, inptr2, outptr0, outptr1;
+  v8i16 lastcolsum0_r, lastcolsum0_l, lastcolsum1_r, lastcolsum1_l;
+  v8i16 thiscolsum0_l, thiscolsum0_r, thiscolsum1_r, thiscolsum1_l;
+  v8i16 nextcolsum0_r, nextcolsum0_l, nextcolsum1_r, nextcolsum1_l;
+  v8i16 dst00_r, dst00_l, dst01_r, dst01_l;
+  v8i16 dst10_r, dst10_l, dst11_r, dst11_l;
+  v8i16 cur0_r, cur1_r, cur2_r, cur0_l, cur1_l, cur2_l;
+  v8i16 const_3 = __msa_ldi_h(3);
+  v16i8 tmp0_l, tmp1_l, tmp2_l, tmp0_r, tmp1_r, tmp2_r, zero = { 0 };
+  v16i8 left0, left1, left2, cur0, cur1, cur2, right0, right1, right2;
+  v16i8 dst00, dst01, dst10, dst11, out00, out01, out10, out11;
+
+  while (outrow < max_v_samp_factor) {
+    /* Current row; Nearest to output pixel */
+    inptr0 = input_data[inrow];
+
+    /* Above row */
+    inptr1 = input_data[inrow - 1];
+    /* Below row */
+    inptr2 = input_data[inrow + 1];
+
+    /* Output pointers */
+    outptr0 = dst[outrow];
+    outptr1 = dst[outrow + 1];
+
+    cur0 = LD_SB(inptr0);
+    cur1 = LD_SB(inptr1);
+    cur2 = LD_SB(inptr2);
+    tmp0_r = LD_SB(inptr0 + 16);
+    tmp1_r = LD_SB(inptr1 + 16);
+    tmp2_r = LD_SB(inptr2 + 16);
+    tmp0_l = __msa_splati_b(cur0, 0);
+    tmp1_l = __msa_splati_b(cur1, 0);
+    tmp2_l = __msa_splati_b(cur2, 0);
+
+    for (col = 0; col < width; col += 16) {
+      left0 = __msa_sldi_b(cur0, tmp0_l, 15); /* -1 0 1 2 ... 12 13 14 */
+      left1 = __msa_sldi_b(cur1, tmp1_l, 15); /* -1 0 1 2 ... 12 13 14 */
+      left2 = __msa_sldi_b(cur2, tmp2_l, 15); /* -1 0 1 2 ... 12 13 14 */
+      right0 = __msa_sldi_b(tmp0_r, cur0, 1); /* 1 2 3 4 ... 14 15 16 */
+      right1 = __msa_sldi_b(tmp1_r, cur1, 1); /* 1 2 3 4 ... 14 15 16 */
+      right2 = __msa_sldi_b(tmp2_r, cur2, 1); /* 1 2 3 4 ... 14 15 16 */
+
+      ILVRL_B2_SH(zero, left0, cur0_r, cur0_l);
+      ILVRL_B2_SH(zero, left1, cur1_r, cur1_l);
+      ILVRL_B2_SH(zero, left2, cur2_r, cur2_l);
+      cur0_r *= const_3;
+      cur0_l *= const_3;
+      lastcolsum0_r = cur0_r + cur1_r;
+      lastcolsum1_r = cur0_r + cur2_r;
+      lastcolsum0_l = cur0_l + cur1_l;
+      lastcolsum1_l = cur0_l + cur2_l;
+
+      ILVRL_B2_SH(zero, cur0, cur0_r, cur0_l);
+      ILVRL_B2_SH(zero, cur1, cur1_r, cur1_l);
+      ILVRL_B2_SH(zero, cur2, cur2_r, cur2_l);
+      cur0_r *= const_3;
+      cur0_l *= const_3;
+      thiscolsum0_r = cur0_r + cur1_r;
+      thiscolsum1_r = cur0_r + cur2_r;
+      thiscolsum0_l = cur0_l + cur1_l;
+      thiscolsum1_l = cur0_l + cur2_l;
+
+      ILVRL_B2_SH(zero, right0, cur0_r, cur0_l);
+      ILVRL_B2_SH(zero, right1, cur1_r, cur1_l);
+      ILVRL_B2_SH(zero, right2, cur2_r, cur2_l);
+      cur0_r *= const_3;
+      cur0_l *= const_3;
+      nextcolsum0_r = cur0_r + cur1_r;
+      nextcolsum1_r = cur0_r + cur2_r;
+      nextcolsum0_l = cur0_l + cur1_l;
+      nextcolsum1_l = cur0_l + cur2_l;
+
+      /* Prepare for next 16 width column */
+      tmp0_l = cur0;
+      tmp1_l = cur1;
+      tmp2_l = cur2;
+      cur0 = tmp0_r;
+      cur1 = tmp1_r;
+      cur2 = tmp2_r;
+      tmp0_r = LD_SB(inptr0 + col + 32);
+      tmp1_r = LD_SB(inptr1 + col + 32);
+      tmp2_r = LD_SB(inptr2 + col + 32);
+
+      /* outptr0 */
+      dst00_r = MSA_ADDVI_H(thiscolsum0_r * const_3 + lastcolsum0_r, 8);
+      dst00_l = MSA_ADDVI_H(thiscolsum0_l * const_3 + lastcolsum0_l, 8);
+      dst01_r = MSA_ADDVI_H(thiscolsum0_r * const_3 + nextcolsum0_r, 7);
+      dst01_l = MSA_ADDVI_H(thiscolsum0_l * const_3 + nextcolsum0_l, 7);
+      dst00_r = MSA_SRAI_H(dst00_r, 4);
+      dst00_l = MSA_SRAI_H(dst00_l, 4);
+      dst01_r = MSA_SRAI_H(dst01_r, 4);
+      dst01_l = MSA_SRAI_H(dst01_l, 4);
+
+      /* outptr1 */
+      dst10_r = MSA_ADDVI_H(thiscolsum1_r * const_3 + lastcolsum1_r, 8);
+      dst10_l = MSA_ADDVI_H(thiscolsum1_l * const_3 + lastcolsum1_l, 8);
+      dst11_r = MSA_ADDVI_H(thiscolsum1_r * const_3 + nextcolsum1_r, 7);
+      dst11_l = MSA_ADDVI_H(thiscolsum1_l * const_3 + nextcolsum1_l, 7);
+      dst10_r = MSA_SRAI_H(dst10_r, 4);
+      dst10_l = MSA_SRAI_H(dst10_l, 4);
+      dst11_r = MSA_SRAI_H(dst11_r, 4);
+      dst11_l = MSA_SRAI_H(dst11_l, 4);
+
+      /* Pack */
+      PCKEV_B2_SB(dst00_l, dst00_r, dst01_l, dst01_r, dst00, dst01);
+      PCKEV_B2_SB(dst10_l, dst10_r, dst11_l, dst11_r, dst10, dst11);
+
+      /* Interleave and Store */
+      ILVRL_B2_SB(dst01, dst00, out00, out01);
+      ILVRL_B2_SB(dst11, dst10, out10, out11);
+
+      ST_SB2(out00, out01, (outptr0 + 2 * col), 16);
+      ST_SB2(out10, out11, (outptr1 + 2 * col), 16);
+    }
+
+    /* Special case for last column */
+    outptr0[2 * width - 1] = (uint8_t)((((int)(inptr0[width - 1]) * 3 +
+                             (int)(inptr1[width - 1])) * 4 + 7) >> 4);
+    outptr1[2 * width - 1] = (uint8_t)((((int)(inptr0[width - 1]) * 3 +
+                             (int)(inptr2[width - 1])) * 4 + 7) >> 4);
+
+    /* Update input and output pointers */
+    inrow++;
+    outrow += 2;
+  }
+}
+
+GLOBAL(void)
+jsimd_h2v1_upsample_msa(int max_v_samp_factor,
+                        JDIMENSION output_width,
+                        JSAMPARRAY input_data,
+                        JSAMPARRAY *output_data_ptr)
+{
+  JSAMPROW inptr, inptr1, outptr, outptr1, out32end, out64end;
+  JDIMENSION inrow, out_width = (output_width + 31) & (~31);
+  JSAMPARRAY dst = *output_data_ptr;
+  v16u8 src0, src1, src2, src3;
+  v16u8 dst0_l, dst0_r, dst1_l, dst1_r, dst2_l, dst2_r, dst3_l, dst3_r;
+
+  inrow = 0;
+
+  /* Height multiple of 2 */
+  for (; inrow < (max_v_samp_factor & ~1); inrow += 2) {
+    inptr = input_data[inrow];
+    inptr1 = input_data[inrow + 1];
+    outptr = dst[inrow];
+    outptr1 = dst[inrow + 1];
+    out32end = outptr + out_width;
+    out64end = outptr + ((out_width >> 6) << 6);
+
+    src0 = LD_UB(inptr);
+    src2 = LD_UB(inptr + output_width);
+
+    while (outptr < out64end) {
+      src1 = LD_UB(inptr + 16);
+      src3 = LD_UB(inptr1 + 16);
+      ILVRL_B2_UB(src0, src0, dst0_r, dst0_l);
+      ILVRL_B2_UB(src1, src1, dst1_r, dst1_l);
+      ILVRL_B2_UB(src2, src2, dst2_r, dst2_l);
+      ILVRL_B2_UB(src3, src3, dst3_r, dst3_l);
+      ST_UB4(dst0_r, dst0_l, dst1_r, dst1_l, outptr, 16);
+      ST_UB4(dst2_r, dst2_l, dst3_r, dst3_l, outptr1, 16);
+      inptr += 32;
+      inptr1 += 32;
+      outptr += 64;
+      outptr1 += 64;
+
+      src0 = LD_UB(inptr);
+      src2 = LD_UB(inptr1);
+    }
+
+    if (out32end > out64end) {
+      ILVRL_B2_UB(src0, src0, dst0_r, dst0_l);
+      ILVRL_B2_UB(src2, src2, dst2_r, dst2_l);
+      ST_UB2(dst0_r, dst0_l, outptr, 16);
+      ST_UB2(dst2_r, dst2_l, outptr1, 16);
+    }
+  }
+
+  /* Remaining row */
+  if (inrow < max_v_samp_factor) {
+    inptr = input_data[inrow];
+    outptr = dst[inrow];
+    out32end = outptr + out_width;
+    out64end = outptr + ((out_width >> 6) << 6);
+
+    src0 = LD_UB(inptr);
+
+    while (outptr < out64end) {
+      src1 = LD_UB(inptr + 16);
+      ILVRL_B2_UB(src0, src0, dst0_r, dst0_l);
+      ILVRL_B2_UB(src1, src1, dst1_r, dst1_l);
+      ST_UB4(dst0_r, dst0_l, dst1_r, dst1_l, outptr, 16);
+      inptr += 32;
+      outptr += 64;
+
+      src0 = LD_UB(inptr);
+    }
+
+    if (out32end > out64end) {
+      ILVRL_B2_UB(src0, src0, dst0_r, dst0_l);
+      ST_UB2(dst0_r, dst0_l, outptr, 16);
+    }
+  }
+}
+
+GLOBAL(void)
+jsimd_h2v2_upsample_msa(int max_v_samp_factor,
+                        JDIMENSION output_width,
+                        JSAMPARRAY input_data,
+                        JSAMPARRAY *output_data_ptr)
+{
+  JSAMPROW inptr, outptr;
+  JDIMENSION out_width = (output_width + 31) & (~31);
+  JSAMPARRAY dst = *output_data_ptr;
+  JSAMPROW out32end, out64end;
+  int inrow, outrow;
+  v16u8 src0, src1, dst0_l, dst0_r, dst1_l, dst1_r;
+
+  inrow = outrow = 0;
+
+  while (outrow < max_v_samp_factor) {
+    inptr = input_data[inrow];
+    outptr = dst[outrow];
+    out32end = outptr + out_width;
+    out64end = outptr + ((out_width >> 6) << 6);
+
+    src0 = LD_UB(inptr);
+
+    while (outptr < out64end) {
+      src1 = LD_UB(inptr + 16);
+      ILVRL_B2_UB(src0, src0, dst0_r, dst0_l);
+      ILVRL_B2_UB(src1, src1, dst1_r, dst1_l);
+      ST_UB4(dst0_r, dst0_l, dst1_r, dst1_l, outptr, 16);
+      ST_UB4(dst0_r, dst0_l, dst1_r, dst1_l, outptr + out_width, 16);
+      inptr += 32;
+      outptr += 64;
+
+      src0 = LD_UB(inptr);
+    }
+
+    if (out32end > out64end) {
+      ILVRL_B2_UB(src0, src0, dst0_r, dst0_l);
+      ST_UB2(dst0_r, dst0_l, outptr, 16);
+      ST_UB2(dst0_r, dst0_l, outptr + out_width, 16);
+      inptr += 16;
+      outptr += 32;
+    }
+
+    inrow++;
+    outrow += 2;
+  }
+}

--- a/simd/mips/jfdctfst_msa.c
+++ b/simd/mips/jfdctfst_msa.c
@@ -1,0 +1,123 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#define JPEG_INTERNALS
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "../../jsimd.h"
+#include "../../jdct.h"
+#include "../jsimd.h"
+#include "jmacros_msa.h"
+
+
+#define FIX_0_382683433       ((int32_t)( 98 * 256))  /* FIX(0.382683433) */
+#define FIX_0_541196100_fast  ((int32_t)(139 * 256))  /* FIX(0.541196100) */
+#define FIX_0_707106781       ((int32_t)(181 * 256))  /* FIX(0.707106781) */
+#define FIX_1_306562965       ((int32_t)(334 * 256))  /* FIX(1.306562965) */
+
+/* Do one pass of FDCT_IFAST */
+#define FDCT_IFAST_1PASS(val0, val1, val2, val3, val4, val5, val6, val7, \
+dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7, const0) { \
+  v8i16 tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7; \
+  v8i16 tmp10, tmp11, tmp12, tmp13; \
+  v8i16 z1, z2, z3, z4, z5, z11, z13; \
+  v4i32 z1_r, z1_l, z2_r, z2_l, z3_r, z3_l, z4_r, z4_l, z5_r, z5_l; \
+  \
+  BUTTERFLY_8(val0, val1, val2, val3, val4, val5, val6, val7, \
+              tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7); \
+  \
+  BUTTERFLY_4(tmp0, tmp1, tmp2, tmp3, tmp10, tmp11, tmp12, tmp13); \
+  \
+  dst0 = tmp10 + tmp11; \
+  dst4 = tmp10 - tmp11; \
+  \
+  tmp12 = tmp12 + tmp13; \
+  UNPCK_SH_SW(tmp12, z1_r, z1_l); \
+  z1_r = z1_r * __msa_splati_w(const0, 0); \
+  z1_l = z1_l * __msa_splati_w(const0, 0); \
+  z1 = __msa_pckod_h((v8i16)z1_l, (v8i16)z1_r); \
+  \
+  dst2 = tmp13 + z1; \
+  dst6 = tmp13 - z1; \
+  \
+  /* Odd part */ \
+  tmp10 = tmp4 + tmp5; \
+  tmp11 = tmp5 + tmp6; \
+  tmp12 = tmp6 + tmp7; \
+  z5 = tmp10 - tmp12; \
+  \
+  UNPCK_SH4_SW(z5, tmp10, tmp12, tmp11, z5_r, z5_l, z2_r, z2_l, \
+               z4_r, z4_l, z3_r, z3_l); \
+  \
+  z5_r = z5_r * __msa_splati_w(const0, 1); \
+  z5_l = z5_l * __msa_splati_w(const0, 1); \
+  z2_r = z2_r * __msa_splati_w(const0, 2); \
+  z2_l = z2_l * __msa_splati_w(const0, 2); \
+  z4_r = z4_r * __msa_splati_w(const0, 3); \
+  z4_l = z4_l * __msa_splati_w(const0, 3); \
+  z3_r = z3_r * __msa_splati_w(const0, 0); \
+  z3_l = z3_l * __msa_splati_w(const0, 0); \
+  \
+  /* Descale */ \
+  PCKOD_H2_SH(z5_l, z5_r, z2_l, z2_r, z5, z2); \
+  PCKOD_H2_SH(z4_l, z4_r, z3_l, z3_r, z4, z3); \
+  ADD2(z2, z5, z4, z5, z2, z4); \
+  \
+  z11 = tmp7 + z3; \
+  z13 = tmp7 - z3; \
+  \
+  dst5 = z13 + z2; \
+  dst3 = z13 - z2; \
+  dst1 = z11 + z4; \
+  dst7 = z11 - z4; \
+}
+
+GLOBAL(void)
+jsimd_fdct_ifast_msa(DCTELEM *data)
+{
+  v8i16 val0, val1, val2, val3, val4, val5, val6, val7;
+  v8i16 dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7;
+  v4i32 const0 = { FIX_0_707106781, FIX_0_382683433,
+                   FIX_0_541196100_fast, FIX_1_306562965
+                 };
+
+  /* Load 8 rows */
+  LD_SH8(data, DCTSIZE, val0, val1, val2, val3, val4, val5, val6, val7);
+
+  /* Pass1 */
+  /* Transpose */
+  TRANSPOSE8x8_SH_SH(val0, val1, val2, val3, val4, val5, val6, val7,
+                     val0, val1, val2, val3, val4, val5, val6, val7);
+  FDCT_IFAST_1PASS(val0, val1, val2, val3, val4, val5, val6, val7,
+                   dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7, const0);
+
+  /* Pass 2 */
+  /* Transpose */
+  TRANSPOSE8x8_SH_SH(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7,
+                     val0, val1, val2, val3, val4, val5, val6, val7);
+  FDCT_IFAST_1PASS(val0, val1, val2, val3, val4, val5, val6, val7,
+                   dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7, const0);
+
+  /* Store transformed data */
+  ST_SH8(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7, data, 8);
+}

--- a/simd/mips/jfdctint_msa.c
+++ b/simd/mips/jfdctint_msa.c
@@ -1,0 +1,222 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#define JPEG_INTERNALS
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "../../jsimd.h"
+#include "../../jdct.h"
+#include "../jsimd.h"
+#include "jmacros_msa.h"
+
+
+#define CONST_BITS  13
+#define PASS1_BITS  2
+
+#define FIX_0_298631336  ((int32_t)2446)   /* FIX(0.298631336) */
+#define FIX_0_390180644  ((int32_t)3196)   /* FIX(0.390180644) */
+#define FIX_0_541196100  ((int32_t)4433)   /* FIX(0.541196100) */
+#define FIX_0_765366865  ((int32_t)6270)   /* FIX(0.765366865) */
+#define FIX_0_899976223  ((int32_t)7373)   /* FIX(0.899976223) */
+#define FIX_1_175875602  ((int32_t)9633)   /* FIX(1.175875602) */
+#define FIX_1_501321110  ((int32_t)12299)  /* FIX(1.501321110) */
+#define FIX_1_847759065  ((int32_t)15137)  /* FIX(1.847759065) */
+#define FIX_1_961570560  ((int32_t)16069)  /* FIX(1.961570560) */
+#define FIX_2_053119869  ((int32_t)16819)  /* FIX(2.053119869) */
+#define FIX_2_562915447  ((int32_t)20995)  /* FIX(2.562915447) */
+#define FIX_3_072711026  ((int32_t)25172)  /* FIX(3.072711026) */
+
+/* Local macros */
+#define FDCT_ISLOW_ODD_MULTIPLY(in0, in1, in2, in3, in4, in5, in6, in7, in8, \
+in9, in10, in11, in12, in13, in14, in15, const0, const1) \
+  in0 = in0 * __msa_splati_w(const0, 0); \
+  in1 = in1 * __msa_splati_w(const0, 0); \
+  in2 = in2 * __msa_splati_w(const0, 1); \
+  in3 = in3 * __msa_splati_w(const0, 1); \
+  in4 = in4 * __msa_splati_w(const0, 2); \
+  in5 = in5 * __msa_splati_w(const0, 2); \
+  in6 = in6 * __msa_splati_w(const0, 3); \
+  in7 = in7 * __msa_splati_w(const0, 3); \
+  in8 = in8 * __msa_splati_w(const1, 0); \
+  in9 = in9 * __msa_splati_w(const1, 0); \
+  in10 = in10 * __msa_splati_w(const1, 1); \
+  in11 = in11 * __msa_splati_w(const1, 1); \
+  in12 = in12 * __msa_splati_w(const1, 2); \
+  in13 = in13 * __msa_splati_w(const1, 2); \
+  in14 = in14 * __msa_splati_w(const1, 3); \
+  in15 = in15 * __msa_splati_w(const1, 3);
+
+GLOBAL(void)
+jsimd_fdct_islow_msa(DCTELEM *data)
+{
+  v8i16 val0, val1, val2, val3, val4, val5, val6, val7;
+  v8i16 tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7;
+  v4i32 tmp4_r, tmp5_r, tmp6_r, tmp7_r, tmp4_l, tmp5_l, tmp6_l, tmp7_l;
+  v8i16 tmp10, tmp11, tmp12, tmp13;
+  v8i16 dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7;
+  v4i32 z1_r, z1_l, z2_r, z2_l, z3_r, z3_l, z4_r, z4_l;
+  v4i32 z5_r, z5_l, z12_r, z12_l, z13_r, z13_l;
+  v4i32 const0 =
+    { FIX_0_298631336, FIX_2_053119869, FIX_3_072711026, FIX_1_501321110 };
+  v4i32 const1 =
+    { -FIX_0_899976223, -FIX_2_562915447, -FIX_1_961570560, -FIX_0_390180644 };
+  v4i32 const2 =
+    { FIX_0_541196100, -FIX_1_847759065, FIX_0_765366865, FIX_1_175875602 };
+
+  /* Load 8 rows */
+  LD_SH8(data, DCTSIZE, val0, val1, val2, val3, val4, val5, val6, val7);
+
+  /* Pass1 */
+  /* Transpose */
+  TRANSPOSE8x8_SH_SH(val0, val1, val2, val3, val4, val5, val6, val7,
+                     val0, val1, val2, val3, val4, val5, val6, val7);
+
+  BUTTERFLY_8(val0, val1, val2, val3, val4, val5, val6, val7,
+              tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7);
+
+  BUTTERFLY_4(tmp0, tmp1, tmp2, tmp3, tmp10, tmp11, tmp12, tmp13);
+
+  dst0 = MSA_SLLI_H((tmp10 + tmp11), PASS1_BITS);
+  dst4 = MSA_SLLI_H((tmp10 - tmp11), PASS1_BITS);
+
+  UNPCK_SH_SW(tmp12, z12_r, z12_l);
+  UNPCK_SH_SW(tmp13, z13_r, z13_l);
+
+  tmp12 = tmp12 + tmp13;
+  UNPCK_SH_SW(tmp12, z1_r, z1_l);
+
+  z1_r = z1_r * __msa_splati_w(const2, 0);
+  z1_l = z1_l * __msa_splati_w(const2, 0);
+
+  z12_r = z1_r + z12_r * __msa_splati_w(const2, 1);
+  z12_l = z1_l + z12_l * __msa_splati_w(const2, 1);
+  z13_r = z1_r + z13_r * __msa_splati_w(const2, 2);
+  z13_l = z1_l + z13_l * __msa_splati_w(const2, 2);
+
+  /* Descale */
+  SRARI_W4_SW(z12_l, z12_r, z13_l, z13_r, (CONST_BITS - PASS1_BITS));
+  PCKEV_H2_SH(z12_l, z12_r, z13_l, z13_r, dst6, dst2);
+
+  ADD4(tmp4, tmp7, tmp5, tmp6, tmp4, tmp6, tmp5, tmp7,
+       tmp10, tmp11, tmp12, tmp13);
+
+  UNPCK_SH4_SW(tmp10, tmp11, tmp12, tmp13, z1_r, z1_l, z2_r, z2_l, z3_r, z3_l,
+               z4_r, z4_l);
+  ADD2(z3_r, z4_r, z3_l, z4_l, z5_r, z5_l);
+
+  z5_r = z5_r * __msa_splati_w(const2, 3);
+  z5_l = z5_l * __msa_splati_w(const2, 3);
+
+  UNPCK_SH4_SW(tmp4, tmp5, tmp6, tmp7, tmp4_r, tmp4_l, tmp5_r, tmp5_l,
+               tmp6_r, tmp6_l, tmp7_r, tmp7_l);
+  FDCT_ISLOW_ODD_MULTIPLY(tmp4_r, tmp4_l, tmp5_r, tmp5_l, tmp6_r, tmp6_l,
+                          tmp7_r, tmp7_l, z1_r, z1_l, z2_r, z2_l, z3_r, z3_l,
+                          z4_r, z4_l, const0, const1);
+
+  ADD4(z3_r, z5_r, z3_l, z5_l, z4_r, z5_r, z4_l, z5_l,
+       z3_r, z3_l, z4_r, z4_l);
+
+  tmp4_r += z1_r + z3_r;
+  tmp5_r += z2_r + z4_r;
+  tmp6_r += z2_r + z3_r;
+  tmp7_r += z1_r + z4_r;
+  tmp4_l += z1_l + z3_l;
+  tmp5_l += z2_l + z4_l;
+  tmp6_l += z2_l + z3_l;
+  tmp7_l += z1_l + z4_l;
+
+  /* Descale */
+  SRARI_W4_SW(tmp4_r, tmp5_r, tmp6_r, tmp7_r, (CONST_BITS - PASS1_BITS));
+  SRARI_W4_SW(tmp4_l, tmp5_l, tmp6_l, tmp7_l, (CONST_BITS - PASS1_BITS));
+  PCKEV_H2_SH(tmp4_l, tmp4_r, tmp5_l, tmp5_r, dst7, dst5);
+  PCKEV_H2_SH(tmp6_l, tmp6_r, tmp7_l, tmp7_r, dst3, dst1);
+
+  /* Pass 2 */
+
+  /* Transpose */
+  TRANSPOSE8x8_SH_SH(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7,
+                     val0, val1, val2, val3, val4, val5, val6, val7);
+
+  BUTTERFLY_8(val0, val1, val2, val3, val4, val5, val6, val7,
+              tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7);
+
+  BUTTERFLY_4(tmp0, tmp1, tmp2, tmp3, tmp10, tmp11, tmp12, tmp13);
+
+  dst0 = tmp10 + tmp11;
+  dst4 = tmp10 - tmp11;
+  SRARI_H2_SH(dst0, dst4, PASS1_BITS);
+
+  tmp10 = tmp12 + tmp13;
+  UNPCK_SH_SW(tmp10, z1_r, z1_l);
+
+  z1_r = z1_r * __msa_splati_w(const2, 0);
+  z1_l = z1_l * __msa_splati_w(const2, 0);
+
+  UNPCK_SH_SW(tmp12, z12_r, z12_l);
+  UNPCK_SH_SW(tmp13, z13_r, z13_l);
+
+  z12_r = z1_r + z12_r * __msa_splati_w(const2, 1);
+  z12_l = z1_l + z12_l * __msa_splati_w(const2, 1);
+  z13_r = z1_r + z13_r * __msa_splati_w(const2, 2);
+  z13_l = z1_l + z13_l * __msa_splati_w(const2, 2);
+
+  /* Descale */
+  SRARI_W4_SW(z12_l, z12_r, z13_l, z13_r, (CONST_BITS + PASS1_BITS));
+  PCKEV_H2_SH(z12_l, z12_r, z13_l, z13_r, dst6, dst2);
+
+  ADD4(tmp4, tmp7, tmp5, tmp6, tmp4, tmp6, tmp5, tmp7,
+       tmp10, tmp11, tmp12, tmp13);
+
+  UNPCK_SH4_SW(tmp10, tmp11, tmp12, tmp13, z1_r, z1_l, z2_r, z2_l, z3_r, z3_l,
+               z4_r, z4_l);
+  ADD2(z3_r, z4_r, z3_l, z4_l, z5_r, z5_l);
+
+  z5_r = z5_r * __msa_splati_w(const2, 3);
+  z5_l = z5_l * __msa_splati_w(const2, 3);
+
+  UNPCK_SH4_SW(tmp4, tmp5, tmp6, tmp7, tmp4_r, tmp4_l, tmp5_r, tmp5_l,
+               tmp6_r, tmp6_l, tmp7_r, tmp7_l);
+  FDCT_ISLOW_ODD_MULTIPLY(tmp4_r, tmp4_l, tmp5_r, tmp5_l, tmp6_r, tmp6_l,
+                          tmp7_r, tmp7_l, z1_r, z1_l, z2_r, z2_l, z3_r, z3_l,
+                          z4_r, z4_l, const0, const1);
+
+  ADD4(z3_r, z5_r, z3_l, z5_l, z4_r, z5_r, z4_l, z5_l,
+       z3_r, z3_l, z4_r, z4_l);
+
+  tmp4_r += z1_r + z3_r;
+  tmp5_r += z2_r + z4_r;
+  tmp6_r += z2_r + z3_r;
+  tmp7_r += z1_r + z4_r;
+  tmp4_l += z1_l + z3_l;
+  tmp5_l += z2_l + z4_l;
+  tmp6_l += z2_l + z3_l;
+  tmp7_l += z1_l + z4_l;
+
+  /* Descale */
+  SRARI_W4_SW(tmp4_r, tmp5_r, tmp6_r, tmp7_r, (CONST_BITS + PASS1_BITS));
+  SRARI_W4_SW(tmp4_l, tmp5_l, tmp6_l, tmp7_l, (CONST_BITS + PASS1_BITS));
+  PCKEV_H2_SH(tmp4_l, tmp4_r, tmp5_l, tmp5_r, dst7, dst5);
+  PCKEV_H2_SH(tmp6_l, tmp6_r, tmp7_l, tmp7_r, dst3, dst1);
+
+  ST_SH8(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7, data, 8);
+}

--- a/simd/mips/jidctfst_msa.c
+++ b/simd/mips/jidctfst_msa.c
@@ -1,0 +1,236 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#define JPEG_INTERNALS
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "../../jsimd.h"
+#include "../../jdct.h"
+#include "../../jsimddct.h"
+#include "../jsimd.h"
+#include "jmacros_msa.h"
+
+
+#define DCTSIZE          8
+#define PASS1_BITS       2
+#define CONST_BITS_FAST  8
+
+#define FIX_1_082392200       ((int32_t)277)  /* FIX(1.082392200) */
+#define FIX_1_414213562       ((int32_t)362)  /* FIX(1.414213562) */
+#define FIX_1_847759065_fast  ((int32_t)473)  /* FIX(1.847759065) */
+#define FIX_2_613125930       ((int32_t)669)  /* FIX(2.613125930) */
+
+GLOBAL(void)
+jsimd_idct_ifast_msa(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                     JCOEFPTR coef_block, JSAMPARRAY output_buf,
+                     JDIMENSION output_col)
+{
+  v16u8 res0, res1, res2, res3, res4, res5, res6, res7;
+  v8i16 val0, val1, val2, val3, val4, val5, val6, val7;
+  v8i16 dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7;
+  v8i16 quant0, quant1, quant2, quant3, quant4, quant5, quant6, quant7;
+  v8i16 tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7;
+  v8i16 tmp10, tmp11, tmp12, tmp13, tmp14;
+  v8i16 z5, z10, z11, z12, z13;
+  v4i32 z5_r, z5_l, z12_r, z12_l, z10_r, z10_l;
+  v4i32 tmp11_r, tmp11_l, tmp12_r, tmp12_l;
+  v8i16 reg_128 = __msa_ldi_h(128);
+  v4i32 tmp, tmp_r;
+  JCOEFPTR quantptr = compptr->dct_table;
+  v4i32 const0 = { FIX_1_414213562, FIX_1_847759065_fast,
+                   FIX_1_082392200, -FIX_2_613125930
+                 };
+
+  /* Dequantize */
+  LD_SH8(coef_block, DCTSIZE, val0, val1, val2, val3, val4, val5, val6, val7);
+
+  /* Handle 0 AC terms */
+  tmp_r = (v4i32)(val1 | val2 | val3 | val4 | val5 | val6 | val7);
+  if (__msa_test_bz_v((v16u8)tmp_r)) {
+    quant0 = LD_SH(quantptr);
+
+    tmp0 = val0 * quant0;
+    SPLATI_H4_SH(tmp0, 0, 1, 2, 3, dst0, dst1, dst2, dst3);
+    SPLATI_H4_SH(tmp0, 4, 5, 6, 7, dst4, dst5, dst6, dst7);
+  } else { /* if (!__msa_test_bz_v((v16u8)tmp_r)) */
+    /* Pass 1: process columns. */
+    /* Note results are scaled up by sqrt(8) compared to a true IDCT; */
+    /* furthermore, we scale the results by 2**PASS1_BITS. */
+    LD_SH8(quantptr, DCTSIZE, quant0, quant1, quant2, quant3,
+           quant4, quant5, quant6, quant7);
+    MUL4(val0, quant0, val1, quant1, val2, quant2, val3, quant3,
+         val0, val1, val2, val3);
+    MUL4(val4, quant4, val5, quant5, val6, quant6, val7, quant7,
+         val4, val5, val6, val7);
+
+    /* Even Part */
+    BUTTERFLY_4(val0, val2, val6, val4, tmp10, tmp13, tmp12, tmp11);
+
+    tmp = __msa_splati_w(const0, 0);
+    tmp14 = val2 - val6;
+    UNPCK_SH_SW(tmp14, tmp12_r, tmp12_l);
+    MUL2(tmp12_r, tmp, tmp12_l, tmp, tmp12_r, tmp12_l);
+    tmp12_r = MSA_SRAI_W(tmp12_r, CONST_BITS_FAST);
+    tmp12_l = MSA_SRAI_W(tmp12_l, CONST_BITS_FAST);
+    tmp12 = __msa_pckev_h((v8i16)tmp12_l, (v8i16)tmp12_r);
+    tmp12 = tmp12 - tmp13;
+
+    BUTTERFLY_4(tmp10, tmp11, tmp12, tmp13, tmp0, tmp1, tmp2, tmp3);
+
+    /* Odd Part */
+    BUTTERFLY_4(val5, val1, val7, val3, z13, z11, z12, z10);
+
+    tmp7 = z11 + z13;
+
+    /* tmp11 = MULTIPLY(z11 - z13, FIX_1_414213562); */
+    tmp14 = z11 - z13;
+    UNPCK_SH_SW(tmp14, tmp11_r, tmp11_l);
+    MUL2(tmp11_r, tmp, tmp11_l, tmp, tmp11_r, tmp11_l);
+    tmp11_r = MSA_SRAI_W(tmp11_r, CONST_BITS_FAST);
+    tmp11_l = MSA_SRAI_W(tmp11_l, CONST_BITS_FAST);
+    tmp11 = __msa_pckev_h((v8i16)tmp11_l, (v8i16)tmp11_r);
+
+    /* z5 = MULTIPLY(z10 + z12, FIX_1_847759065);  */
+    tmp = __msa_splati_w(const0, 1);
+    tmp14 = z10 + z12;
+    UNPCK_SH_SW(tmp14, z5_r, z5_l);
+    MUL2(z5_r, tmp, z5_l, tmp, z5_r, z5_l);
+    z5_r = MSA_SRAI_W(z5_r, CONST_BITS_FAST);
+    z5_l = MSA_SRAI_W(z5_l, CONST_BITS_FAST);
+    z5 = __msa_pckev_h((v8i16)z5_l, (v8i16)z5_r);
+
+    /* tmp10 = MULTIPLY(z12, FIX_1_082392200) - z5; */
+    tmp = __msa_splati_w(const0, 2);
+    UNPCK_SH_SW(z12, z12_r, z12_l);
+    MUL2(z12_r, tmp, z12_l, tmp, z12_r, z12_l);
+    z12_r = MSA_SRAI_W(z12_r, CONST_BITS_FAST);
+    z12_l = MSA_SRAI_W(z12_l, CONST_BITS_FAST);
+    tmp10 = __msa_pckev_h((v8i16)z12_l, (v8i16)z12_r);
+    tmp10 -= z5;
+
+    /* tmp12 = MULTIPLY(z10, -FIX_2_613125930) + z5; */
+    tmp = __msa_splati_w(const0, 3);
+    UNPCK_SH_SW(z10, z10_r, z10_l);
+    MUL2(z10_r, tmp, z10_l, tmp, z10_r, z10_l);
+    z10_r = MSA_SRAI_W(z10_r, CONST_BITS_FAST);
+    z10_l = MSA_SRAI_W(z10_l, CONST_BITS_FAST);
+    tmp12 = __msa_pckev_h((v8i16)z10_l, (v8i16)z10_r);
+    tmp12 += z5;
+
+    tmp6 = tmp12 - tmp7;        /* phase 2 */
+    tmp5 = tmp11 - tmp6;
+    tmp4 = tmp10 + tmp5;
+
+    BUTTERFLY_8(tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7,
+                dst0, dst1, dst2, dst4, dst3, dst5, dst6, dst7);
+
+    TRANSPOSE8x8_SH_SH(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7,
+                       dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7);
+  }
+
+  /* Pass 2: process rows. */
+  /* Even part */
+  BUTTERFLY_4(dst0, dst2, dst6, dst4, tmp10, tmp13, tmp12, tmp11);
+
+  /* tmp12 = MULTIPLY(dst2 - dst6, FIX_1_414213562) - tmp13;*/
+  tmp = __msa_splati_w(const0, 0);
+  tmp14 = dst2 - dst6;
+  UNPCK_SH_SW(tmp14, tmp12_r, tmp12_l);
+  MUL2(tmp12_r, tmp, tmp12_l, tmp, tmp12_r, tmp12_l);
+  tmp12_r = MSA_SRAI_W(tmp12_r, CONST_BITS_FAST);
+  tmp12_l = MSA_SRAI_W(tmp12_l, CONST_BITS_FAST);
+  tmp12 = __msa_pckev_h((v8i16)tmp12_l, (v8i16)tmp12_r);
+  tmp12 = tmp12 - tmp13;
+
+  BUTTERFLY_4(tmp10, tmp11, tmp12, tmp13, tmp0, tmp1, tmp2, tmp3);
+
+  /* Odd part */
+  BUTTERFLY_4(dst5, dst1, dst7, dst3, z13, z11, z12, z10);
+
+  tmp7 = z11 + z13;
+
+  /* tmp11 = MULTIPLY(z11 - z13, FIX_1_414213562); */
+  tmp14 = z11 - z13;
+  UNPCK_SH_SW(tmp14, tmp11_r, tmp11_l);
+  MUL2(tmp11_r, tmp, tmp11_l, tmp, tmp11_r, tmp11_l);
+  tmp11_r = MSA_SRAI_W(tmp11_r, CONST_BITS_FAST);
+  tmp11_l = MSA_SRAI_W(tmp11_l, CONST_BITS_FAST);
+  tmp11 = __msa_pckev_h((v8i16)tmp11_l, (v8i16)tmp11_r);
+
+  /* z5 = MULTIPLY(z10 + z12, FIX_1_847759065);  */
+  tmp = __msa_splati_w(const0, 1);
+  tmp14 = z10 + z12;
+  UNPCK_SH_SW(tmp14, z5_r, z5_l);
+  MUL2(z5_r, tmp, z5_l, tmp, z5_r, z5_l);
+  z5_r = MSA_SRAI_W(z5_r, CONST_BITS_FAST);
+  z5_l = MSA_SRAI_W(z5_l, CONST_BITS_FAST);
+  z5 = __msa_pckev_h((v8i16)z5_l, (v8i16)z5_r);
+
+  /* tmp10 = MULTIPLY(z12, FIX_1_082392200) - z5; */
+  tmp = __msa_splati_w(const0, 2);
+  UNPCK_SH_SW(z12, z12_r, z12_l);
+  MUL2(z12_r, tmp, z12_l, tmp, z12_r, z12_l);
+  z12_r = MSA_SRAI_W(z12_r, CONST_BITS_FAST);
+  z12_l = MSA_SRAI_W(z12_l, CONST_BITS_FAST);
+  tmp10 = __msa_pckev_h((v8i16)z12_l, (v8i16)z12_r);
+  tmp10 -= z5;
+
+  /* tmp12 = MULTIPLY(z10, -FIX_2_613125930) + z5; */
+  tmp = __msa_splati_w(const0, 3);
+  UNPCK_SH_SW(z10, z10_r, z10_l);
+  MUL2(z10_r, tmp, z10_l, tmp, z10_r, z10_l);
+  z10_r = MSA_SRAI_W(z10_r, CONST_BITS_FAST);
+  z10_l = MSA_SRAI_W(z10_l, CONST_BITS_FAST);
+  tmp12 = __msa_pckev_h((v8i16)z10_l, (v8i16)z10_r);
+  tmp12 += z5;
+
+  tmp6 = tmp12 - tmp7;        /* phase 2 */
+  tmp5 = tmp11 - tmp6;
+  tmp4 = tmp10 + tmp5;
+
+  dst0 = CLIP_SH_0_255(MSA_SRAI_H((tmp0 + tmp7), (PASS1_BITS + 3)) + reg_128);
+  dst7 = CLIP_SH_0_255(MSA_SRAI_H((tmp0 - tmp7), (PASS1_BITS + 3)) + reg_128);
+  dst1 = CLIP_SH_0_255(MSA_SRAI_H((tmp1 + tmp6), (PASS1_BITS + 3)) + reg_128);
+  dst6 = CLIP_SH_0_255(MSA_SRAI_H((tmp1 - tmp6), (PASS1_BITS + 3)) + reg_128);
+  dst2 = CLIP_SH_0_255(MSA_SRAI_H((tmp2 + tmp5), (PASS1_BITS + 3)) + reg_128);
+  dst5 = CLIP_SH_0_255(MSA_SRAI_H((tmp2 - tmp5), (PASS1_BITS + 3)) + reg_128);
+  dst4 = CLIP_SH_0_255(MSA_SRAI_H((tmp3 + tmp4), (PASS1_BITS + 3)) + reg_128);
+  dst3 = CLIP_SH_0_255(MSA_SRAI_H((tmp3 - tmp4), (PASS1_BITS + 3)) + reg_128);
+
+  PCKEV_B4_UB(dst0, dst0, dst1, dst1, dst2, dst2, dst3, dst3,
+              res0, res1, res2, res3);
+  PCKEV_B4_UB(dst4, dst4, dst5, dst5, dst6, dst6, dst7, dst7,
+              res4, res5, res6, res7);
+
+  TRANSPOSE8x8_UB_UB(res0, res1, res2, res3, res4, res5, res6, res7,
+                     res0, res1, res2, res3, res4, res5, res6, res7);
+
+  ST8x1_UB(res0, output_buf[0]);
+  ST8x1_UB(res1, output_buf[1]);
+  ST8x1_UB(res2, output_buf[2]);
+  ST8x1_UB(res3, output_buf[3]);
+  ST8x1_UB(res4, output_buf[4]);
+  ST8x1_UB(res5, output_buf[5]);
+  ST8x1_UB(res6, output_buf[6]);
+  ST8x1_UB(res7, output_buf[7]);
+}

--- a/simd/mips/jidctint_msa.c
+++ b/simd/mips/jidctint_msa.c
@@ -1,0 +1,380 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#define JPEG_INTERNALS
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "../../jsimd.h"
+#include "../../jdct.h"
+#include "../../jsimddct.h"
+#include "../jsimd.h"
+#include "jmacros_msa.h"
+
+
+#define DCTSIZE     8
+#define CONST_BITS  13
+#define PASS1_BITS  2
+
+#define FIX_0_298631336  ((int32_t)2446)   /* FIX(0.298631336) */
+#define FIX_0_390180644  ((int32_t)3196)   /* FIX(0.390180644) */
+#define FIX_0_541196100  ((int32_t)4433)   /* FIX(0.541196100) */
+#define FIX_0_765366865  ((int32_t)6270)   /* FIX(0.765366865) */
+#define FIX_0_899976223  ((int32_t)7373)   /* FIX(0.899976223) */
+#define FIX_1_175875602  ((int32_t)9633)   /* FIX(1.175875602) */
+#define FIX_1_501321110  ((int32_t)12299)  /* FIX(1.501321110) */
+#define FIX_1_847759065  ((int32_t)15137)  /* FIX(1.847759065) */
+#define FIX_1_961570560  ((int32_t)16069)  /* FIX(1.961570560) */
+#define FIX_2_053119869  ((int32_t)16819)  /* FIX(2.053119869) */
+#define FIX_2_562915447  ((int32_t)20995)  /* FIX(2.562915447) */
+#define FIX_3_072711026  ((int32_t)25172)  /* FIX(3.072711026) */
+
+GLOBAL(void)
+jsimd_idct_islow_msa(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                     JCOEFPTR coef_block, JSAMPARRAY output_buf,
+                     JDIMENSION output_col)
+{
+  v16u8 res0, res1, res2, res3, res4, res5, res6, res7;
+  v8i16 val0, val1, val2, val3, val4, val5, val6, val7;
+  v8i16 quant0, quant1, quant2, quant3, quant4, quant5, quant6, quant7;
+  v4i32 d0_r, d1_r, d2_r, d3_r, d4_r, d5_r, d6_r, d7_r;
+  v4i32 d0_l, d1_l, d2_l, d3_l, d4_l, d5_l, d6_l, d7_l;
+  v4i32 tmp_r, tmp_l, tmp2_r, tmp2_l, tmp3_r, tmp3_l, tmp0_r, tmp0_l, tmp1_r;
+  v4i32 tmp1_l, tmp10_r, tmp10_l, tmp11_r, tmp11_l, tmp12_r, tmp12_l;
+  v4i32 tmp13_r, tmp13_l, tmp, tmp1;
+  v4i32 z1_r, z1_l, z2_r, z2_l, z3_r, z3_l, z4_r, z4_l, z5_r, z5_l;
+  v4i32 dst0_r, dst1_r, dst2_r, dst3_r, dst4_r, dst5_r, dst6_r, dst7_r;
+  v4i32 dst0_l, dst1_l, dst2_l, dst3_l, dst4_l, dst5_l, dst6_l, dst7_l;
+  v8i16 reg_128 = __msa_ldi_h(128);
+  JCOEFPTR quantptr = compptr->dct_table;
+  v4i32 const0 =
+    { FIX_0_541196100, -FIX_1_847759065, FIX_0_765366865, FIX_1_175875602 };
+  v4i32 const1 =
+    { -FIX_0_899976223, -FIX_2_562915447, -FIX_1_961570560, -FIX_0_390180644 };
+  v4i32 const2 =
+    { FIX_0_298631336, FIX_2_053119869, FIX_3_072711026, FIX_1_501321110 };
+
+  /* Dequantize */
+  LD_SH8(coef_block, DCTSIZE, val0, val1, val2, val3, val4, val5, val6, val7);
+  quant0 = LD_SH(quantptr);
+  /* Handle 0 AC terms */
+  tmp_r = (v4i32)(val1 | val2 | val3 | val4 | val5 | val6 | val7);
+  if (__msa_test_bz_v((v16u8)tmp_r)) {
+    UNPCK_SH_SW(val0, d0_r, d0_l);
+    UNPCK_SH_SW(quant0, d2_r, d2_l);
+    MUL2(d0_r, d2_r, d0_l, d2_l, dst0_r, dst0_l);
+    dst0_r = MSA_SLLI_W(dst0_r, PASS1_BITS);
+    dst0_l = MSA_SLLI_W(dst0_l, PASS1_BITS);
+
+    SPLATI_W4_SW(dst0_r, d0_r, d1_r, d2_r, d3_r);
+    SPLATI_W4_SW(dst0_l, d4_r, d5_r, d6_r, d7_r);
+
+    d0_l = d0_r;
+    d1_l = d1_r;
+    d2_l = d2_r;
+    d3_l = d3_r;
+    d4_l = d4_r;
+    d5_l = d5_r;
+    d6_l = d6_r;
+    d7_l = d7_r;
+  } else { /* if (!__msa_test_bz_v((v16u8)tmp_r)) */
+    /* Pass 1: process columns. */
+    /* Note results are scaled up by sqrt(8) compared to a true IDCT; */
+    /* furthermore, we scale the results by 2**PASS1_BITS. */
+
+    LD_SH6(quantptr + DCTSIZE, DCTSIZE, quant1, quant2, quant3, quant4,
+           quant5, quant6);
+    quant7 = LD_SH(quantptr + 7 * DCTSIZE);
+    MUL4(val0, quant0, val1, quant1, val2, quant2, val3, quant3,
+         val0, val1, val2, val3);
+    MUL4(val4, quant4, val5, quant5, val6, quant6, val7, quant7,
+         val4, val5, val6, val7);
+
+    UNPCK_SH_SW(val0, d0_r, d0_l);
+    UNPCK_SH_SW(val2, d2_r, d2_l);
+    UNPCK_SH_SW(val4, d4_r, d4_l);
+    UNPCK_SH_SW(val6, d6_r, d6_l);
+
+    /* z1 = MULTIPLY(d2 + d6, FIX_0_541196100); */
+    tmp1 = __msa_splati_w(const0, 0);
+    ADD2(d2_r, d6_r, d2_l, d6_l, tmp_r, tmp_l);
+    MUL2(tmp_r, tmp1, tmp_l, tmp1, z1_r, z1_l);
+
+    /* tmp2 = z1 + MULTIPLY(-d6, FIX_1_847759065) */
+    tmp1 = __msa_splati_w(const0, 1);
+    MUL2(d6_r, tmp1, d6_l, tmp1, tmp2_r, tmp2_l);
+    ADD2(tmp2_r, z1_r, tmp2_l, z1_l, tmp2_r, tmp2_l);
+
+    /* tmp3 = z1 + MULTIPLY(d2, FIX_0_765366865); */
+    tmp1 = __msa_splati_w(const0, 2);
+    MUL2(d2_r, tmp1, d2_l, tmp1, tmp3_r, tmp3_l);
+    ADD2(tmp3_r, z1_r, tmp3_l, z1_l, tmp3_r, tmp3_l);
+    BUTTERFLY_4(d0_r, d0_l, d4_l, d4_r, tmp0_r, tmp0_l, tmp1_l, tmp1_r);
+
+    SLLI_W4_SW(tmp0_r, tmp0_l, tmp1_r, tmp1_l, CONST_BITS);
+
+    BUTTERFLY_8(tmp0_r, tmp0_l, tmp1_r, tmp1_l, tmp2_l, tmp2_r, tmp3_l, tmp3_r,
+                tmp10_r, tmp10_l, tmp11_r, tmp11_l, tmp12_l, tmp12_r, tmp13_l,
+                tmp13_r);
+
+    UNPCK_SH_SW(val1, d1_r, d1_l);
+    UNPCK_SH_SW(val3, d3_r, d3_l);
+    UNPCK_SH_SW(val5, d5_r, d5_l);
+    UNPCK_SH_SW(val7, d7_r, d7_l);
+    /* z1 = d7 + d1 */
+    /* z2 = d5 + d3 */
+    ADD4(d7_r, d1_r, d7_l, d1_l, d5_r, d3_r, d5_l, d3_l,
+         z1_r, z1_l, z2_r, z2_l);
+    /* z3 = d7 + d3 */
+    /* z4 = d5 + d1 */
+    ADD4(d7_r, d3_r, d7_l, d3_l, d5_r, d1_r, d5_l, d1_l,
+         z3_r, z3_l, z4_r, z4_l);
+    /* z5 = MULTIPLY(z3 + z4, FIX_1_175875602) */
+    tmp1 = __msa_splati_w(const0, 3);
+    ADD2(z3_r, z4_r, z3_l, z4_l, z5_r, z5_l);
+    MUL2(z5_r, tmp1, z5_l, tmp1, z5_r, z5_l);
+
+    /* z1 = MULTIPLY(-z1, FIX_0_899976223) */
+    tmp1 = __msa_splati_w(const1, 0);
+    MUL2(z1_r, tmp1, z1_l, tmp1, z1_r, z1_l);
+
+    /* z2 = MULTIPLY(-z2, FIX_2_562915447) */
+    tmp1 = __msa_splati_w(const1, 1);
+    MUL2(z2_r, tmp1, z2_l, tmp1, z2_r, z2_l);
+
+    /* z3 = MULTIPLY(-z3, FIX_1_961570560) */
+    tmp1 = __msa_splati_w(const1, 2);
+    MUL2(z3_r, tmp1, z3_l, tmp1, z3_r, z3_l);
+
+    /* z4 = MULTIPLY(-z4, FIX_0_390180644) */
+    tmp1 = __msa_splati_w(const1, 3);
+    MUL2(z4_r, tmp1, z4_l, tmp1, z4_r, z4_l);
+
+    /* z3 += z5 */
+    /* z4 += z5 */
+    ADD4(z3_r, z5_r, z3_l, z5_l, z4_r, z5_r, z4_l, z5_l,
+         z3_r, z3_l, z4_r, z4_l);
+
+    /* tmp0 = MULTIPLY(d7, FIX_0_298631336) */
+    /* tmp0 += z1 + z3 */
+    tmp1 = __msa_splati_w(const2, 0);
+    ADD2(z1_r, z3_r, z1_l, z3_l, tmp0_r, tmp0_l);
+    tmp0_r = __msa_maddv_w(tmp0_r, d7_r, tmp1);
+    tmp0_l = __msa_maddv_w(tmp0_l, d7_l, tmp1);
+
+    /* dataptr[3] = DESCALE(tmp13 + tmp0, CONST_BITS-PASS1_BITS) */
+    ADD2(tmp13_r, tmp0_r, tmp13_l, tmp0_l, dst3_r, dst3_l);
+    SRARI_W2_SW(dst3_r, dst3_l, CONST_BITS - PASS1_BITS);
+
+    /* dataptr[4] = DESCALE(tmp13 - tmp0, CONST_BITS-PASS1_BITS) */
+    SUB2(tmp13_r, tmp0_r, tmp13_l, tmp0_l, dst4_r, dst4_l);
+    SRARI_W2_SW(dst4_r, dst4_l, CONST_BITS - PASS1_BITS);
+
+    /* tmp1 = MULTIPLY(d5, FIX_2_053119869) */
+    /* tmp1 += z2 + z4 */
+    tmp1 = __msa_splati_w(const2, 1);
+    ADD2(z2_r, z4_r, z2_l, z4_l, tmp1_r, tmp1_l);
+    tmp1_r = __msa_maddv_w(tmp1_r, d5_r, tmp1);
+    tmp1_l = __msa_maddv_w(tmp1_l, d5_l, tmp1);
+
+    /* dataptr[2] = DESCALE(tmp12 + tmp1, CONST_BITS-PASS1_BITS) */
+    ADD2(tmp12_r, tmp1_r, tmp12_l, tmp1_l, dst2_r, dst2_l);
+    SRARI_W2_SW(dst2_r, dst2_l, CONST_BITS - PASS1_BITS);
+
+    /* dataptr[5] = DESCALE(tmp12 - tmp1, CONST_BITS-PASS1_BITS) */
+    SUB2(tmp12_r, tmp1_r, tmp12_l, tmp1_l, dst5_r, dst5_l);
+    SRARI_W2_SW(dst5_r, dst5_l, CONST_BITS - PASS1_BITS);
+
+    /* tmp2 = MULTIPLY(d3, FIX_3_072711026) */
+    /* tmp2 += z2 + z3 */
+    tmp1 = __msa_splati_w(const2, 2);
+    ADD2(z2_r, z3_r, z2_l, z3_l, tmp2_r, tmp2_l);
+    tmp2_r = __msa_maddv_w(tmp2_r, d3_r, tmp1);
+    tmp2_l = __msa_maddv_w(tmp2_l, d3_l, tmp1);
+
+    /* dataptr[1] = DESCALE(tmp11 + tmp2, CONST_BITS-PASS1_BITS) */
+    ADD2(tmp11_r, tmp2_r, tmp11_l, tmp2_l, dst1_r, dst1_l)
+    SRARI_W2_SW(dst1_r, dst1_l, CONST_BITS - PASS1_BITS);
+
+    /* dataptr[6] = DESCALE(tmp11 - tmp2, CONST_BITS-PASS1_BITS) */
+    SUB2(tmp11_r, tmp2_r, tmp11_l, tmp2_l, dst6_r, dst6_l)
+    SRARI_W2_SW(dst6_r, dst6_l, CONST_BITS - PASS1_BITS);
+
+    /* tmp3 = MULTIPLY(d1, FIX_1_501321110) */
+    /* tmp3 += z1 + z4 */
+    tmp1 = __msa_splati_w(const2, 3);
+    ADD2(z1_r, z4_r, z1_l, z4_l, tmp3_r, tmp3_l);
+    tmp3_r = __msa_maddv_w(tmp3_r, d1_r, tmp1);
+    tmp3_l = __msa_maddv_w(tmp3_l, d1_l, tmp1);
+
+    /* dataptr[0] = DESCALE(tmp10 + tmp3, CONST_BITS-PASS1_BITS) */
+    ADD2(tmp10_r, tmp3_r, tmp10_l, tmp3_l, dst0_r, dst0_l);
+    SRARI_W2_SW(dst0_r, dst0_l, CONST_BITS - PASS1_BITS);
+
+    /* dataptr[7] = DESCALE(tmp10 - tmp3, CONST_BITS-PASS1_BITS) */
+    SUB2(tmp10_r, tmp3_r, tmp10_l, tmp3_l, dst7_r, dst7_l);
+    SRARI_W2_SW(dst7_r, dst7_l, CONST_BITS - PASS1_BITS);
+
+    TRANSPOSE4x4_SW_SW(dst0_r, dst1_r, dst2_r, dst3_r, d0_r, d1_r, d2_r, d3_r);
+    TRANSPOSE4x4_SW_SW(dst4_r, dst5_r, dst6_r, dst7_r, d0_l, d1_l, d2_l, d3_l);
+    TRANSPOSE4x4_SW_SW(dst0_l, dst1_l, dst2_l, dst3_l, d4_r, d5_r, d6_r, d7_r);
+    TRANSPOSE4x4_SW_SW(dst4_l, dst5_l, dst6_l, dst7_l, d4_l, d5_l, d6_l, d7_l);
+  }
+
+  /* z1 = MULTIPLY(d2 + d6, FIX_0_541196100); */
+  tmp = __msa_shf_w(const0, 0);
+  ADD2(d2_r, d6_r, d2_l, d6_l, tmp_r, tmp_l);
+  MUL2(tmp_r, tmp, tmp_l, tmp, z1_r, z1_l);
+  /* tmp2 = z1 + MULTIPLY(-d6, FIX_1_847759065) */
+  tmp = __msa_shf_w(const0, 0x55);
+  MUL2(d6_r, tmp, d6_l, tmp, tmp2_r, tmp2_l);
+  ADD2(tmp2_r, z1_r, tmp2_l, z1_l, tmp2_r, tmp2_l);
+  /* tmp3 = z1 + MULTIPLY(d2, FIX_0_765366865); */
+  tmp = __msa_shf_w(const0, 0xAA);
+  MUL2(d2_r, tmp, d2_l, tmp, tmp3_r, tmp3_l);
+  ADD2(tmp3_r, z1_r, tmp3_l, z1_l, tmp3_r, tmp3_l);
+  BUTTERFLY_4(d0_r, d0_l, d4_l, d4_r, tmp0_r, tmp0_l, tmp1_l, tmp1_r);
+  SLLI_W4_SW(tmp0_r, tmp0_l, tmp1_r, tmp1_l, CONST_BITS);
+  BUTTERFLY_8(tmp0_r, tmp0_l, tmp1_r, tmp1_l, tmp2_l, tmp2_r, tmp3_l, tmp3_r,
+              tmp10_r, tmp10_l, tmp11_r, tmp11_l, tmp12_l, tmp12_r, tmp13_l,
+              tmp13_r);
+  /* z1 = d7 + d1 */
+  /* z2 = d5 + d3 */
+  ADD4(d7_r, d1_r, d7_l, d1_l, d5_r, d3_r, d5_l, d3_l, z1_r, z1_l, z2_r, z2_l);
+  /* z3 = d7 + d3 */
+  /* z4 = d5 + d1 */
+  ADD4(d7_r, d3_r, d7_l, d3_l, d5_r, d1_r, d5_l, d1_l, z3_r, z3_l, z4_r, z4_l);
+  /* z5 = MULTIPLY(z3 + z4, FIX_1_175875602) */
+  tmp = __msa_shf_w(const0, 0xFF);
+  ADD2(z3_r, z4_r, z3_l, z4_l, z5_r, z5_l);
+  MUL2(z5_r, tmp, z5_l, tmp, z5_r, z5_l);
+  /* z1 = MULTIPLY(-z1, FIX_0_899976223) */
+  tmp = __msa_shf_w(const1, 0);
+  MUL2(z1_r, tmp, z1_l, tmp, z1_r, z1_l);
+  /* z2 = MULTIPLY(-z2, FIX_2_562915447) */
+  tmp = __msa_shf_w(const1, 0x55);
+  MUL2(z2_r, tmp, z2_l, tmp, z2_r, z2_l);
+  /* z3 = MULTIPLY(-z3, FIX_1_961570560) */
+  tmp = __msa_shf_w(const1, 0xAA);
+  MUL2(z3_r, tmp, z3_l, tmp, z3_r, z3_l);
+  /* z4 = MULTIPLY(-z4, FIX_0_390180644) */
+  tmp = __msa_shf_w(const1, 0xFF);
+  MUL2(z4_r, tmp, z4_l, tmp, z4_r, z4_l);
+  /* z3 += z5 */
+  /* z4 += z5 */
+  ADD4(z3_r, z5_r, z3_l, z5_l, z4_r, z5_r, z4_l, z5_l, z3_r, z3_l, z4_r, z4_l);
+  /* tmp0 = MULTIPLY(d7, FIX_0_298631336) */
+  /* tmp0 += z1 + z3 */
+  tmp = __msa_shf_w(const2, 0);
+  ADD2(z1_r, z3_r, z1_l, z3_l, tmp0_r, tmp0_l);
+  tmp0_r = __msa_maddv_w(tmp0_r, d7_r, tmp);
+  tmp0_l = __msa_maddv_w(tmp0_l, d7_l, tmp);
+
+  /* dataptr[3] = DESCALE(tmp13 + tmp0, CONST_BITS+PASS1_BITS+3) */
+  ADD2(tmp13_r, tmp0_r, tmp13_l, tmp0_l, dst3_r, dst3_l);
+  SRARI_W2_SW(dst3_r, dst3_l, CONST_BITS + PASS1_BITS + 3);
+  dst3_r = (v4i32)__msa_pckev_h((v8i16)dst3_l, (v8i16)dst3_r);
+  dst3_r = (v4i32)CLIP_SH_0_255(dst3_r + reg_128);
+  res3 = (v16u8)__msa_pckev_b((v16i8)dst3_l, (v16i8)dst3_r);
+
+  /* dataptr[4] = DESCALE(tmp13 - tmp0, CONST_BITS+PASS1_BITS+3) */
+  SUB2(tmp13_r, tmp0_r, tmp13_l, tmp0_l, dst4_r, dst4_l);
+  SRARI_W2_SW(dst4_r, dst4_l, CONST_BITS + PASS1_BITS + 3);
+  dst4_r = (v4i32)__msa_pckev_h((v8i16)dst4_l, (v8i16)dst4_r);
+  dst4_r = (v4i32)CLIP_SH_0_255(dst4_r + reg_128);
+  res4 = (v16u8)__msa_pckev_b((v16i8)dst4_l, (v16i8)dst4_r);
+
+  /* tmp1 = MULTIPLY(d5, FIX_2_053119869) */
+  /* tmp1 += z2 + z4 */
+  tmp = __msa_shf_w(const2, 0x55);
+  ADD2(z2_r, z4_r, z2_l, z4_l, tmp1_r, tmp1_l);
+  tmp1_r = __msa_maddv_w(tmp1_r, d5_r, tmp);
+  tmp1_l = __msa_maddv_w(tmp1_l, d5_l, tmp);
+
+  /* dataptr[2] = DESCALE(tmp12 + tmp1, CONST_BITS+PASS1_BITS+3) */
+  ADD2(tmp12_r, tmp1_r, tmp12_l, tmp1_l, dst2_r, dst2_l);
+  SRARI_W2_SW(dst2_r, dst2_l, CONST_BITS + PASS1_BITS + 3);
+  dst2_r = (v4i32)__msa_pckev_h((v8i16)dst2_l, (v8i16)dst2_r);
+  dst2_r = (v4i32)CLIP_SH_0_255(dst2_r + reg_128);
+  res2 = (v16u8)__msa_pckev_b((v16i8)dst2_l, (v16i8)dst2_r);
+
+  /* dataptr[5] = DESCALE(tmp12 - tmp1, CONST_BITS+PASS1_BITS+3) */
+  SUB2(tmp12_r, tmp1_r, tmp12_l, tmp1_l, dst5_r, dst5_l);
+  SRARI_W2_SW(dst5_r, dst5_l, CONST_BITS + PASS1_BITS + 3);
+  dst5_r = (v4i32)__msa_pckev_h((v8i16)dst5_l, (v8i16)dst5_r);
+  dst5_r = (v4i32)CLIP_SH_0_255(dst5_r + reg_128);
+  res5 = (v16u8)__msa_pckev_b((v16i8)dst5_l, (v16i8)dst5_r);
+
+  /* tmp2 = MULTIPLY(d3, FIX_3_072711026) */
+  /* tmp2 += z2 + z3 */
+  tmp = __msa_shf_w(const2, 0xAA);
+  ADD2(z2_r, z3_r, z2_l, z3_l, tmp2_r, tmp2_l);
+  tmp2_r = __msa_maddv_w(tmp2_r, d3_r, tmp);
+  tmp2_l = __msa_maddv_w(tmp2_l, d3_l, tmp);
+
+  /* dataptr[1] = DESCALE(tmp11 + tmp2, CONST_BITS+PASS1_BITS+3) */
+  ADD2(tmp11_r, tmp2_r, tmp11_l, tmp2_l, dst1_r, dst1_l);
+  SRARI_W2_SW(dst1_r, dst1_l, CONST_BITS + PASS1_BITS + 3);
+  dst1_r = (v4i32)__msa_pckev_h((v8i16)dst1_l, (v8i16)dst1_r);
+  dst1_r = (v4i32)CLIP_SH_0_255(dst1_r + reg_128);
+  res1 = (v16u8)__msa_pckev_b((v16i8)dst1_l, (v16i8)dst1_r);
+
+  /* dataptr[6] = DESCALE(tmp11 - tmp2, CONST_BITS+PASS1_BITS+3) */
+  SUB2(tmp11_r, tmp2_r, tmp11_l, tmp2_l, dst6_r, dst6_l);
+  SRARI_W2_SW(dst6_r, dst6_l, CONST_BITS + PASS1_BITS + 3);
+  dst6_r = (v4i32)__msa_pckev_h((v8i16)dst6_l, (v8i16)dst6_r);
+  dst6_r = (v4i32)CLIP_SH_0_255(dst6_r + reg_128);
+  res6 = (v16u8)__msa_pckev_b((v16i8)dst6_l, (v16i8)dst6_r);
+
+  /* tmp3 = MULTIPLY(d1, FIX_1_501321110) */
+  /* tmp3 += z1 + z4 */
+  tmp = __msa_shf_w(const2, 0xFF);
+  ADD2(z1_r, z4_r, z1_l, z4_l, tmp3_r, tmp3_l);
+  tmp3_r = __msa_maddv_w(tmp3_r, d1_r, tmp);
+  tmp3_l = __msa_maddv_w(tmp3_l, d1_l, tmp);
+
+  /* dataptr[0] = DESCALE(tmp10 + tmp3, CONST_BITS+PASS1_BITS+3) */
+  ADD2(tmp10_r, tmp3_r, tmp10_l, tmp3_l, dst0_r, dst0_l);
+  SRARI_W2_SW(dst0_r, dst0_l, CONST_BITS + PASS1_BITS + 3);
+  dst0_r = (v4i32)__msa_pckev_h((v8i16)dst0_l, (v8i16)dst0_r);
+  dst0_r = (v4i32)CLIP_SH_0_255(dst0_r + reg_128);
+  res0 = (v16u8)__msa_pckev_b((v16i8)dst0_l, (v16i8)dst0_r);
+
+  /* dataptr[7] = DESCALE(tmp10 - tmp3, CONST_BITS+PASS1_BITS+3) */
+  SUB2(tmp10_r, tmp3_r, tmp10_l, tmp3_l, dst7_r, dst7_l);
+  SRARI_W2_SW(dst7_r, dst7_l, CONST_BITS + PASS1_BITS + 3);
+  dst7_r = (v4i32)__msa_pckev_h((v8i16)dst7_l, (v8i16)dst7_r);
+  dst7_r = (v4i32)CLIP_SH_0_255(dst7_r + reg_128);
+  res7 = (v16u8)__msa_pckev_b((v16i8)dst7_l, (v16i8)dst7_r);
+
+  TRANSPOSE8x8_UB_UB(res0, res1, res2, res3, res4, res5, res6, res7,
+                     res0, res1, res2, res3, res4, res5, res6, res7);
+
+  ST8x1_UB(res0, output_buf[0]);
+  ST8x1_UB(res1, output_buf[1]);
+  ST8x1_UB(res2, output_buf[2]);
+  ST8x1_UB(res3, output_buf[3]);
+  ST8x1_UB(res4, output_buf[4]);
+  ST8x1_UB(res5, output_buf[5]);
+  ST8x1_UB(res6, output_buf[6]);
+  ST8x1_UB(res7, output_buf[7]);
+}

--- a/simd/mips/jidctred_msa.c
+++ b/simd/mips/jidctred_msa.c
@@ -1,0 +1,324 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#define JPEG_INTERNALS
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "../../jsimd.h"
+#include "../../jdct.h"
+#include "../../jsimddct.h"
+#include "../jsimd.h"
+#include "jmacros_msa.h"
+
+
+#define DCTSIZE     8
+#define CONST_BITS  13
+#define PASS1_BITS  2
+
+#define FIX_0_765366865  ((int32_t)6270)   /* FIX(0.765366865) */
+#define FIX_0_899976223  ((int32_t)7373)   /* FIX(0.899976223) */
+#define FIX_1_847759065  ((int32_t)15137)  /* FIX(1.847759065) */
+#define FIX_2_562915447  ((int32_t)20995)  /* FIX(2.562915447) */
+#define FIX_0_211164243  ((int32_t)1730)   /* FIX(0.211164243) */
+#define FIX_0_509795579  ((int32_t)4176)   /* FIX(0.509795579) */
+#define FIX_0_601344887  ((int32_t)4926)   /* FIX(0.601344887) */
+#define FIX_0_720959822  ((int32_t)5906)   /* FIX(0.720959822) */
+#define FIX_0_850430095  ((int32_t)6967)   /* FIX(0.850430095) */
+#define FIX_1_061594337  ((int32_t)8697)   /* FIX(1.061594337) */
+#define FIX_1_272758580  ((int32_t)10426)  /* FIX(1.272758580) */
+#define FIX_1_451774981  ((int32_t)11893)  /* FIX(1.451774981) */
+#define FIX_2_172734803  ((int32_t)17799)  /* FIX(2.172734803) */
+#define FIX_3_624509785  ((int32_t)29692)  /* FIX(3.624509785) */
+
+GLOBAL(void)
+jsimd_idct_2x2_msa(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                   JCOEFPTR coef_block, JSAMPARRAY output_buf,
+                   JDIMENSION output_col)
+{
+  uint8_t out0, out1, out2, out3;
+  v8i16 res, val0, val1, val3, val5, val7;
+  v8i16 quant0, quant1, quant3, quant5, quant7;
+  v4i32 tmp0, tmp10, tmp0_r, tmp0_l, tmp10_r, tmp10_l;
+  v4i32 dst0_r, dst1_r, dst0_l, dst1_l;
+  v4i32 d0_r, d1_r, d3_r, d5_r, d7_r, d0_l, d1_l, d3_l, d5_l, d7_l;
+  JCOEFPTR quantptr = compptr->dct_table;
+  v4i32 const0 =
+    { FIX_3_624509785, -FIX_1_272758580, FIX_3_624509785, -FIX_1_272758580 };
+  v4i32 const1 =
+    { FIX_0_850430095, -FIX_0_720959822, FIX_0_850430095, -FIX_0_720959822 };
+
+  /* Pass 1: process columns from input, store into work array. */
+
+  /* Load coeff values */
+  val0 = LD_SH(coef_block);
+  LD_SH4(coef_block + DCTSIZE, DCTSIZE * 2, val1, val3, val5, val7);
+
+  /* Load quant value */
+  quant0 = LD_SH(quantptr);
+  res = val1 | val3 | val5 | val7;
+
+  if (__msa_test_bz_v((v16u8)res)) {
+    val0 = val0 * quant0;
+    UNPCK_SH_SW(val0, dst0_r, dst0_l);
+    dst0_r = MSA_SLLI_W(dst0_r, PASS1_BITS);
+    dst0_l = MSA_SLLI_W(dst0_l, PASS1_BITS);
+
+    dst1_r = dst0_r;
+    dst1_l = dst0_l;
+  } else {
+    /* Pass 1: process columns. */
+    /* Note results are scaled up by sqrt(8) compared to a true IDCT; */
+    /* furthermore, we scale the results by 2**PASS1_BITS. */
+
+    /* Load remaining quant values */
+    LD_SH4(quantptr + DCTSIZE, 2 * DCTSIZE, quant1, quant3, quant5, quant7);
+
+    /* Dequantize */
+    val0 *= quant0;
+    MUL4(val1, quant1, val3, quant3, val5, quant5, val7, quant7,
+         val1, val3, val5, val7);
+
+    /* Even Part */
+    UNPCK_SH_SW(val0, d0_r, d0_l);
+    d0_r = MSA_SLLI_W(d0_r, (CONST_BITS + 2));
+    d0_l = MSA_SLLI_W(d0_l, (CONST_BITS + 2));
+    tmp10_r = d0_r;
+    tmp10_l = d0_l;
+
+    /* Odd Part */
+    UNPCK_SH_SW(val1, d1_r, d1_l); /* z4 */
+    UNPCK_SH_SW(val3, d3_r, d3_l); /* z3 */
+    UNPCK_SH_SW(val5, d5_r, d5_l); /* z2 */
+    UNPCK_SH_SW(val7, d7_r, d7_l); /* z1 */
+
+    tmp0_r = d7_r * __msa_fill_w(-FIX_0_720959822) +
+             d5_r * __msa_fill_w(FIX_0_850430095) -
+             d3_r * __msa_fill_w(FIX_1_272758580) +
+             d1_r * __msa_fill_w(FIX_3_624509785);
+    tmp0_l = d7_l * __msa_fill_w(-FIX_0_720959822) +
+             d5_l * __msa_fill_w(FIX_0_850430095) -
+             d3_l * __msa_fill_w(FIX_1_272758580) +
+             d1_l * __msa_fill_w(FIX_3_624509785);
+
+    BUTTERFLY_4(tmp10_r, tmp10_l, tmp0_l, tmp0_r,
+                dst0_r, dst0_l, dst1_l, dst1_r);
+
+    /* Descale */
+    SRARI_W4_SW(dst0_r, dst0_l, dst1_r, dst1_l, CONST_BITS - PASS1_BITS + 2);
+  }
+
+  /* Get 0th row */
+  tmp10 = __msa_ilvr_w(dst1_r, dst0_r);
+  tmp10 = MSA_SLLI_W(tmp10, (CONST_BITS + 2));
+
+  /* Ignore 0 2 4 and 6th row */
+  dst0_l = __msa_pckod_w(dst1_l, dst0_l); /* 1 3 1 3 */
+  dst0_r = __msa_pckod_w(dst1_r, dst0_r); /* 5 7 5 7 */
+
+  dst0_l = (v4i32)__msa_dotp_s_d(dst0_l, const1);
+  dst0_r = (v4i32)__msa_dotp_s_d(dst0_r, const0);
+
+  tmp0 = dst0_l + dst0_r;
+  tmp0 = __msa_pckev_w(tmp0, tmp0);
+
+  dst0_r = tmp10 + tmp0;
+  dst1_r = tmp10 - tmp0;
+
+  /* Descale */
+  SRARI_W2_SW(dst0_r, dst1_r, CONST_BITS + PASS1_BITS + 3 + 2);
+
+  res = (v8i16)__msa_pckev_d((v2i64)dst1_r, (v2i64)dst0_r);
+  res = MSA_ADDVI_H(res, 128);
+  res = CLIP_SH_0_255(res);
+
+  out0 = __msa_copy_u_b((v16i8)res, 0);
+  out1 = __msa_copy_u_b((v16i8)res, 4);
+  out2 = __msa_copy_u_b((v16i8)res, 8);
+  out3 = __msa_copy_u_b((v16i8)res, 12);
+
+  *(output_buf[0]) = out0;
+  *(output_buf[0] + 1) = out2;
+  *(output_buf[1]) = out1;
+  *(output_buf[1] + 1) = out3;
+}
+
+GLOBAL(void)
+jsimd_idct_4x4_msa(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                   JCOEFPTR coef_block, JSAMPARRAY output_buf,
+                   JDIMENSION output_col)
+{
+  uint32_t out0, out1, out2, out3;
+  v8i16 val0, val1, val2, val3, val5, val6, val7;
+  v8i16 quant0, quant1, quant2, quant3, quant5, quant6, quant7;
+  v4i32 tmp2_r, tmp2_l, tmp0_r, tmp0_l, tmp10_r, tmp10_l, tmp12_r, tmp12_l;
+  v4i32 res, dst0_r, dst1_r, dst2_r, dst3_r, dst0_l, dst1_l, dst2_l, dst3_l;
+  v4i32 d0_r, d1_r, d2_r, d3_r, d5_r, d6_r, d7_r;
+  v4i32 d0_l, d1_l, d2_l, d3_l, d5_l, d6_l, d7_l;
+  v8i16 reg_128 = __msa_ldi_h(128);
+  JCOEFPTR quantptr = compptr->dct_table;
+
+  /* Pass 1: process columns from input, store into work array. */
+
+  /* Load coeff values */
+  LD_SH4(coef_block, DCTSIZE, val0, val1, val2, val3);
+  LD_SH2(coef_block + 5 * DCTSIZE, DCTSIZE, val5, val6);
+  val7 = LD_SH(coef_block + 7 * DCTSIZE);
+
+  /* Load quant value */
+  quant0 = LD_SH(quantptr);
+  res = (v4i32)(val1 | val2 | val3 | val5 | val6 | val7);
+  if (__msa_test_bz_v((v16u8)res)) {
+    val0 = val0 * quant0;
+    UNPCK_SH_SW(val0, dst0_r, dst0_l);
+    dst0_r = MSA_SLLI_W(dst0_r, PASS1_BITS);
+    dst0_l = MSA_SLLI_W(dst0_l, PASS1_BITS);
+
+    SPLATI_W4_SW(dst0_r, d0_r, d1_r, d2_r, d3_r);
+    SPLATI_W2_SW(dst0_l, 2, d6_r, d7_r);
+    d5_r = __msa_splati_w(dst0_l, 1);
+  } else {
+    /* Pass 1: process columns. */
+    /* Note results are scaled up by sqrt(8) compared to a true IDCT; */
+    /* furthermore, we scale the results by 2**PASS1_BITS. */
+
+    /* Load remaining quant values */
+    LD_SH2(quantptr + DCTSIZE, DCTSIZE, quant1, quant2);
+    quant3 = LD_SH(quantptr + 3 * DCTSIZE);
+    LD_SH2(quantptr + 5 * DCTSIZE, DCTSIZE, quant5, quant6);
+    quant7 = LD_SH(quantptr + 7 * DCTSIZE);
+
+    /* Dequantize */
+    MUL4(val0, quant0, val1, quant1, val2, quant2, val3, quant3,
+         val0, val1, val2, val3);
+    MUL2(val5, quant5, val6, quant6, val5, val6);
+    val7 *= quant7;
+
+    /* Even Part */
+    UNPCK_SH_SW(val0, d0_r, d0_l);
+    UNPCK_SH_SW(val2, d2_r, d2_l);
+    UNPCK_SH_SW(val6, d6_r, d6_l);
+
+    d0_r = MSA_SLLI_W(d0_r, (CONST_BITS + 1));
+    d0_l = MSA_SLLI_W(d0_l, (CONST_BITS + 1));
+    /* tmp2 = MULTIPLY(z2, FIX_1_847759065) + MULTIPLY(z3, -FIX_0_765366865); */
+    d2_r = d2_r * __msa_fill_w(FIX_1_847759065);
+    d2_l = d2_l * __msa_fill_w(FIX_1_847759065);
+    d6_r = d6_r * __msa_fill_w(-FIX_0_765366865);
+    d6_l = d6_l * __msa_fill_w(-FIX_0_765366865);
+
+    d2_r += d6_r;
+    d2_l += d6_l;
+
+    BUTTERFLY_4(d0_r, d0_l, d2_l, d2_r, tmp10_r, tmp10_l, tmp12_l, tmp12_r);
+
+    /* Odd Part */
+    UNPCK_SH_SW(val1, d1_r, d1_l); /* z4 */
+    UNPCK_SH_SW(val3, d3_r, d3_l); /* z3 */
+    UNPCK_SH_SW(val5, d5_r, d5_l); /* z2 */
+    UNPCK_SH_SW(val7, d7_r, d7_l); /* z1 */
+
+    tmp0_r = d7_r * __msa_fill_w(-FIX_0_211164243) +
+             d5_r * __msa_fill_w(FIX_1_451774981) -
+             d3_r * __msa_fill_w(FIX_2_172734803) +
+             d1_r * __msa_fill_w(FIX_1_061594337);
+    tmp0_l = d7_l * __msa_fill_w(-FIX_0_211164243) +
+             d5_l * __msa_fill_w(FIX_1_451774981) -
+             d3_l * __msa_fill_w(FIX_2_172734803) +
+             d1_l * __msa_fill_w(FIX_1_061594337);
+
+    tmp2_r = d7_r * __msa_fill_w(-FIX_0_509795579) -
+             d5_r * __msa_fill_w(FIX_0_601344887) +
+             d3_r * __msa_fill_w(FIX_0_899976223) +
+             d1_r * __msa_fill_w(FIX_2_562915447);
+    tmp2_l = d7_l * __msa_fill_w(-FIX_0_509795579) -
+             d5_l * __msa_fill_w(FIX_0_601344887) +
+             d3_l * __msa_fill_w(FIX_0_899976223) +
+             d1_l * __msa_fill_w(FIX_2_562915447);
+
+    BUTTERFLY_4(tmp10_r, tmp12_r, tmp0_r, tmp2_r,
+                dst0_r, dst1_r, dst2_r, dst3_r);
+    BUTTERFLY_4(tmp10_l, tmp12_l, tmp0_l, tmp2_l,
+                dst0_l, dst1_l, dst2_l, dst3_l);
+
+    /* Descale */
+    SRARI_W4_SW(dst0_r, dst0_l, dst1_r, dst1_l, CONST_BITS - PASS1_BITS + 1);
+    SRARI_W4_SW(dst2_r, dst2_l, dst3_r, dst3_l, CONST_BITS - PASS1_BITS + 1);
+
+    TRANSPOSE4x4_SW_SW(dst0_r, dst1_r, dst2_r, dst3_r, d0_r, d1_r, d2_r, d3_r);
+
+    /* Partial transpose!, one register ignored */
+    ILVRL_W2_SH(dst1_l, dst0_l, val0, val1);
+    ILVRL_W2_SH(dst3_l, dst2_l, val2, val3);
+
+    d5_r = (v4i32)__msa_ilvl_d((v2i64)val2, (v2i64)val0);
+    d6_r = (v4i32)__msa_ilvr_d((v2i64)val3, (v2i64)val1);
+    d7_r = (v4i32)__msa_ilvl_d((v2i64)val3, (v2i64)val1);
+  }
+
+  /* Pass 2: process 4 rows from work array, store into output array. */
+
+  /* Even Part */
+  d0_r = MSA_SLLI_W(d0_r, (CONST_BITS + 1));
+
+  d2_r = d2_r * __msa_fill_w(FIX_1_847759065);
+  d6_r = d6_r * __msa_fill_w(-FIX_0_765366865);
+  d2_r += d6_r;
+
+  tmp10_r = d0_r + d2_r;
+  tmp12_r = d0_r - d2_r;
+
+  /* Odd Part */
+  tmp0_r = d7_r * __msa_fill_w(-FIX_0_211164243) +
+           d5_r * __msa_fill_w(FIX_1_451774981) -
+           d3_r * __msa_fill_w(FIX_2_172734803) +
+           d1_r * __msa_fill_w(FIX_1_061594337);
+
+  tmp2_r = d7_r * __msa_fill_w(-FIX_0_509795579) -
+           d5_r * __msa_fill_w(FIX_0_601344887) +
+           d3_r * __msa_fill_w(FIX_0_899976223) +
+           d1_r * __msa_fill_w(FIX_2_562915447);
+
+  BUTTERFLY_4(tmp10_r, tmp12_r, tmp0_r, tmp2_r, dst0_r, dst1_r, dst2_r, dst3_r);
+
+  /* Descale */
+  SRARI_W4_SW(dst0_r, dst1_r, dst2_r, dst3_r, CONST_BITS + PASS1_BITS + 3 + 1);
+  TRANSPOSE4x4_SW_SW(dst0_r, dst1_r, dst2_r, dst3_r,
+                     dst0_r, dst1_r, dst2_r, dst3_r);
+  val0 = __msa_pckev_h((v8i16)dst1_r, (v8i16)dst0_r);
+  val1 = __msa_pckev_h((v8i16)dst3_r, (v8i16)dst2_r);
+  val0 = __msa_adds_s_h(val0, reg_128);
+  val1 = __msa_adds_s_h(val1, reg_128);
+  CLIP_SH2_0_255(val0, val1);
+  res = (v4i32)__msa_pckev_b((v16i8)val1, (v16i8)val0);
+
+  /* Macro intentionally not used! */
+  out0 = __msa_copy_u_w(res, 0);
+  out1 = __msa_copy_u_w(res, 1);
+  out2 = __msa_copy_u_w(res, 2);
+  out3 = __msa_copy_u_w(res, 3);
+
+  SW(out0, output_buf[0]);
+  SW(out1, output_buf[1]);
+  SW(out2, output_buf[2]);
+  SW(out3, output_buf[3]);
+}

--- a/simd/mips/jmacros_msa.h
+++ b/simd/mips/jmacros_msa.h
@@ -1,0 +1,1151 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef __JMACROS_MSA_H__
+#define __JMACROS_MSA_H__
+
+#include <stdint.h>
+#include <msa.h>
+
+
+#ifdef CLANG_BUILD
+#define MSA_ADDVI_B(a, b)  __msa_addvi_b((v16i8)a, b)
+#define MSA_ADDVI_H(a, b)  __msa_addvi_h((v8i16)a, b)
+#define MSA_ADDVI_W(a, b)  __msa_addvi_w((v4i32)a, b)
+#define MSA_SLLI_B(a, b)   __msa_slli_b((v16i8)a, b)
+#define MSA_SLLI_H(a, b)   __msa_slli_h((v8i16)a, b)
+#define MSA_SLLI_W(a, b)   __msa_slli_w((v4i32)a, b)
+#define MSA_SRAI_B(a, b)   __msa_srai_b((v16i8)a, b)
+#define MSA_SRAI_H(a, b)   __msa_srai_h((v8i16)a, b)
+#define MSA_SRAI_W(a, b)   __msa_srai_w((v4i32)a, b)
+#else
+#define MSA_ADDVI_B(a, b)  (a + b)
+#define MSA_ADDVI_H(a, b)  (a + b)
+#define MSA_ADDVI_W(a, b)  (a + b)
+#define MSA_SLLI_B(a, b)   (a << b)
+#define MSA_SLLI_H(a, b)   (a << b)
+#define MSA_SLLI_W(a, b)   (a << b)
+#define MSA_SRAI_B(a, b)   (a >> b)
+#define MSA_SRAI_H(a, b)   (a >> b)
+#define MSA_SRAI_W(a, b)   (a >> b)
+#endif
+
+#define LD_B(RTYPE, psrc)  *((RTYPE *)(psrc))
+#define LD_UB(...)  LD_B(v16u8, __VA_ARGS__)
+#define LD_SB(...)  LD_B(v16i8, __VA_ARGS__)
+
+#define LD_H(RTYPE, psrc)  *((RTYPE *)(psrc))
+#define LD_SH(...)  LD_H(v8i16, __VA_ARGS__)
+
+#define ST_B(RTYPE, in, pdst)  *((RTYPE *)(pdst)) = (in)
+#define ST_UB(...)  ST_B(v16u8, __VA_ARGS__)
+#define ST_SB(...)  ST_B(v16i8, __VA_ARGS__)
+
+#define ST_H(RTYPE, in, pdst)  *((RTYPE *)(pdst)) = (in)
+
+#ifdef CLANG_BUILD
+#define LH(psrc) \
+( { \
+  unsigned char *psrc_lh_m = (unsigned char *)(psrc); \
+  unsigned short val_m; \
+  \
+  asm volatile( \
+    "lh %[val_m], %[psrc_lh_m] \n\t" : \
+    [val_m] "=r" (val_m) : \
+    [psrc_lh_m] "m" (*psrc_lh_m) \
+  ); \
+  \
+  val_m; \
+} )
+
+#define LW(psrc) \
+( { \
+  unsigned char *psrc_lw_m = (unsigned char *)(psrc); \
+  unsigned int val_m; \
+  \
+  asm volatile( \
+    "lw %[val_m], %[psrc_lw_m] \n\t" : \
+    [val_m] "=r" (val_m) : \
+    [psrc_lw_m] "m" (*psrc_lw_m) \
+  ); \
+  \
+  val_m; \
+} )
+
+#if (__mips == 64)
+#define LD(psrc) \
+( { \
+  unsigned char *psrc_ld_m = (unsigned char *)(psrc); \
+  uint64_t val_m = 0; \
+  \
+  asm volatile( \
+    "ld %[val_m], %[psrc_ld_m] \n\t" : \
+    [val_m] "=r" (val_m) : \
+    [psrc_ld_m] "m" (*psrc_ld_m) \
+  ); \
+  \
+  val_m; \
+} )
+#else /* !(__mips == 64) */
+#define LD(psrc) \
+( { \
+  unsigned char *psrc_ld_m = (unsigned char *)(psrc); \
+  unsigned int val0_m, val1_m; \
+  uint64_t val_m = 0; \
+  \
+  val0_m = LW(psrc_ld_m); \
+  val1_m = LW(psrc_ld_m + 4); \
+  \
+  val_m = (uint64_t)(val1_m); \
+  val_m = (uint64_t)((val_m << 32) & 0xFFFFFFFF00000000); \
+  val_m = (uint64_t)(val_m | (uint64_t)val0_m); \
+  \
+  val_m; \
+} )
+#endif
+
+#define SH(val, pdst) { \
+  unsigned char *pdst_sh_m = (unsigned char *)(pdst); \
+  unsigned short val_m = (val); \
+  \
+  asm volatile( \
+    "sh %[val_m], %[pdst_sh_m] \n\t" : \
+    [pdst_sh_m] "=m" (*pdst_sh_m) : \
+    [val_m] "r" (val_m) \
+  ); \
+}
+
+#define SW(val, pdst) { \
+  unsigned char *pdst_sw_m = (unsigned char *)(pdst); \
+  unsigned int val_m = (val); \
+  \
+  asm volatile( \
+    "sw %[val_m], %[pdst_sw_m] \n\t" : \
+    [pdst_sw_m] "=m" (*pdst_sw_m) : \
+    [val_m] "r" (val_m) \
+  ); \
+}
+
+#if (__mips == 64)
+#define SD(val, pdst) { \
+  unsigned char *pdst_sd_m = (unsigned char *)(pdst); \
+  uint64_t val_m = (val); \
+  \
+  asm volatile( \
+    "sd %[val_m], %[pdst_sd_m] \n\t" : \
+    [pdst_sd_m] "=m" (*pdst_sd_m) : \
+    [val_m] "r" (val_m) \
+  ); \
+}
+#else
+#define SD(val, pdst) { \
+  unsigned char *pdst_sd_m = (unsigned char *)(pdst); \
+  unsigned int val0_m, val1_m; \
+  \
+  val0_m = (unsigned int)((val) & 0x00000000FFFFFFFF); \
+  val1_m = (unsigned int)(((val) >> 32) & 0x00000000FFFFFFFF); \
+  \
+  SW(val0_m, pdst_sd_m); \
+  SW(val1_m, pdst_sd_m + 4); \
+}
+#endif
+
+#define SW_ZERO(pdst) { \
+  unsigned char *pdst_m = (unsigned char *)(pdst); \
+  \
+  asm volatile( \
+    "sw $0, %[pdst_m] \n\t" : \
+    [pdst_m] "=m" (*pdst_m) : \
+    \
+  ); \
+}
+
+#else /* #ifndef CLANG_BUILD */
+
+#if (__mips_isa_rev >= 6)
+#define LW(psrc) \
+( { \
+  unsigned char *psrc_lw_m = (unsigned char *)(psrc); \
+  unsigned int val_m; \
+  \
+  asm volatile( \
+    "lw %[val_m], %[psrc_lw_m] \n\t" : \
+    [val_m] "=r" (val_m) : \
+    [psrc_lw_m] "m" (*psrc_lw_m) \
+  ); \
+  \
+  val_m; \
+} )
+
+#if (__mips == 64)
+#define LD(psrc) \
+( { \
+  unsigned char *psrc_ld_m = (unsigned char *)(psrc); \
+  unsigned long long val_m = 0; \
+  \
+  asm volatile( \
+    "ld %[val_m], %[psrc_ld_m] \n\t" : \
+    [val_m] "=r" (val_m) : \
+    [psrc_ld_m] "m" (*psrc_ld_m) \
+  ); \
+  \
+  val_m; \
+} )
+#else /* !(__mips == 64) */
+#define LD(psrc) \
+( { \
+  unsigned char *psrc_ld_m = (unsigned char *)(psrc); \
+  unsigned int val0_m, val1_m; \
+  unsigned long long val_m = 0; \
+  \
+  val0_m = LW(psrc_ld_m); \
+  val1_m = LW(psrc_ld_m + 4); \
+  \
+  val_m = (unsigned long long)(val1_m); \
+  val_m = (unsigned long long)((val_m << 32) & 0xFFFFFFFF00000000); \
+  val_m = (unsigned long long)(val_m | (unsigned long long)val0_m); \
+  \
+  val_m; \
+} )
+#endif
+
+#define SW(val, pdst) { \
+  unsigned char *pdst_sw_m = (unsigned char *)(pdst); \
+  unsigned int val_m = (val); \
+  \
+  asm volatile( \
+    "sw %[val_m], %[pdst_sw_m] \n\t" : \
+    [pdst_sw_m] "=m" (*pdst_sw_m) : \
+    [val_m] "r" (val_m) \
+  ); \
+}
+
+#define SD(val, pdst) { \
+  unsigned char *pdst_sd_m = (unsigned char *)(pdst); \
+  unsigned long long val_m = (val); \
+  \
+  asm volatile( \
+    "sd %[val_m], %[pdst_sd_m] \n\t" : \
+    [pdst_sd_m] "=m" (*pdst_sd_m) : \
+    [val_m] "r" (val_m) \
+  ); \
+}
+#else  /* !(__mips_isa_rev >= 6) */
+#define LW(psrc) \
+( { \
+  unsigned char *psrc_lw_m = (unsigned char *)(psrc); \
+  unsigned int val_m; \
+  \
+  asm volatile( \
+    "ulw %[val_m], %[psrc_lw_m] \n\t" : \
+    [val_m] "=r" (val_m) : \
+    [psrc_lw_m] "m" (*psrc_lw_m) \
+  ); \
+  \
+  val_m; \
+} )
+
+#if (__mips == 64)
+#define LD(psrc) \
+( { \
+  unsigned char *psrc_ld_m = (unsigned char *)(psrc); \
+  unsigned long long val_m = 0; \
+  \
+  asm volatile( \
+    "uld %[val_m], %[psrc_ld_m] \n\t" : \
+    [val_m] "=r" (val_m) : \
+    [psrc_ld_m] "m" (*psrc_ld_m) \
+  ); \
+  \
+  val_m; \
+} )
+#else /* !(__mips == 64) */
+#define LD(psrc) \
+( { \
+  unsigned char *psrc_ld_m = (unsigned char *)(psrc); \
+  unsigned int val0_m, val1_m; \
+  unsigned long long val_m = 0; \
+  \
+  val0_m = LW(psrc_ld_m); \
+  val1_m = LW(psrc_ld_m + 4); \
+  \
+  val_m = (unsigned long long)(val1_m); \
+  val_m = (unsigned long long)((val_m << 32) & 0xFFFFFFFF00000000); \
+  val_m = (unsigned long long)(val_m | (unsigned long long)val0_m); \
+  \
+  val_m; \
+} )
+#endif
+
+#define SW(val, pdst) { \
+  unsigned char *pdst_sw_m = (unsigned char *)(pdst); \
+  unsigned int val_m = (val); \
+  \
+  asm volatile( \
+    "usw %[val_m], %[pdst_sw_m] \n\t" : \
+    [pdst_sw_m] "=m" (*pdst_sw_m) : \
+    [val_m] "r" (val_m) \
+  ); \
+}
+
+#define SD(val, pdst) { \
+  unsigned char *pdst_sd_m = (unsigned char *)(pdst); \
+  unsigned int val0_m, val1_m; \
+  \
+  val0_m = (unsigned int)((val) & 0x00000000FFFFFFFF); \
+  val1_m = (unsigned int)(((val) >> 32) & 0x00000000FFFFFFFF); \
+  \
+  SW(val0_m, pdst_sd_m); \
+  SW(val1_m, pdst_sd_m + 4); \
+}
+#endif
+#endif
+
+/* Description: Load vectors with 16 byte elements with stride
+   Arguments  : Inputs  - psrc, stride
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Load 16 byte elements in 'out0' from (psrc)
+                Load 16 byte elements in 'out1' from (psrc + stride)
+*/
+#define LD_B2(RTYPE, psrc, stride, out0, out1) { \
+  out0 = LD_B(RTYPE, (psrc)); \
+  out1 = LD_B(RTYPE, (psrc) + stride); \
+}
+#define LD_UB2(...)  LD_B2(v16u8, __VA_ARGS__)
+#define LD_SB2(...)  LD_B2(v16i8, __VA_ARGS__)
+
+#define LD_B3(RTYPE, psrc, stride, out0, out1, out2) { \
+  LD_B2(RTYPE, (psrc), stride, out0, out1); \
+  out2 = LD_B(RTYPE, (psrc) + 2 * stride); \
+}
+#define LD_UB3(...)  LD_B3(v16u8, __VA_ARGS__)
+
+#define LD_B4(RTYPE, psrc, stride, out0, out1, out2, out3) { \
+  LD_B2(RTYPE, (psrc), stride, out0, out1); \
+  LD_B2(RTYPE, (psrc) + 2 * stride, stride, out2, out3); \
+}
+#define LD_UB4(...)  LD_B4(v16u8, __VA_ARGS__)
+#define LD_SB4(...)  LD_B4(v16i8, __VA_ARGS__)
+
+#define LD_B6(RTYPE, psrc, stride, out0, out1, out2, out3, out4, out5) { \
+  LD_B4(RTYPE, (psrc), stride, out0, out1, out2, out3); \
+  LD_B2(RTYPE, (psrc) + 4 * stride, stride, out4, out5); \
+}
+#define LD_UB6(...)  LD_B6(v16u8, __VA_ARGS__)
+
+#define LD_B8(RTYPE, psrc, stride, out0, out1, out2, out3, \
+out4, out5, out6, out7) { \
+  LD_B4(RTYPE, (psrc), stride, out0, out1, out2, out3); \
+  LD_B4(RTYPE, (psrc) + 4 * stride, stride, out4, out5, out6, out7); \
+}
+#define LD_UB8(...)  LD_B8(v16u8, __VA_ARGS__)
+#define LD_SB8(...)  LD_B8(v16i8, __VA_ARGS__)
+
+/* Description: Load vectors with 8 halfword elements with stride
+   Arguments  : Inputs  - psrc, stride
+                Outputs - out0, out1
+   Details    : Load 8 halfword elements in 'out0' from (psrc)
+                Load 8 halfword elements in 'out1' from (psrc + stride)
+*/
+#define LD_H2(RTYPE, psrc, stride, out0, out1) { \
+  out0 = LD_H(RTYPE, (psrc)); \
+  out1 = LD_H(RTYPE, (psrc) + (stride)); \
+}
+#define LD_SH2(...)  LD_H2(v8i16, __VA_ARGS__)
+
+#define LD_H4(RTYPE, psrc, stride, out0, out1, out2, out3) { \
+  LD_H2(RTYPE, (psrc), stride, out0, out1); \
+  LD_H2(RTYPE, (psrc) + 2 * stride, stride, out2, out3); \
+}
+#define LD_UH4(...)  LD_H4(v8u16, __VA_ARGS__)
+#define LD_SH4(...)  LD_H4(v8i16, __VA_ARGS__)
+
+#define LD_H6(RTYPE, psrc, stride, out0, out1, out2, out3, out4, out5) { \
+  LD_H4(RTYPE, (psrc), stride, out0, out1, out2, out3); \
+  LD_H2(RTYPE, (psrc) + 4 * stride, stride, out4, out5); \
+}
+#define LD_SH6(...)  LD_H6(v8i16, __VA_ARGS__)
+
+#define LD_H8(RTYPE, psrc, stride, out0, out1, out2, out3, \
+out4, out5, out6, out7) { \
+  LD_H4(RTYPE, (psrc), stride, out0, out1, out2, out3); \
+  LD_H4(RTYPE, (psrc) + 4 * stride, stride, out4, out5, out6, out7); \
+}
+#define LD_SH8(...)  LD_H8(v8i16, __VA_ARGS__)
+
+/* Description: Store vectors of 16 byte elements with stride
+   Arguments  : Inputs - in0, in1, pdst, stride
+   Details    : Store 16 byte elements from 'in0' to (pdst)
+                Store 16 byte elements from 'in1' to (pdst + stride)
+*/
+#define ST_B2(RTYPE, in0, in1, pdst, stride) { \
+  ST_B(RTYPE, in0, (pdst)); \
+  ST_B(RTYPE, in1, (pdst) + stride); \
+}
+#define ST_UB2(...)  ST_B2(v16u8, __VA_ARGS__)
+#define ST_SB2(...)  ST_B2(v16i8, __VA_ARGS__)
+
+#define ST_B4(RTYPE, in0, in1, in2, in3, pdst, stride) { \
+  ST_B2(RTYPE, in0, in1, (pdst), stride); \
+  ST_B2(RTYPE, in2, in3, (pdst) + 2 * stride, stride); \
+}
+#define ST_UB4(...)  ST_B4(v16u8, __VA_ARGS__)
+#define ST_SB4(...)  ST_B4(v16i8, __VA_ARGS__)
+
+#define ST_B8(RTYPE, in0, in1, in2, in3, in4, in5, in6, in7, pdst, stride) { \
+  ST_B4(RTYPE, in0, in1, in2, in3, pdst, stride); \
+  ST_B4(RTYPE, in4, in5, in6, in7, (pdst) + 4 * stride, stride); \
+}
+#define ST_UB8(...)  ST_B8(v16u8, __VA_ARGS__)
+
+/* Description: Store vectors of 8 halfword elements with stride
+   Arguments  : Inputs - in0, in1, pdst, stride
+   Details    : Store 8 halfword elements from 'in0' to (pdst)
+                Store 8 halfword elements from 'in1' to (pdst + stride)
+*/
+#define ST_H2(RTYPE, in0, in1, pdst, stride) { \
+  ST_H(RTYPE, in0, (pdst)); \
+  ST_H(RTYPE, in1, (pdst) + stride); \
+}
+#define ST_H4(RTYPE, in0, in1, in2, in3, pdst, stride) { \
+  ST_H2(RTYPE, in0, in1, (pdst), stride); \
+  ST_H2(RTYPE, in2, in3, (pdst) + 2 * stride, stride); \
+}
+#define ST_SH4(...)  ST_H4(v8i16, __VA_ARGS__)
+
+#define ST_H8(RTYPE, in0, in1, in2, in3, in4, in5, in6, in7, pdst, stride) { \
+  ST_H4(RTYPE, in0, in1, in2, in3, (pdst), stride); \
+  ST_H4(RTYPE, in4, in5, in6, in7, (pdst) + 4 * stride, stride); \
+}
+#define ST_SH8(...)  ST_H8(v8i16, __VA_ARGS__)
+
+/* Description: Store 8x1 byte block to destination memory from input vector
+   Arguments  : Inputs - in, pdst
+   Details    : Index 0 double word element from 'in' vector is copied to the
+                GP register and stored to (pdst)
+*/
+#define ST8x1_UB(in, pdst) { \
+  unsigned long long out0_m; \
+  out0_m = __msa_copy_u_d((v2i64)in, 0); \
+  SD(out0_m, pdst); \
+}
+
+/* Description: Immediate number of elements to slide with zero
+   Arguments  : Inputs  - in0, in1, slide_val
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Byte elements from 'zero_m' vector are slid into 'in0' by
+                value specified in the 'slide_val'
+*/
+#define SLDI_B2_0(RTYPE, in0, in1, out0, out1, slide_val) { \
+  v16i8 zero_m = { 0 }; \
+  out0 = (RTYPE)__msa_sldi_b((v16i8)zero_m, (v16i8)in0, slide_val); \
+  out1 = (RTYPE)__msa_sldi_b((v16i8)zero_m, (v16i8)in1, slide_val); \
+}
+
+/* Description: Immediate number of elements to slide
+   Arguments  : Inputs  - in0_0, in0_1, in1_0, in1_1, slide_val
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Byte elements from 'in0_0' vector are slid into 'in1_0' by
+                value specified in the 'slide_val'
+*/
+#define SLDI_B2(RTYPE, in0_0, in0_1, in1_0, in1_1, out0, out1, slide_val) { \
+  out0 = (RTYPE)__msa_sldi_b((v16i8)in0_0, (v16i8)in1_0, slide_val); \
+  out1 = (RTYPE)__msa_sldi_b((v16i8)in0_1, (v16i8)in1_1, slide_val); \
+}
+#define SLDI_B2_UB(...)  SLDI_B2(v16u8, __VA_ARGS__)
+
+/* Description: Shuffle byte vector elements as per mask vector
+   Arguments  : Inputs  - in0, in1, in2, in3, mask0, mask1
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Byte elements from 'in0' & 'in1' are copied selectively to
+                'out0' as per control vector 'mask0'
+*/
+#define VSHF_B2(RTYPE, in0, in1, in2, in3, mask0, mask1, out0, out1) { \
+  out0 = (RTYPE)__msa_vshf_b((v16i8)mask0, (v16i8)in1, (v16i8)in0); \
+  out1 = (RTYPE)__msa_vshf_b((v16i8)mask1, (v16i8)in3, (v16i8)in2); \
+}
+#define VSHF_B2_UB(...)  VSHF_B2(v16u8, __VA_ARGS__)
+#define VSHF_B2_SB(...)  VSHF_B2(v16i8, __VA_ARGS__)
+#define VSHF_B2_SH(...)  VSHF_B2(v8i16, __VA_ARGS__)
+
+/* Description: Dot product of halfword vector elements
+   Arguments  : Inputs  - mult0, mult1, cnst0, cnst1
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Signed halfword elements from 'mult0' are multiplied with
+                signed halfword elements from 'cnst0' producing a result
+                twice the size of input i.e. signed word.
+                The multiplication result of adjacent odd-even elements
+                are added together and written to the 'out0' vector
+*/
+#define DOTP_SH2(RTYPE, mult0, mult1, cnst0, cnst1, out0, out1) { \
+  out0 = (RTYPE)__msa_dotp_s_w((v8i16)mult0, (v8i16)cnst0); \
+  out1 = (RTYPE)__msa_dotp_s_w((v8i16)mult1, (v8i16)cnst1); \
+}
+#define DOTP_SH2_SW(...)  DOTP_SH2(v4i32, __VA_ARGS__)
+
+#define DOTP_SH4(RTYPE, mult0, mult1, mult2, mult3, \
+cnst0, cnst1, cnst2, cnst3, out0, out1, out2, out3) { \
+  DOTP_SH2(RTYPE, mult0, mult1, cnst0, cnst1, out0, out1); \
+  DOTP_SH2(RTYPE, mult2, mult3, cnst2, cnst3, out2, out3); \
+}
+#define DOTP_SH4_SW(...)  DOTP_SH4(v4i32, __VA_ARGS__)
+
+/* Description: Dot product & addition of halfword vector elements
+   Arguments  : Inputs  - mult0, mult1, cnst0, cnst1
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Signed halfword elements from 'mult0' are multiplied with
+                signed halfword elements from 'cnst0' producing a result
+                twice the size of input i.e. signed word.
+                The multiplication result of adjacent odd-even elements
+                are added to the 'out0' vector
+*/
+#define DPADD_SH2(RTYPE, mult0, mult1, cnst0, cnst1, out0, out1) { \
+  out0 = (RTYPE)__msa_dpadd_s_w((v4i32)out0, (v8i16)mult0, (v8i16)cnst0); \
+  out1 = (RTYPE)__msa_dpadd_s_w((v4i32)out1, (v8i16)mult1, (v8i16)cnst1); \
+}
+#define DPADD_SH2_SW(...)  DPADD_SH2(v4i32, __VA_ARGS__)
+
+#define DPADD_SH4(RTYPE, mult0, mult1, mult2, mult3, \
+cnst0, cnst1, cnst2, cnst3, out0, out1, out2, out3) { \
+  DPADD_SH2(RTYPE, mult0, mult1, cnst0, cnst1, out0, out1); \
+  DPADD_SH2(RTYPE, mult2, mult3, cnst2, cnst3, out2, out3); \
+}
+#define DPADD_SH4_SW(...)  DPADD_SH4(v4i32, __VA_ARGS__)
+
+/* Description: Clips all halfword elements of input vector between min & max
+                out = (in < min) ? min : ((in > max) ? max : in)
+   Arguments  : Inputs - in, min, max
+                Output - out_m
+                Return Type - signed halfword
+*/
+#define CLIP_SH(in, min, max) \
+( { \
+  v8i16 out_m; \
+  \
+  out_m = __msa_max_s_h((v8i16)min, (v8i16)in); \
+  out_m = __msa_min_s_h((v8i16)max, (v8i16)out_m); \
+  out_m; \
+} )
+
+/* Description: Clips all signed halfword elements of input vector
+                between 0 & 255
+   Arguments  : Input  - in
+                Output - out_m
+                Return Type - signed halfword
+*/
+#define CLIP_SH_0_255(in) \
+( { \
+  v8i16 max_m = __msa_ldi_h(255); \
+  v8i16 out_m; \
+  \
+  out_m = __msa_maxi_s_h((v8i16)in, 0); \
+  out_m = __msa_min_s_h((v8i16)max_m, (v8i16)out_m); \
+  out_m; \
+} )
+#define CLIP_SH2_0_255(in0, in1) { \
+  in0 = CLIP_SH_0_255(in0); \
+  in1 = CLIP_SH_0_255(in1); \
+}
+#define CLIP_SH4_0_255(in0, in1, in2, in3) { \
+  CLIP_SH2_0_255(in0, in1); \
+  CLIP_SH2_0_255(in2, in3); \
+}
+
+/* Description: Clips all signed word elements of input vector
+                between 0 & 255
+   Arguments  : Input  - in
+                Output - out_m
+                Return Type - signed word
+*/
+#define CLIP_SW_0_255(in) \
+( { \
+  v4i32 max_m = __msa_ldi_w(255); \
+  v4i32 out_m; \
+  \
+  out_m = __msa_maxi_s_w((v4i32)in, 0); \
+  out_m = __msa_min_s_w((v4i32)max_m, (v4i32)out_m); \
+  out_m \
+} )
+
+/* Description: Horizontal addition of unsigned byte vector elements
+   Arguments  : Inputs  - in0, in1
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Each unsigned odd byte element from 'in0' is added to
+                even unsigned byte element from 'in0' (pairwise) and the
+                halfword result is written to 'out0'
+*/
+#define HADD_UB2(RTYPE, in0, in1, out0, out1) { \
+  out0 = (RTYPE)__msa_hadd_u_h((v16u8)in0, (v16u8)in0); \
+  out1 = (RTYPE)__msa_hadd_u_h((v16u8)in1, (v16u8)in1); \
+}
+#define HADD_UB2_SH(...)  HADD_UB2(v8i16, __VA_ARGS__)
+
+#define HADD_UB4(RTYPE, in0, in1, in2, in3, out0, out1, out2, out3) { \
+  HADD_UB2(RTYPE, in0, in1, out0, out1); \
+  HADD_UB2(RTYPE, in2, in3, out2, out3); \
+}
+#define HADD_UB4_SH(...)  HADD_UB4(v8i16, __VA_ARGS__)
+
+/* Description: Horizontal subtraction of unsigned byte vector elements
+   Arguments  : Inputs  - in0, in1
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Each unsigned odd byte element from 'in0' is subtracted from
+                even unsigned byte element from 'in0' (pairwise) and the
+                halfword result is written to 'out0'
+*/
+#define HSUB_UB2(RTYPE, in0, in1, out0, out1) { \
+  out0 = (RTYPE)__msa_hsub_u_h((v16u8)in0, (v16u8)in0); \
+  out1 = (RTYPE)__msa_hsub_u_h((v16u8)in1, (v16u8)in1); \
+}
+#define HSUB_UB4(RTYPE, in0, in1, in2, in3, out0, out1, out2, out3) { \
+  HSUB_UB2(RTYPE, in0, in1, out0, out1); \
+  HSUB_UB2(RTYPE, in2, in3, out2, out3); \
+}
+#define HSUB_UB4_SH(...)  HSUB_UB4(v8i16, __VA_ARGS__)
+
+/* Description: Interleave left half of byte elements from vectors
+   Arguments  : Inputs  - in0, in1, in2, in3
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Left half of byte elements of 'in0' and 'in1' are interleaved
+                and written to 'out0'.
+*/
+#define ILVL_B2(RTYPE, in0, in1, in2, in3, out0, out1) { \
+  out0 = (RTYPE)__msa_ilvl_b((v16i8)in0, (v16i8)in1); \
+  out1 = (RTYPE)__msa_ilvl_b((v16i8)in2, (v16i8)in3); \
+}
+#define ILVL_B2_SH(...)  ILVL_B2(v8i16, __VA_ARGS__)
+
+/* Description: Interleave left half of halfword elements from vectors
+   Arguments  : Inputs  - in0, in1, in2, in3
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Left half of halfword elements of 'in0' and 'in1' are
+                interleaved and written to 'out0'.
+*/
+#define ILVL_H2(RTYPE, in0, in1, in2, in3, out0, out1) { \
+  out0 = (RTYPE)__msa_ilvl_h((v8i16)in0, (v8i16)in1); \
+  out1 = (RTYPE)__msa_ilvl_h((v8i16)in2, (v8i16)in3); \
+}
+#define ILVL_H2_SH(...)  ILVL_H2(v8i16, __VA_ARGS__)
+
+/* Description: Interleave right half of byte elements from vectors
+   Arguments  : Inputs  - in0, in1, in2, in3
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Right half of byte elements of 'in0' and 'in1' are interleaved
+                and written to out0.
+*/
+#define ILVR_B2(RTYPE, in0, in1, in2, in3, out0, out1) { \
+  out0 = (RTYPE)__msa_ilvr_b((v16i8)in0, (v16i8)in1); \
+  out1 = (RTYPE)__msa_ilvr_b((v16i8)in2, (v16i8)in3); \
+}
+#define ILVR_B2_SH(...)  ILVR_B2(v8i16, __VA_ARGS__)
+
+#define ILVR_B4(RTYPE, in0, in1, in2, in3, in4, in5, in6, in7, \
+out0, out1, out2, out3) { \
+  ILVR_B2(RTYPE, in0, in1, in2, in3, out0, out1); \
+  ILVR_B2(RTYPE, in4, in5, in6, in7, out2, out3); \
+}
+#define ILVR_B4_UB(...)  ILVR_B4(v16u8, __VA_ARGS__)
+#define ILVR_B4_SB(...)  ILVR_B4(v16i8, __VA_ARGS__)
+
+/* Description: Interleave right half of halfword elements from vectors
+   Arguments  : Inputs  - in0, in1, in2, in3
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Right half of halfword elements of 'in0' and 'in1' are
+                interleaved and written to 'out0'.
+*/
+#define ILVR_H2(RTYPE, in0, in1, in2, in3, out0, out1) { \
+  out0 = (RTYPE)__msa_ilvr_h((v8i16)in0, (v8i16)in1); \
+  out1 = (RTYPE)__msa_ilvr_h((v8i16)in2, (v8i16)in3); \
+}
+#define ILVR_H2_UB(...)  ILVR_H2(v16u8, __VA_ARGS__)
+#define ILVR_H2_SH(...)  ILVR_H2(v8i16, __VA_ARGS__)
+
+#define ILVR_H4(RTYPE, in0, in1, in2, in3, in4, in5, in6, in7, \
+out0, out1, out2, out3) { \
+  ILVR_H2(RTYPE, in0, in1, in2, in3, out0, out1); \
+  ILVR_H2(RTYPE, in4, in5, in6, in7, out2, out3); \
+}
+#define ILVR_H4_UB(...)  ILVR_H4(v16u8, __VA_ARGS__)
+
+/* Description: Interleave both left and right half of input vectors
+   Arguments  : Inputs  - in0, in1
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Right half of byte elements from 'in0' and 'in1' are
+                interleaved and written to 'out0'
+*/
+#define ILVRL_B2(RTYPE, in0, in1, out0, out1) { \
+  out0 = (RTYPE)__msa_ilvr_b((v16i8)in0, (v16i8)in1); \
+  out1 = (RTYPE)__msa_ilvl_b((v16i8)in0, (v16i8)in1); \
+}
+#define ILVRL_B2_UB(...)  ILVRL_B2(v16u8, __VA_ARGS__)
+#define ILVRL_B2_SB(...)  ILVRL_B2(v16i8, __VA_ARGS__)
+#define ILVRL_B2_SH(...)  ILVRL_B2(v8i16, __VA_ARGS__)
+
+#define ILVRL_H2(RTYPE, in0, in1, out0, out1) { \
+  out0 = (RTYPE)__msa_ilvr_h((v8i16)in0, (v8i16)in1); \
+  out1 = (RTYPE)__msa_ilvl_h((v8i16)in0, (v8i16)in1); \
+}
+#define ILVRL_H2_UB(...)  ILVRL_H2(v16u8, __VA_ARGS__)
+#define ILVRL_H2_SH(...)  ILVRL_H2(v8i16, __VA_ARGS__)
+#define ILVRL_H2_SW(...)  ILVRL_H2(v4i32, __VA_ARGS__)
+
+#define ILVRL_W2(RTYPE, in0, in1, out0, out1) { \
+  out0 = (RTYPE)__msa_ilvr_w((v4i32)in0, (v4i32)in1); \
+  out1 = (RTYPE)__msa_ilvl_w((v4i32)in0, (v4i32)in1); \
+}
+#define ILVRL_W2_SH(...)  ILVRL_W2(v8i16, __VA_ARGS__)
+#define ILVRL_W2_SW(...)  ILVRL_W2(v4i32, __VA_ARGS__)
+
+/* Description: Indexed halfword element values are replicated to all
+                elements in output vector
+   Arguments  : Inputs  - in, idx0, idx1
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : 'idx0' element value from 'in' vector is replicated to all
+                elements in 'out0' vector
+                Valid index range for halfword operation is 0-7
+*/
+#define SPLATI_H2(RTYPE, in, idx0, idx1, out0, out1) { \
+  out0 = (RTYPE)__msa_splati_h((v8i16)in, idx0); \
+  out1 = (RTYPE)__msa_splati_h((v8i16)in, idx1); \
+}
+#define SPLATI_H4(RTYPE, in, idx0, idx1, idx2, idx3, \
+out0, out1, out2, out3) { \
+  SPLATI_H2(RTYPE, in, idx0, idx1, out0, out1); \
+  SPLATI_H2(RTYPE, in, idx2, idx3, out2, out3); \
+}
+#define SPLATI_H4_SH(...)  SPLATI_H4(v8i16, __VA_ARGS__)
+
+/* Description: Indexed word element values are replicated to all
+                elements in output vector
+   Arguments  : Inputs  - in, stidx
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : 'stidx' element value from 'in' vector is replicated to all
+                elements in 'out0' vector
+                'stidx + 1' element value from 'in' vector is replicated to all
+                elements in 'out1' vector
+                Valid index range for word operation is 0-3
+*/
+#define SPLATI_W2(RTYPE, in, stidx, out0, out1) { \
+  out0 = (RTYPE)__msa_splati_w((v4i32)in, stidx); \
+  out1 = (RTYPE)__msa_splati_w((v4i32)in, (stidx + 1)); \
+}
+#define SPLATI_W2_SW(...)  SPLATI_W2(v4i32, __VA_ARGS__)
+
+#define SPLATI_W4(RTYPE, in, out0, out1, out2, out3) { \
+  SPLATI_W2(RTYPE, in, 0, out0, out1); \
+  SPLATI_W2(RTYPE, in, 2, out2, out3); \
+}
+#define SPLATI_W4_SW(...)  SPLATI_W4(v4i32, __VA_ARGS__)
+
+/* Description: Pack even byte elements of vector pairs
+   Arguments  : Inputs  - in0, in1, in2, in3
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Even byte elements of 'in0' are copied to the left half of
+                'out0' & even byte elements of 'in1' are copied to the right
+                half of 'out0'.
+*/
+#define PCKEV_B2(RTYPE, in0, in1, in2, in3, out0, out1) { \
+  out0 = (RTYPE)__msa_pckev_b((v16i8)in0, (v16i8)in1); \
+  out1 = (RTYPE)__msa_pckev_b((v16i8)in2, (v16i8)in3); \
+}
+#define PCKEV_B2_SB(...)  PCKEV_B2(v16i8, __VA_ARGS__)
+
+#define PCKEV_B4(RTYPE, in0, in1, in2, in3, in4, in5, in6, in7, \
+out0, out1, out2, out3) { \
+  PCKEV_B2(RTYPE, in0, in1, in2, in3, out0, out1); \
+  PCKEV_B2(RTYPE, in4, in5, in6, in7, out2, out3); \
+}
+#define PCKEV_B4_UB(...)  PCKEV_B4(v16u8, __VA_ARGS__)
+
+/* Description: Pack even halfword elements of vector pairs
+   Arguments  : Inputs  - in0, in1, in2, in3
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Even halfword elements of 'in0' are copied to the left half of
+                'out0' & even halfword elements of 'in1' are copied to the
+                right half of 'out0'.
+*/
+#define PCKEV_H2(RTYPE, in0, in1, in2, in3, out0, out1) { \
+  out0 = (RTYPE)__msa_pckev_h((v8i16)in0, (v8i16)in1); \
+  out1 = (RTYPE)__msa_pckev_h((v8i16)in2, (v8i16)in3); \
+}
+#define PCKEV_H2_SH(...)  PCKEV_H2(v8i16, __VA_ARGS__)
+#define PCKEV_H2_SW(...)  PCKEV_H2(v4i32, __VA_ARGS__)
+
+/* Description: Pack even double word elements of vector pairs
+   Arguments  : Inputs  - in0, in1, in2, in3
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Even double elements of 'in0' are copied to the left half of
+                'out0' & even double elements of 'in1' are copied to the right
+                half of 'out0'.
+*/
+#define PCKEV_D2(RTYPE, in0, in1, in2, in3, out0, out1) { \
+  out0 = (RTYPE)__msa_pckev_d((v2i64)in0, (v2i64)in1); \
+  out1 = (RTYPE)__msa_pckev_d((v2i64)in2, (v2i64)in3); \
+}
+#define PCKEV_D4(RTYPE, in0, in1, in2, in3, in4, in5, in6, in7, \
+out0, out1, out2, out3) { \
+  PCKEV_D2(RTYPE, in0, in1, in2, in3, out0, out1); \
+  PCKEV_D2(RTYPE, in4, in5, in6, in7, out2, out3); \
+}
+
+/* Description: Pack odd half elements of vector pairs
+   Arguments  : Inputs  - in0, in1, in2, in3
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Odd half elements of 'in0' are copied to the left half of
+                'out0' & odd half elements of 'in1' are copied to the right
+                half of 'out0'.
+*/
+#define PCKOD_H2(RTYPE, in0, in1, in2, in3, out0, out1) { \
+  out0 = (RTYPE)__msa_pckod_h((v8i16)in0, (v8i16)in1); \
+  out1 = (RTYPE)__msa_pckod_h((v8i16)in2, (v8i16)in3); \
+}
+#define PCKOD_H2_SH(...)  PCKOD_H2(v8i16, __VA_ARGS__)
+
+/* Description: Shift left all elements of word vector
+   Arguments  : Inputs  - in0, in1, in2, in3, shift
+                Outputs - in place operation
+                Return Type - as per input vector RTYPE
+   Details    : Each element of vector 'in0' is left shifted by 'shift' and
+                the result is written in-place.
+*/
+#define SLLI_W4(RTYPE, in0, in1, in2, in3, shift_val) { \
+  in0 = (RTYPE)MSA_SLLI_W(in0, shift_val); \
+  in1 = (RTYPE)MSA_SLLI_W(in1, shift_val); \
+  in2 = (RTYPE)MSA_SLLI_W(in2, shift_val); \
+  in3 = (RTYPE)MSA_SLLI_W(in3, shift_val); \
+}
+#define SLLI_W4_SW(...)  SLLI_W4(v4i32, __VA_ARGS__)
+
+/* Description: Arithmetic shift right all elements of half-word vector
+   Arguments  : Inputs  - in0, in1, in2, in3, shift
+                Outputs - in place operation
+                Return Type - as per input vector RTYPE
+   Details    : Each element of vector 'in0' is right shifted by 'shift' and
+                the result is written in-place. 'shift' is a GP variable.
+*/
+#define SRAI_H2(RTYPE, in0, in1, shift) { \
+  in0 = (RTYPE)__msa_srai_h((v8i16)in0, shift); \
+  in1 = (RTYPE)__msa_srai_h((v8i16)in1, shift); \
+}
+#define SRAI_H2_SH(...)  SRAI_H2(v8i16, __VA_ARGS__)
+
+#define SRAI_H4(RTYPE, in0, in1, in2, in3, shift) { \
+  SRAI_H2(RTYPE, in0, in1, shift); \
+  SRAI_H2(RTYPE, in2, in3, shift); \
+}
+#define SRAI_H4_SH(...)  SRAI_H4(v8i16, __VA_ARGS__)
+
+/* Description: Arithmetic shift right all elements of word vector
+   Arguments  : Inputs  - in0, in1, in2, in3, shift
+                Outputs - in place operation
+                Return Type - as per input vector RTYPE
+   Details    : Each element of vector 'in0' is right shifted by 'shift' and
+                the result is written in-place. 'shift' is a GP variable.
+*/
+#define SRAI_W4(RTYPE, in0, in1, in2, in3, shift_val) { \
+  in0 = (RTYPE)MSA_SRAI_W(in0, shift_val); \
+  in1 = (RTYPE)MSA_SRAI_W(in1, shift_val); \
+  in2 = (RTYPE)MSA_SRAI_W(in2, shift_val); \
+  in3 = (RTYPE)MSA_SRAI_W(in3, shift_val); \
+}
+#define SRAI_W4_SW(...)  SRAI_W4(v4i32, __VA_ARGS__)
+
+/* Description: Shift right arithmetic rounded (immediate)
+   Arguments  : Inputs  - in0, in1, shift
+                Outputs - in place operation
+                Return Type - as per RTYPE
+   Details    : Each element of vector 'in0' is shifted right arithmetically by
+                the value in 'shift'. The last discarded bit is added to the
+                shifted value for rounding and the result is written in-place.
+                'shift' is an immediate value.
+*/
+#define SRARI_H2(RTYPE, in0, in1, shift) { \
+  in0 = (RTYPE)__msa_srari_h((v8i16)in0, shift); \
+  in1 = (RTYPE)__msa_srari_h((v8i16)in1, shift); \
+}
+#define SRARI_H2_UH(...)  SRARI_H2(v8u16, __VA_ARGS__)
+#define SRARI_H2_SH(...)  SRARI_H2(v8i16, __VA_ARGS__)
+
+#define SRARI_H4(RTYPE, in0, in1, in2, in3, shift) { \
+  SRARI_H2(RTYPE, in0, in1, shift); \
+  SRARI_H2(RTYPE, in2, in3, shift); \
+}
+#define SRARI_H4_UH(...)  SRARI_H4(v8u16, __VA_ARGS__)
+#define SRARI_H4_SH(...)  SRARI_H4(v8i16, __VA_ARGS__)
+
+#define SRARI_W2(RTYPE, in0, in1, shift) { \
+  in0 = (RTYPE)__msa_srari_w((v4i32)in0, shift); \
+  in1 = (RTYPE)__msa_srari_w((v4i32)in1, shift); \
+}
+#define SRARI_W2_SW(...)  SRARI_W2(v4i32, __VA_ARGS__)
+
+#define SRARI_W4(RTYPE, in0, in1, in2, in3, shift) { \
+  SRARI_W2(RTYPE, in0, in1, shift); \
+  SRARI_W2(RTYPE, in2, in3, shift); \
+}
+#define SRARI_W4_SW(...)  SRARI_W4(v4i32, __VA_ARGS__)
+
+/* Description: Multiplication of pairs of vectors
+   Arguments  : Inputs  - in0, in1, in2, in3
+                Outputs - out0, out1
+   Details    : Each element from 'in0' is multiplied with elements from 'in1'
+                and the result is written to 'out0'
+*/
+#define MUL2(in0, in1, in2, in3, out0, out1) { \
+  out0 = in0 * in1; \
+  out1 = in2 * in3; \
+}
+#define MUL4(in0, in1, in2, in3, in4, in5, in6, in7, \
+out0, out1, out2, out3) { \
+  MUL2(in0, in1, in2, in3, out0, out1); \
+  MUL2(in4, in5, in6, in7, out2, out3); \
+}
+
+/* Description: XOR of 2 pairs of vectors
+   Arguments  : Inputs  - in0, in1, in2, in3
+                Outputs - out0, out1
+                Return Type - as per RTYPE
+   Details    : Each element in 'in0' is xor'ed with 'in1' and result is
+                 written to 'out0'.
+*/
+#define XOR_V2(RTYPE, in0, in1, in2, in3, out0, out1) { \
+  out0 = (RTYPE)((v16u8)in0 ^ (v16u8)in1); \
+  out1 = (RTYPE)((v16u8)in2 ^ (v16u8)in3); \
+}
+#define XOR_V4(RTYPE, in0, in1, in2, in3, in4, in5, in6, in7, \
+out0, out1, out2, out3) { \
+  XOR_V2(RTYPE, in0, in1, in2, in3, out0, out1); \
+  XOR_V2(RTYPE, in4, in5, in6, in7, out2, out3); \
+}
+#define XOR_V4_SH(...)  XOR_V4(v8i16, __VA_ARGS__);
+
+/* Description: Addition of 2 pairs of vectors
+   Arguments  : Inputs  - in0, in1, in2, in3
+                Outputs - out0, out1
+   Details    : Each element in 'in0' is added to 'in1' and result is written
+                to 'out0'.
+*/
+#define ADD2(in0, in1, in2, in3, out0, out1) { \
+  out0 = in0 + in1; \
+  out1 = in2 + in3; \
+}
+#define ADD4(in0, in1, in2, in3, in4, in5, in6, in7, \
+out0, out1, out2, out3) { \
+  ADD2(in0, in1, in2, in3, out0, out1); \
+  ADD2(in4, in5, in6, in7, out2, out3); \
+}
+
+/* Description: Subtraction of 2 pairs of vectors
+   Arguments  : Inputs  - in0, in1, in2, in3
+                Outputs - out0, out1
+   Details    : Each element in 'in1' is subtracted from 'in0' and result is
+                written to 'out0'.
+*/
+#define SUB2(in0, in1, in2, in3, out0, out1) { \
+  out0 = in0 - in1; \
+  out1 = in2 - in3; \
+}
+#define SUB4(in0, in1, in2, in3, in4, in5, in6, in7, \
+out0, out1, out2, out3) { \
+  out0 = in0 - in1; \
+  out1 = in2 - in3; \
+  out2 = in4 - in5; \
+  out3 = in6 - in7; \
+}
+
+/* Description: Sign extend byte elements from input vector and return
+                halfword results in pair of vectors
+   Arguments  : Input   - in         (byte vector)
+                Outputs - out0, out1 (sign extended halfword vectors)
+                Return Type - signed halfword
+   Details    : Sign bit of byte elements from input vector 'in' is
+                extracted and interleaved right with same vector 'in0' to
+                generate 8 signed halfword elements in 'out0'
+                Then interleaved left with same vector 'in0' to
+                generate 8 signed halfword elements in 'out1'
+*/
+#define UNPCK_SB_SH(in, out0, out1) { \
+  v16i8 tmp_m; \
+  \
+  tmp_m = __msa_clti_s_b((v16i8)in, 0); \
+  ILVRL_B2_SH(tmp_m, in, out0, out1); \
+}
+
+/* Description: Zero extend unsigned byte elements to halfword elements
+   Arguments  : Input   - in         (unsigned byte vector)
+                Outputs - out0, out1 (unsigned  halfword vectors)
+                Return Type - signed halfword
+   Details    : Zero extended right half of vector is returned in 'out0'
+                Zero extended left half of vector is returned in 'out1'
+*/
+#define UNPCK_UB_SH(in, out0, out1) { \
+  v16i8 zero_m = { 0 }; \
+  \
+  ILVRL_B2_SH(zero_m, in, out0, out1); \
+}
+
+/* Description: Sign extend halfword elements from input vector and return
+                the result in pair of vectors
+   Arguments  : Input   - in         (halfword vector)
+                Outputs - out0, out1 (sign extended word vectors)
+                Return Type - signed word
+   Details    : Sign bit of halfword elements from input vector 'in' is
+                extracted and interleaved right with same vector 'in0' to
+                generate 4 signed word elements in 'out0'
+                Then interleaved left with same vector 'in0' to
+                generate 4 signed word elements in 'out1'
+*/
+#define UNPCK_SH_SW(in, out0, out1) { \
+  v8i16 tmp_m; \
+  \
+  tmp_m = __msa_clti_s_h((v8i16)in, 0); \
+  ILVRL_H2_SW(tmp_m, in, out0, out1); \
+}
+#define UNPCK_SH2_SW(in0, in1, out0, out1, out2, out3) { \
+  UNPCK_SH_SW(in0, out0, out1); \
+  UNPCK_SH_SW(in1, out2, out3); \
+}
+#define UNPCK_SH4_SW(in0, in1, in2, in3, out0, out1, out2, out3, \
+out4, out5, out6, out7) { \
+  UNPCK_SH2_SW(in0, in1, out0, out1, out2, out3); \
+  UNPCK_SH2_SW(in2, in3, out4, out5, out6, out7); \
+}
+
+/* Description: Butterfly of 4 input vectors
+   Arguments  : Inputs  - in0, in1, in2, in3
+                Outputs - out0, out1, out2, out3
+   Details    : Butterfly operation
+*/
+#define BUTTERFLY_4(in0, in1, in2, in3, out0, out1, out2, out3) { \
+  out0 = in0 + in3; \
+  out1 = in1 + in2; \
+  \
+  out2 = in1 - in2; \
+  out3 = in0 - in3; \
+}
+
+/* Description: Butterfly of 8 input vectors
+   Arguments  : Inputs  - in0 ...  in7
+                Outputs - out0 .. out7
+   Details    : Butterfly operation
+*/
+#define BUTTERFLY_8(in0, in1, in2, in3, in4, in5, in6, in7, \
+out0, out1, out2, out3, out4, out5, out6, out7) { \
+  out0 = in0 + in7; \
+  out1 = in1 + in6; \
+  out2 = in2 + in5; \
+  out3 = in3 + in4; \
+  \
+  out4 = in3 - in4; \
+  out5 = in2 - in5; \
+  out6 = in1 - in6; \
+  out7 = in0 - in7; \
+}
+
+/* Description: Transpose input 8x8 byte block
+   Arguments  : Inputs  - in0, in1, in2, in3, in4, in5, in6, in7
+                Outputs - out0, out1, out2, out3, out4, out5, out6, out7
+                Return Type - as per RTYPE
+*/
+#define TRANSPOSE8x8_UB(RTYPE, in0, in1, in2, in3, in4, in5, in6, in7, \
+out0, out1, out2, out3, out4, out5, out6, out7) { \
+  v16i8 tmp0_m, tmp1_m, tmp2_m, tmp3_m; \
+  v16i8 tmp4_m, tmp5_m, tmp6_m, tmp7_m; \
+  \
+  ILVR_B4_SB(in2, in0, in3, in1, in6, in4, in7, in5, \
+             tmp0_m, tmp1_m, tmp2_m, tmp3_m); \
+  ILVRL_B2_SB(tmp1_m, tmp0_m, tmp4_m, tmp5_m); \
+  ILVRL_B2_SB(tmp3_m, tmp2_m, tmp6_m, tmp7_m); \
+  ILVRL_W2(RTYPE, tmp6_m, tmp4_m, out0, out2); \
+  ILVRL_W2(RTYPE, tmp7_m, tmp5_m, out4, out6); \
+  SLDI_B2_0(RTYPE, out0, out2, out1, out3, 8); \
+  SLDI_B2_0(RTYPE, out4, out6, out5, out7, 8); \
+}
+#define TRANSPOSE8x8_UB_UB(...)  TRANSPOSE8x8_UB(v16u8, __VA_ARGS__)
+
+/* Description: Transpose 8x8 block with half word elements in vectors
+   Arguments  : Inputs  - in0, in1, in2, in3, in4, in5, in6, in7
+                Outputs - out0, out1, out2, out3, out4, out5, out6, out7
+                Return Type - as per RTYPE
+*/
+#define TRANSPOSE8x8_H(RTYPE, in0, in1, in2, in3, in4, in5, in6, in7, \
+out0, out1, out2, out3, out4, out5, out6, out7) { \
+  v8i16 s0_m, s1_m; \
+  v8i16 tmp0_m, tmp1_m, tmp2_m, tmp3_m; \
+  v8i16 tmp4_m, tmp5_m, tmp6_m, tmp7_m; \
+  \
+  ILVR_H2_SH(in6, in4, in7, in5, s0_m, s1_m); \
+  ILVRL_H2_SH(s1_m, s0_m, tmp0_m, tmp1_m); \
+  ILVL_H2_SH(in6, in4, in7, in5, s0_m, s1_m); \
+  ILVRL_H2_SH(s1_m, s0_m, tmp2_m, tmp3_m); \
+  ILVR_H2_SH(in2, in0, in3, in1, s0_m, s1_m); \
+  ILVRL_H2_SH(s1_m, s0_m, tmp4_m, tmp5_m); \
+  ILVL_H2_SH(in2, in0, in3, in1, s0_m, s1_m); \
+  ILVRL_H2_SH(s1_m, s0_m, tmp6_m, tmp7_m); \
+  PCKEV_D4(RTYPE, tmp0_m, tmp4_m, tmp1_m, tmp5_m, tmp2_m, tmp6_m, \
+           tmp3_m, tmp7_m, out0, out2, out4, out6); \
+  out1 = (RTYPE)__msa_pckod_d((v2i64)tmp0_m, (v2i64)tmp4_m); \
+  out3 = (RTYPE)__msa_pckod_d((v2i64)tmp1_m, (v2i64)tmp5_m); \
+  out5 = (RTYPE)__msa_pckod_d((v2i64)tmp2_m, (v2i64)tmp6_m); \
+  out7 = (RTYPE)__msa_pckod_d((v2i64)tmp3_m, (v2i64)tmp7_m); \
+}
+#define TRANSPOSE8x8_SH_SH(...)  TRANSPOSE8x8_H(v8i16, __VA_ARGS__)
+
+/* Description: Transpose 4x4 block with word elements in vectors
+   Arguments  : Inputs  - in0, in1, in2, in3
+                Outputs - out0, out1, out2, out3
+                Return Type - as per RTYPE
+*/
+#define TRANSPOSE4x4_W(RTYPE, in0, in1, in2, in3, out0, out1, out2, out3) { \
+  v4i32 s0_m, s1_m, s2_m, s3_m; \
+  \
+  ILVRL_W2_SW(in1, in0, s0_m, s1_m); \
+  ILVRL_W2_SW(in3, in2, s2_m, s3_m); \
+  \
+  out0 = (RTYPE)__msa_ilvr_d((v2i64)s2_m, (v2i64)s0_m); \
+  out1 = (RTYPE)__msa_ilvl_d((v2i64)s2_m, (v2i64)s0_m); \
+  out2 = (RTYPE)__msa_ilvr_d((v2i64)s3_m, (v2i64)s1_m); \
+  out3 = (RTYPE)__msa_ilvl_d((v2i64)s3_m, (v2i64)s1_m); \
+}
+#define TRANSPOSE4x4_SW_SW(...)  TRANSPOSE4x4_W(v4i32, __VA_ARGS__)
+
+#endif /* __JMACROS_MSA_H__ */

--- a/simd/mips/jquanti_msa.c
+++ b/simd/mips/jquanti_msa.c
@@ -1,0 +1,152 @@
+/*
+ * MIPS MSA optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * All rights reserved.
+ * Authors: Vikram Dattu (vikram.dattu@imgtec.com)
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* INTEGER QUANTIZATION AND SAMPLE CONVERSION */
+
+#define JPEG_INTERNALS
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "../../jsimd.h"
+#include "../../jdct.h"
+#include "jmacros_msa.h"
+
+
+GLOBAL(void)
+jsimd_convsamp_msa(JSAMPARRAY sample_data, JDIMENSION start_col,
+                   DCTELEM *workspace)
+{
+  v16u8 val0, val1, val2, val3, val4, val5, val6, val7;
+  v16u8 tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7;
+  v8i16 dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7;
+  v16u8 reg_128 = (v16u8)__msa_ldi_b(128);
+
+  val0 = LD_UB(sample_data[0] + start_col);
+  val1 = LD_UB(sample_data[1] + start_col);
+  val2 = LD_UB(sample_data[2] + start_col);
+  val3 = LD_UB(sample_data[3] + start_col);
+  val4 = LD_UB(sample_data[4] + start_col);
+  val5 = LD_UB(sample_data[5] + start_col);
+  val6 = LD_UB(sample_data[6] + start_col);
+  val7 = LD_UB(sample_data[7] + start_col);
+
+  /* Interleave with CENTERSAMPLE */
+  ILVR_B4_UB(val0, reg_128, val1, reg_128, val2, reg_128, val3, reg_128,
+             tmp0, tmp1, tmp2, tmp3);
+  ILVR_B4_UB(val4, reg_128, val5, reg_128, val6, reg_128, val7, reg_128,
+             tmp4, tmp5, tmp6, tmp7);
+
+  /* Subtract CENTRESAMPLE from u8 sample */
+  HSUB_UB4_SH(tmp0, tmp1, tmp2, tmp3, dst0, dst1, dst2, dst3);
+  HSUB_UB4_SH(tmp4, tmp5, tmp6, tmp7, dst4, dst5, dst6, dst7);
+
+  /* Store results */
+  ST_SH8(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7, workspace, 8);
+}
+
+GLOBAL(void)
+jsimd_quantize_msa(JCOEFPTR coef_block, DCTELEM *divisors, DCTELEM *workspace)
+{
+  DCTELEM *recip, *corr, *shift;
+  JDIMENSION cnt;
+  v4i32 tmp0_r, tmp0_l, tmp1_r, tmp1_l, tmp2_r, tmp2_l, tmp3_r, tmp3_l;
+  v4i32 shift0_r, shift1_r, shift2_r, shift3_r, shift0_l, shift1_l, shift2_l;
+  v4i32 shift3_l, recip0_r, recip0_l, recip1_r, recip1_l;
+  v4i32 recip2_r, recip2_l, recip3_r, recip3_l;
+  v8i16 val0, val1, val2, val3, recip0, recip1, recip2, recip3;
+  v8i16 corr0, corr1, corr2, corr3, shift0, shift1, shift2, shift3;
+  v8i16 sign0, sign1, sign2, sign3, zero = { 0 };
+
+  recip = divisors + 0 * 64;
+  corr = divisors + 1 * 64;
+  shift = divisors + 3 * 64;
+
+  for (cnt = 0; cnt < 2; cnt++) {
+    /* Load data, recip, corr, shift vectors */
+    LD_SH4((workspace + cnt * 32), 8, val0, val1, val2, val3);
+    LD_SH4((recip + cnt * 32), 8, recip0, recip1, recip2, recip3);
+    LD_SH4((corr + cnt * 32), 8, corr0, corr1, corr2, corr3);
+    LD_SH4((shift + cnt * 32), 8, shift0, shift1, shift2, shift3);
+
+    /* Sign */
+    sign0 = MSA_SRAI_H(val0, 15);
+    sign1 = MSA_SRAI_H(val1, 15);
+    sign2 = MSA_SRAI_H(val2, 15);
+    sign3 = MSA_SRAI_H(val3, 15);
+
+    /* Calculate absolute */
+    XOR_V4_SH(val0, sign0, val1, sign1, val2, sign2, val3, sign3,
+              val0, val1, val2, val3);
+    SUB4(val0, sign0, val1, sign1, val2, sign2, val3, sign3,
+         val0, val1, val2, val3);
+
+    /* Add correction factor */
+    ADD4(val0, corr0, val1, corr1, val2, corr2, val3, corr3,
+         val0, val1, val2, val3);
+
+    /* Prepare for multiplication; Promote to 32 bit */
+    ILVRL_H2_SW(zero, val0, tmp0_r, tmp0_l);
+    ILVRL_H2_SW(zero, val1, tmp1_r, tmp1_l);
+    ILVRL_H2_SW(zero, val2, tmp2_r, tmp2_l);
+    ILVRL_H2_SW(zero, val3, tmp3_r, tmp3_l);
+    ILVRL_H2_SW(zero, recip0, recip0_r, recip0_l);
+    ILVRL_H2_SW(zero, recip1, recip1_r, recip1_l);
+    ILVRL_H2_SW(zero, recip2, recip2_r, recip2_l);
+    ILVRL_H2_SW(zero, recip3, recip3_r, recip3_l);
+
+    /* Multiply: val * recip */
+    MUL4(tmp0_r, recip0_r, tmp0_l, recip0_l, tmp1_r, recip1_r,
+         tmp1_l, recip1_l, tmp0_r, tmp0_l, tmp1_r, tmp1_l);
+    MUL4(tmp2_r, recip2_r, tmp2_l, recip2_l, tmp3_r, recip3_r,
+         tmp3_l, recip3_l, tmp2_r, tmp2_l, tmp3_r, tmp3_l);
+
+    /* Promote shift to 32 bit */
+    ILVRL_H2_SW(zero, shift0, shift0_r, shift0_l);
+    ILVRL_H2_SW(zero, shift1, shift1_r, shift1_l);
+    ILVRL_H2_SW(zero, shift2, shift2_r, shift2_l);
+    ILVRL_H2_SW(zero, shift3, shift3_r, shift3_l);
+
+    /* Shift by promoted shift register values */
+    tmp0_r >>= shift0_r;
+    tmp1_r >>= shift1_r;
+    tmp2_r >>= shift2_r;
+    tmp3_r >>= shift3_r;
+    tmp0_l >>= shift0_l;
+    tmp1_l >>= shift1_l;
+    tmp2_l >>= shift2_l;
+    tmp3_l >>= shift3_l;
+
+    /* We need to right shift by 16 and then pckev. */
+    /* Instead we'll do pckod. */
+    PCKOD_H2_SH(tmp0_l, tmp0_r, tmp1_l, tmp1_r, val0, val1);
+    PCKOD_H2_SH(tmp2_l, tmp2_r, tmp3_l, tmp3_r, val2, val3);
+
+    /* Apply back original signs */
+    XOR_V4_SH(val0, sign0, val1, sign1, val2, sign2, val3, sign3,
+              val0, val1, val2, val3);
+    SUB4(val0, sign0, val1, sign1, val2, sign2, val3, sign3,
+         val0, val1, val2, val3);
+
+    /* Store results */
+    ST_SH4(val0, val1, val2, val3, (coef_block + cnt * 32), 8);
+  }
+}

--- a/simd/mips/jsimd_dspr2.c
+++ b/simd/mips/jsimd_dspr2.c
@@ -1,5 +1,5 @@
 /*
- * jsimd_mips.c
+ * jsimd_dspr2.c
  *
  * Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
  * Copyright (C) 2009-2011, 2014, 2016, 2018, D. R. Commander.

--- a/simd/mips/jsimd_dspr2.c
+++ b/simd/mips/jsimd_dspr2.c
@@ -73,7 +73,7 @@ init_simd(void)
 
   simd_support = 0;
 
-#if defined(__MIPSEL__) && defined(__mips_dsp) && (__mips_dsp_rev >= 2)
+#if defined(__MIPSEL__) && defined(__mips_dsp) && (__mips_dsp_rev == 2)
   simd_support |= JSIMD_DSPR2;
 #elif defined(__linux__)
   /* We still have a chance to use MIPS DSPR2 regardless of globally used

--- a/simd/mips/jsimd_msa.c
+++ b/simd/mips/jsimd_msa.c
@@ -1,0 +1,960 @@
+/*
+ * jsimd_msa.c
+ *
+ * Copyright (C) 2016-2017, Imagination Technologies.
+ * Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+ * Copyright 2009-2011, 2014 D. R. Commander
+ * Copyright 2015 Matthieu Darbois
+ *
+ * This file contains the interface between the "normal" portions
+ * of the library and the MSA implementations when running on a
+ * MIPS architecture.
+ */
+
+#define JPEG_INTERNALS
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "../../jsimd.h"
+#include "../../jdct.h"
+#include "../../jsimddct.h"
+#include "../jsimd.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+
+static unsigned int simd_support = ~0;
+
+#if defined(__linux__)
+
+LOCAL(int)
+parse_proc_cpuinfo(void)
+{
+  const char *file_name = "/proc/cpuinfo";
+  char cpuinfo_line[256];
+  FILE *f = NULL;
+  simd_support = 0;
+
+  if ((f = fopen(file_name, "r")) != NULL) {
+    while (fgets(cpuinfo_line, sizeof(cpuinfo_line), f) != NULL) {
+      if (strstr(cpuinfo_line, "msa") != NULL) {
+        fclose(f);
+        simd_support |= JSIMD_MSA;
+        return 1;
+      }
+    }
+    fclose(f);
+  }
+
+  /* Did not find string in the proc file, or not Linux ELF. */
+  return 0;
+}
+
+#endif
+
+/*
+ * Check what SIMD accelerations are supported.
+ *
+ * FIXME: This code is racy under a multi-threaded environment.
+ */
+LOCAL(void)
+init_simd(void)
+{
+  if (simd_support != ~0U)
+    return;
+
+  simd_support = 0;
+
+#if defined(__MIPSEL__) && defined(__mips_msa) && (__mips_isa_rev >= 5)
+  simd_support |= JSIMD_MSA;
+#elif defined(__linux__)
+  /* We still have a chance to use MSA regardless of globally used
+   * -mmsa option passed to gcc by performing runtime detection via
+   * /proc/cpuinfo parsing on linux */
+  parse_proc_cpuinfo();
+  return;
+#endif
+}
+
+GLOBAL(int)
+jsimd_can_rgb_ycc(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+  if ((RGB_PIXELSIZE != 3) && (RGB_PIXELSIZE != 4))
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_rgb_gray(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+  if ((RGB_PIXELSIZE != 3) && (RGB_PIXELSIZE != 4))
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_ycc_rgb(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+  if ((RGB_PIXELSIZE != 3) && (RGB_PIXELSIZE != 4))
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_ycc_rgb565(void)
+{
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_c_can_null_convert(void)
+{
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_rgb_ycc_convert(j_compress_ptr cinfo,
+                      JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+                      JDIMENSION output_row, int num_rows)
+{
+  void (*msafct) (JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
+
+  switch (cinfo->in_color_space) {
+    case JCS_EXT_RGB:
+      msafct = jsimd_extrgb_ycc_convert_msa;
+      break;
+    case JCS_EXT_RGBX:
+    case JCS_EXT_RGBA:
+      msafct = jsimd_extrgbx_ycc_convert_msa;
+      break;
+    case JCS_EXT_BGR:
+      msafct = jsimd_extbgr_ycc_convert_msa;
+      break;
+    case JCS_EXT_BGRX:
+    case JCS_EXT_BGRA:
+      msafct = jsimd_extbgrx_ycc_convert_msa;
+      break;
+    case JCS_EXT_XBGR:
+    case JCS_EXT_ABGR:
+      msafct = jsimd_extxbgr_ycc_convert_msa;
+      break;
+    case JCS_EXT_XRGB:
+    case JCS_EXT_ARGB:
+      msafct = jsimd_extxrgb_ycc_convert_msa;
+      break;
+    default:
+      msafct = jsimd_extrgb_ycc_convert_msa;
+      break;
+  }
+
+  msafct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
+}
+
+GLOBAL(void)
+jsimd_rgb_gray_convert(j_compress_ptr cinfo,
+                       JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+                       JDIMENSION output_row, int num_rows)
+{
+  void (*msafct) (JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
+
+  switch (cinfo->in_color_space) {
+    case JCS_EXT_RGB:
+      msafct = jsimd_extrgb_gray_convert_msa;
+      break;
+    case JCS_EXT_RGBX:
+    case JCS_EXT_RGBA:
+      msafct = jsimd_extrgbx_gray_convert_msa;
+      break;
+    case JCS_EXT_BGR:
+      msafct = jsimd_extbgr_gray_convert_msa;
+      break;
+    case JCS_EXT_BGRX:
+    case JCS_EXT_BGRA:
+      msafct = jsimd_extbgrx_gray_convert_msa;
+      break;
+    case JCS_EXT_XBGR:
+    case JCS_EXT_ABGR:
+      msafct = jsimd_extxbgr_gray_convert_msa;
+      break;
+    case JCS_EXT_XRGB:
+    case JCS_EXT_ARGB:
+      msafct = jsimd_extxrgb_gray_convert_msa;
+      break;
+    default:
+      msafct = jsimd_rgb_gray_convert_msa;
+      break;
+  }
+
+  msafct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
+}
+
+GLOBAL(void)
+jsimd_ycc_rgb_convert(j_decompress_ptr cinfo,
+                      JSAMPIMAGE input_buf, JDIMENSION input_row,
+                      JSAMPARRAY output_buf, int num_rows)
+{
+  void (*mipsoptfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY, int);
+
+  switch (cinfo->out_color_space) {
+    case JCS_EXT_RGB:
+      mipsoptfct = jsimd_ycc_extrgb_convert_msa;
+      break;
+    case JCS_EXT_RGBX:
+    case JCS_EXT_RGBA:
+      mipsoptfct = jsimd_ycc_extrgbx_convert_msa;
+      break;
+    case JCS_EXT_BGR:
+      mipsoptfct = jsimd_ycc_extbgr_convert_msa;
+      break;
+    case JCS_EXT_BGRX:
+    case JCS_EXT_BGRA:
+      mipsoptfct = jsimd_ycc_extbgrx_convert_msa;
+      break;
+    case JCS_EXT_XBGR:
+    case JCS_EXT_ABGR:
+      mipsoptfct = jsimd_ycc_extxbgr_convert_msa;
+      break;
+    case JCS_EXT_XRGB:
+    case JCS_EXT_ARGB:
+      mipsoptfct = jsimd_ycc_extxrgb_convert_msa;
+      break;
+    default:
+      mipsoptfct = jsimd_ycc_extrgb_convert_msa;
+      break;
+  }
+
+  mipsoptfct(cinfo->output_width, input_buf, input_row, output_buf,
+             num_rows);
+}
+
+GLOBAL(void)
+jsimd_ycc_rgb565_convert(j_decompress_ptr cinfo,
+                         JSAMPIMAGE input_buf, JDIMENSION input_row,
+                         JSAMPARRAY output_buf, int num_rows)
+{
+  jsimd_ycc_rgb565_convert_msa(cinfo->output_width, input_buf, input_row,
+                               output_buf, num_rows);
+}
+
+GLOBAL(void)
+jsimd_c_null_convert(j_compress_ptr cinfo,
+                     JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
+                     JDIMENSION output_row, int num_rows)
+{
+}
+
+GLOBAL(int)
+jsimd_can_h2v2_downsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_h2v2_smooth_downsample(void)
+{
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_h2v1_downsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_h2v2_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
+                      JSAMPARRAY input_data, JSAMPARRAY output_data)
+{
+  jsimd_h2v2_downsample_msa(cinfo->image_width, cinfo->max_v_samp_factor,
+                            compptr->v_samp_factor, compptr->width_in_blocks,
+                            input_data, output_data);
+}
+
+GLOBAL(void)
+jsimd_h2v2_smooth_downsample(j_compress_ptr cinfo,
+                             jpeg_component_info *compptr,
+                             JSAMPARRAY input_data, JSAMPARRAY output_data)
+{
+}
+
+GLOBAL(void)
+jsimd_h2v1_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
+                      JSAMPARRAY input_data, JSAMPARRAY output_data)
+{
+  jsimd_h2v1_downsample_msa(cinfo->image_width, cinfo->max_v_samp_factor,
+                            compptr->v_samp_factor, compptr->width_in_blocks,
+                            input_data, output_data);
+}
+
+GLOBAL(int)
+jsimd_can_h2v2_upsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_h2v1_upsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_int_upsample(void)
+{
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_h2v2_upsample(j_decompress_ptr cinfo,
+                    jpeg_component_info *compptr,
+                    JSAMPARRAY input_data,
+                    JSAMPARRAY *output_data_ptr)
+{
+  jsimd_h2v2_upsample_msa(cinfo->max_v_samp_factor, cinfo->output_width,
+                          input_data, output_data_ptr);
+}
+
+GLOBAL(void)
+jsimd_h2v1_upsample(j_decompress_ptr cinfo,
+                    jpeg_component_info *compptr,
+                    JSAMPARRAY input_data,
+                    JSAMPARRAY *output_data_ptr)
+{
+  jsimd_h2v1_upsample_msa(cinfo->max_v_samp_factor, cinfo->output_width,
+                          input_data, output_data_ptr);
+}
+
+GLOBAL(void)
+jsimd_int_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                   JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
+{
+}
+
+GLOBAL(int)
+jsimd_can_h2v2_fancy_upsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_h2v1_fancy_upsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_h2v2_fancy_upsample(j_decompress_ptr cinfo,
+                          jpeg_component_info *compptr,
+                          JSAMPARRAY input_data,
+                          JSAMPARRAY *output_data_ptr)
+{
+  jsimd_h2v2_fancy_upsample_msa(cinfo->max_v_samp_factor,
+                                compptr->downsampled_width,
+                                input_data, output_data_ptr);
+}
+
+GLOBAL(void)
+jsimd_h2v1_fancy_upsample(j_decompress_ptr cinfo,
+                          jpeg_component_info *compptr,
+                          JSAMPARRAY input_data,
+                          JSAMPARRAY *output_data_ptr)
+{
+  jsimd_h2v1_fancy_upsample_msa(cinfo->max_v_samp_factor,
+                                compptr->downsampled_width,
+                                input_data, output_data_ptr);
+}
+
+GLOBAL(int)
+jsimd_can_h2v2_merged_upsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_h2v1_merged_upsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_h2v2_merged_upsample(j_decompress_ptr cinfo,
+                           JSAMPIMAGE input_buf,
+                           JDIMENSION in_row_group_ctr,
+                           JSAMPARRAY output_buf)
+{
+  void (*msafct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
+
+  switch (cinfo->out_color_space) {
+    case JCS_EXT_RGB:
+      msafct = jsimd_h2v2_extrgb_merged_upsample_msa;
+      break;
+    case JCS_EXT_RGBX:
+    case JCS_EXT_RGBA:
+      msafct = jsimd_h2v2_extrgbx_merged_upsample_msa;
+      break;
+    case JCS_EXT_BGR:
+      msafct = jsimd_h2v2_extbgr_merged_upsample_msa;
+      break;
+    case JCS_EXT_BGRX:
+    case JCS_EXT_BGRA:
+      msafct = jsimd_h2v2_extbgrx_merged_upsample_msa;
+      break;
+    case JCS_EXT_XBGR:
+    case JCS_EXT_ABGR:
+      msafct = jsimd_h2v2_extxbgr_merged_upsample_msa;
+      break;
+    case JCS_EXT_XRGB:
+    case JCS_EXT_ARGB:
+      msafct = jsimd_h2v2_extxrgb_merged_upsample_msa;
+      break;
+    default:
+      msafct = jsimd_h2v2_merged_upsample_msa;
+      break;
+  }
+
+  msafct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
+}
+
+GLOBAL(void)
+jsimd_h2v1_merged_upsample(j_decompress_ptr cinfo,
+                           JSAMPIMAGE input_buf,
+                           JDIMENSION in_row_group_ctr,
+                           JSAMPARRAY output_buf)
+{
+  void (*msafct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
+
+  switch (cinfo->out_color_space) {
+    case JCS_EXT_RGB:
+      msafct = jsimd_h2v1_extrgb_merged_upsample_msa;
+      break;
+    case JCS_EXT_RGBX:
+    case JCS_EXT_RGBA:
+      msafct = jsimd_h2v1_extrgbx_merged_upsample_msa;
+      break;
+    case JCS_EXT_BGR:
+      msafct = jsimd_h2v1_extbgr_merged_upsample_msa;
+      break;
+    case JCS_EXT_BGRX:
+    case JCS_EXT_BGRA:
+      msafct = jsimd_h2v1_extbgrx_merged_upsample_msa;
+      break;
+    case JCS_EXT_XBGR:
+    case JCS_EXT_ABGR:
+      msafct = jsimd_h2v1_extxbgr_merged_upsample_msa;
+      break;
+    case JCS_EXT_XRGB:
+    case JCS_EXT_ARGB:
+      msafct = jsimd_h2v1_extxrgb_merged_upsample_msa;
+      break;
+    default:
+      msafct = jsimd_h2v1_merged_upsample_msa;
+      break;
+  }
+
+  msafct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
+}
+
+GLOBAL(int)
+jsimd_can_convsamp(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+  if (sizeof(DCTELEM) != 2)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_convsamp_float(void)
+{
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_convsamp(JSAMPARRAY sample_data, JDIMENSION start_col,
+               DCTELEM *workspace)
+{
+  jsimd_convsamp_msa(sample_data, start_col, workspace);
+}
+
+GLOBAL(void)
+jsimd_convsamp_float(JSAMPARRAY sample_data, JDIMENSION start_col,
+                     FAST_FLOAT *workspace)
+{
+}
+
+GLOBAL(int)
+jsimd_can_fdct_islow(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (sizeof(DCTELEM) != 2)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_fdct_ifast(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (sizeof(DCTELEM) != 2)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_fdct_float(void)
+{
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_fdct_islow(DCTELEM *data)
+{
+  jsimd_fdct_islow_msa(data);
+}
+
+GLOBAL(void)
+jsimd_fdct_ifast(DCTELEM *data)
+{
+  jsimd_fdct_ifast_msa(data);
+}
+
+GLOBAL(void)
+jsimd_fdct_float(FAST_FLOAT *data)
+{
+}
+
+GLOBAL(int)
+jsimd_can_quantize(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (sizeof(JCOEF) != 2)
+    return 0;
+  if (sizeof(DCTELEM) != 2)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_quantize_float(void)
+{
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_quantize(JCOEFPTR coef_block, DCTELEM *divisors,
+               DCTELEM *workspace)
+{
+  jsimd_quantize_msa(coef_block, divisors, workspace);
+}
+
+GLOBAL(void)
+jsimd_quantize_float(JCOEFPTR coef_block, FAST_FLOAT *divisors,
+                     FAST_FLOAT *workspace)
+{
+}
+
+GLOBAL(int)
+jsimd_can_idct_2x2(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (sizeof(JCOEF) != 2)
+    return 0;
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+  if (sizeof(ISLOW_MULT_TYPE) != 2)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_idct_4x4(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (sizeof(JCOEF) != 2)
+    return 0;
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+  if (sizeof(ISLOW_MULT_TYPE) != 2)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_idct_6x6(void)
+{
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_idct_12x12(void)
+{
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_idct_2x2(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+               JCOEFPTR coef_block, JSAMPARRAY output_buf,
+               JDIMENSION output_col)
+{
+  unsigned char *output[2] = {
+    output_buf[0] + output_col,
+    output_buf[1] + output_col,
+  };
+
+  jsimd_idct_2x2_msa(cinfo, compptr, coef_block, output, output_col);
+}
+
+GLOBAL(void)
+jsimd_idct_4x4(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+               JCOEFPTR coef_block, JSAMPARRAY output_buf,
+               JDIMENSION output_col)
+{
+  unsigned char *output[4] = {
+    output_buf[0] + output_col,
+    output_buf[1] + output_col,
+    output_buf[2] + output_col,
+    output_buf[3] + output_col,
+  };
+
+  jsimd_idct_4x4_msa(cinfo, compptr, coef_block, output, output_col);
+}
+
+GLOBAL(void)
+jsimd_idct_6x6(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+               JCOEFPTR coef_block, JSAMPARRAY output_buf,
+               JDIMENSION output_col)
+{
+}
+
+GLOBAL(void)
+jsimd_idct_12x12(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                 JCOEFPTR coef_block,
+                 JSAMPARRAY output_buf, JDIMENSION output_col)
+{
+}
+
+GLOBAL(int)
+jsimd_can_idct_islow(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (sizeof(JCOEF) != 2)
+    return 0;
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+  if (sizeof(ISLOW_MULT_TYPE) != 2)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_idct_ifast(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (sizeof(JCOEF) != 2)
+    return 0;
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(JDIMENSION) != 4)
+    return 0;
+  if (sizeof(IFAST_MULT_TYPE) != 2)
+    return 0;
+  if (IFAST_SCALE_BITS != 2)
+    return 0;
+
+  if (simd_support & JSIMD_MSA)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_idct_float(void)
+{
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_idct_islow(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                 JCOEFPTR coef_block, JSAMPARRAY output_buf,
+                 JDIMENSION output_col)
+{
+  unsigned char *output[8] = {
+    output_buf[0] + output_col,
+    output_buf[1] + output_col,
+    output_buf[2] + output_col,
+    output_buf[3] + output_col,
+    output_buf[4] + output_col,
+    output_buf[5] + output_col,
+    output_buf[6] + output_col,
+    output_buf[7] + output_col,
+  };
+
+  jsimd_idct_islow_msa(cinfo, compptr, coef_block, output, output_col);
+}
+
+GLOBAL(void)
+jsimd_idct_ifast(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                 JCOEFPTR coef_block, JSAMPARRAY output_buf,
+                 JDIMENSION output_col)
+{
+  unsigned char *output[8] = {
+    output_buf[0] + output_col,
+    output_buf[1] + output_col,
+    output_buf[2] + output_col,
+    output_buf[3] + output_col,
+    output_buf[4] + output_col,
+    output_buf[5] + output_col,
+    output_buf[6] + output_col,
+    output_buf[7] + output_col,
+  };
+
+  jsimd_idct_ifast_msa(cinfo, compptr, coef_block, output, output_col);
+}
+
+GLOBAL(void)
+jsimd_idct_float(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                 JCOEFPTR coef_block, JSAMPARRAY output_buf,
+                 JDIMENSION output_col)
+{
+}
+
+GLOBAL(int)
+jsimd_can_huff_encode_one_block(void)
+{
+  return 0;
+}
+
+GLOBAL(JOCTET *)
+jsimd_huff_encode_one_block(void *state, JOCTET *buffer, JCOEFPTR block,
+                            int last_dc_val, c_derived_tbl *dctbl,
+                            c_derived_tbl *actbl)
+{
+  return NULL;
+}
+
+GLOBAL(int)
+jsimd_can_encode_mcu_AC_first_prepare(void)
+{
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_encode_mcu_AC_first_prepare(const JCOEF *block,
+                                  const int *jpeg_natural_order_start, int Sl,
+                                  int Al, JCOEF *values, size_t *zerobits)
+{
+}
+
+GLOBAL(int)
+jsimd_can_encode_mcu_AC_refine_prepare(void)
+{
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_encode_mcu_AC_refine_prepare(const JCOEF *block,
+                                   const int *jpeg_natural_order_start, int Sl,
+                                   int Al, JCOEF *absvalues, size_t *bits)
+{
+  return 0;
+}


### PR DESCRIPTION
Hello,
I have finished the MSA-optimized codes for MIPS platform on libjpeg-turbo:
1. A month ago, I submitted a pull request for MSA implementation on master branch and you give me lots of comments, this time I updated these codes as your comments and submitted it again on dev branch. Please help to review it, thank you very much.
2. I have run the checkstyle script from https://github.com/libjpeg-turbo/checkstyle and all MSA-optimized files can pass this test.
3. About performance test, I attach the file - libjpgturbo-mips-performance-report-1core_0926.xlsx which includes the comparable results between libjpeg v6b and libjpeg-turbo dev with MSA code. I run tjbench on Elise board(based MIPS32R5) and get it. On the other hand I also run tjunittest on it all test cases can be passed.

If you have any questions or comments please feel free to let me know, we will discuss them further. We hope you help us to upstream these codes to the github in the near future. Thank you very much.
[libjpgturbo-mips-performance-report-1core_0926.xlsx](https://github.com/libjpeg-turbo/libjpeg-turbo/files/3661092/libjpgturbo-mips-performance-report-1core_0926.xlsx)
