### PR TITLE
WIP: Abort upon global state errors

### DIFF
--- a/jcapimin.c
+++ b/jcapimin.c
@@ -170,7 +170,7 @@ jpeg_finish_compress(j_compress_ptr cinfo)
       ERREXIT(cinfo, JERR_TOO_LITTLE_DATA);
     (*cinfo->master->finish_pass) (cinfo);
   } else if (cinfo->global_state != CSTATE_WRCOEFS)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_finish_compress", cinfo->global_state);
   /* Perform any remaining passes */
   while (!cinfo->master->is_last_pass) {
     (*cinfo->master->prepare_for_pass) (cinfo);
@@ -213,7 +213,7 @@ jpeg_write_marker(j_compress_ptr cinfo, int marker, const JOCTET *dataptr,
       (cinfo->global_state != CSTATE_SCANNING &&
        cinfo->global_state != CSTATE_RAW_OK &&
        cinfo->global_state != CSTATE_WRCOEFS))
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_write_marker", cinfo->global_state);
 
   (*cinfo->marker->write_marker_header) (cinfo, marker, datalen);
   write_marker_byte = cinfo->marker->write_marker_byte; /* copy for speed */
@@ -232,7 +232,7 @@ jpeg_write_m_header(j_compress_ptr cinfo, int marker, unsigned int datalen)
       (cinfo->global_state != CSTATE_SCANNING &&
        cinfo->global_state != CSTATE_RAW_OK &&
        cinfo->global_state != CSTATE_WRCOEFS))
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_write_m_header", cinfo->global_state);
 
   (*cinfo->marker->write_marker_header) (cinfo, marker, datalen);
 }
@@ -269,7 +269,7 @@ GLOBAL(void)
 jpeg_write_tables(j_compress_ptr cinfo)
 {
   if (cinfo->global_state != CSTATE_START)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_write_tables", cinfo->global_state);
 
   /* (Re)initialize error mgr and destination modules */
   (*cinfo->err->reset_error_mgr) ((j_common_ptr)cinfo);

--- a/jcapistd.c
+++ b/jcapistd.c
@@ -39,7 +39,7 @@ GLOBAL(void)
 jpeg_start_compress(j_compress_ptr cinfo, boolean write_all_tables)
 {
   if (cinfo->global_state != CSTATE_START)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_start_compress", cinfo->global_state);
 
   if (write_all_tables)
     jpeg_suppress_tables(cinfo, FALSE); /* mark all tables to be written */
@@ -81,7 +81,7 @@ jpeg_write_scanlines(j_compress_ptr cinfo, JSAMPARRAY scanlines,
   JDIMENSION row_ctr, rows_left;
 
   if (cinfo->global_state != CSTATE_SCANNING)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_write_scanlines", cinfo->global_state);
   if (cinfo->next_scanline >= cinfo->image_height)
     WARNMS(cinfo, JWRN_TOO_MUCH_DATA);
 
@@ -124,7 +124,7 @@ jpeg_write_raw_data(j_compress_ptr cinfo, JSAMPIMAGE data,
   JDIMENSION lines_per_iMCU_row;
 
   if (cinfo->global_state != CSTATE_RAW_OK)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_write_raw_data", cinfo->global_state);
   if (cinfo->next_scanline >= cinfo->image_height) {
     WARNMS(cinfo, JWRN_TOO_MUCH_DATA);
     return 0;

--- a/jcicc.c
+++ b/jcicc.c
@@ -56,7 +56,7 @@ jpeg_write_icc_profile(j_compress_ptr cinfo, const JOCTET *icc_data_ptr,
   if (icc_data_ptr == NULL || icc_data_len == 0)
     ERREXIT(cinfo, JERR_BUFFER_SIZE);
   if (cinfo->global_state < CSTATE_SCANNING)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_write_icc_profile", cinfo->global_state);
 
   /* Calculate the number of markers we'll need, rounding up of course */
   num_markers = icc_data_len / MAX_DATA_BYTES_IN_MARKER;

--- a/jcparam.c
+++ b/jcparam.c
@@ -40,7 +40,7 @@ jpeg_add_quant_table(j_compress_ptr cinfo, int which_tbl,
 
   /* Safety check to ensure start_compress not called yet. */
   if (cinfo->global_state != CSTATE_START)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_add_quant_table", cinfo->global_state);
 
   if (which_tbl < 0 || which_tbl >= NUM_QUANT_TBLS)
     ERREXIT1(cinfo, JERR_DQT_INDEX, which_tbl);
@@ -185,7 +185,7 @@ jpeg_set_defaults(j_compress_ptr cinfo)
 
   /* Safety check to ensure start_compress not called yet. */
   if (cinfo->global_state != CSTATE_START)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_set_defaults", cinfo->global_state);
 
   /* Allocate comp_info array large enough for maximum component count.
    * Array is made permanent in case application wants to compress
@@ -337,7 +337,7 @@ jpeg_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace)
 
   /* Safety check to ensure start_compress not called yet. */
   if (cinfo->global_state != CSTATE_START)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_set_colorspace", cinfo->global_state);
 
   /* For all colorspaces, we use Q and Huff tables 0 for luminance components,
    * tables 1 for chrominance components.
@@ -473,7 +473,7 @@ jpeg_simple_progression(j_compress_ptr cinfo)
 
   /* Safety check to ensure start_compress not called yet. */
   if (cinfo->global_state != CSTATE_START)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_simple_progression", cinfo->global_state);
 
   /* Figure space needed for script.  Calculation must match code below! */
   if (ncomps == 3 && cinfo->jpeg_color_space == JCS_YCbCr) {

--- a/jctrans.c
+++ b/jctrans.c
@@ -42,7 +42,7 @@ GLOBAL(void)
 jpeg_write_coefficients(j_compress_ptr cinfo, jvirt_barray_ptr *coef_arrays)
 {
   if (cinfo->global_state != CSTATE_START)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_write_coefficients", cinfo->global_state);
   /* Mark all tables to be written */
   jpeg_suppress_tables(cinfo, FALSE);
   /* (Re)initialize error mgr and destination modules */
@@ -73,7 +73,7 @@ jpeg_copy_critical_parameters(j_decompress_ptr srcinfo, j_compress_ptr dstinfo)
 
   /* Safety check to ensure start_compress not called yet. */
   if (dstinfo->global_state != CSTATE_START)
-    ERREXIT1(dstinfo, JERR_BAD_STATE, dstinfo->global_state);
+    jabort_bad_state("jpeg_copy_critical_parameters", dstinfo->global_state);
   /* Copy fundamental image dimensions */
   dstinfo->image_width = srcinfo->image_width;
   dstinfo->image_height = srcinfo->image_height;

--- a/jdapimin.c
+++ b/jdapimin.c
@@ -256,7 +256,7 @@ jpeg_read_header(j_decompress_ptr cinfo, boolean require_image)
 
   if (cinfo->global_state != DSTATE_START &&
       cinfo->global_state != DSTATE_INHEADER)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_read_header", cinfo->global_state);
 
   retcode = jpeg_consume_input(cinfo);
 
@@ -332,7 +332,7 @@ jpeg_consume_input(j_decompress_ptr cinfo)
     retcode = (*cinfo->inputctl->consume_input) (cinfo);
     break;
   default:
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_consume_input", cinfo->global_state);
   }
   return retcode;
 }
@@ -348,7 +348,7 @@ jpeg_input_complete(j_decompress_ptr cinfo)
   /* Check for valid jpeg object */
   if (cinfo->global_state < DSTATE_START ||
       cinfo->global_state > DSTATE_STOPPING)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_input_complete", cinfo->global_state);
   return cinfo->inputctl->eoi_reached;
 }
 
@@ -363,7 +363,7 @@ jpeg_has_multiple_scans(j_decompress_ptr cinfo)
   /* Only valid after jpeg_read_header completes */
   if (cinfo->global_state < DSTATE_READY ||
       cinfo->global_state > DSTATE_STOPPING)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_has_multiple_scans", cinfo->global_state);
   return cinfo->inputctl->has_multiple_scans;
 }
 
@@ -392,7 +392,7 @@ jpeg_finish_decompress(j_decompress_ptr cinfo)
     cinfo->global_state = DSTATE_STOPPING;
   } else if (cinfo->global_state != DSTATE_STOPPING) {
     /* STOPPING = repeat call after a suspension, anything else is error */
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_finish_decompress", cinfo->global_state);
   }
   /* Read until EOI */
   while (!cinfo->inputctl->eoi_reached) {

--- a/jdapistd.c
+++ b/jdapistd.c
@@ -82,7 +82,7 @@ jpeg_start_decompress(j_decompress_ptr cinfo)
     }
     cinfo->output_scan_number = cinfo->input_scan_number;
   } else if (cinfo->global_state != DSTATE_PRESCAN)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_start_decompress", cinfo->global_state);
   /* Perform any dummy output passes, and set up for the final pass */
   return output_pass_setup(cinfo);
 }
@@ -159,7 +159,7 @@ jpeg_crop_scanline(j_decompress_ptr cinfo, JDIMENSION *xoffset,
   jpeg_component_info *compptr;
 
   if (cinfo->global_state != DSTATE_SCANNING || cinfo->output_scanline != 0)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_crop_scanline", cinfo->global_state);
 
   if (!xoffset || !width)
     ERREXIT(cinfo, JERR_BAD_CROP_SPEC);
@@ -267,7 +267,7 @@ jpeg_read_scanlines(j_decompress_ptr cinfo, JSAMPARRAY scanlines,
   JDIMENSION row_ctr;
 
   if (cinfo->global_state != DSTATE_SCANNING)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_read_scanlines", cinfo->global_state);
   if (cinfo->output_scanline >= cinfo->output_height) {
     WARNMS(cinfo, JWRN_TOO_MUCH_DATA);
     return 0;
@@ -389,7 +389,7 @@ jpeg_skip_scanlines(j_decompress_ptr cinfo, JDIMENSION num_lines)
   JDIMENSION lines_to_skip, lines_to_read;
 
   if (cinfo->global_state != DSTATE_SCANNING)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_skip_scanlines", cinfo->global_state);
 
   /* Do not skip past the bottom of the image. */
   if (cinfo->output_scanline + num_lines >= cinfo->output_height) {
@@ -553,7 +553,7 @@ jpeg_read_raw_data(j_decompress_ptr cinfo, JSAMPIMAGE data,
   JDIMENSION lines_per_iMCU_row;
 
   if (cinfo->global_state != DSTATE_RAW_OK)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_read_raw_data", cinfo->global_state);
   if (cinfo->output_scanline >= cinfo->output_height) {
     WARNMS(cinfo, JWRN_TOO_MUCH_DATA);
     return 0;
@@ -594,7 +594,7 @@ jpeg_start_output(j_decompress_ptr cinfo, int scan_number)
 {
   if (cinfo->global_state != DSTATE_BUFIMAGE &&
       cinfo->global_state != DSTATE_PRESCAN)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_start_output", cinfo->global_state);
   /* Limit scan number to valid range */
   if (scan_number <= 0)
     scan_number = 1;
@@ -624,7 +624,7 @@ jpeg_finish_output(j_decompress_ptr cinfo)
     cinfo->global_state = DSTATE_BUFPOST;
   } else if (cinfo->global_state != DSTATE_BUFPOST) {
     /* BUFPOST = repeat call after a suspension, anything else is error */
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_finish_output", cinfo->global_state);
   }
   /* Read markers looking for SOS or EOI */
   while (cinfo->input_scan_number <= cinfo->output_scan_number &&

--- a/jdicc.c
+++ b/jdicc.c
@@ -87,7 +87,7 @@ jpeg_read_icc_profile(j_decompress_ptr cinfo, JOCTET **icc_data_ptr,
   if (icc_data_ptr == NULL || icc_data_len == NULL)
     ERREXIT(cinfo, JERR_BUFFER_SIZE);
   if (cinfo->global_state < DSTATE_READY)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_read_icc_profile", cinfo->global_state);
 
   *icc_data_ptr = NULL;         /* avoid confusion if FALSE return */
   *icc_data_len = 0;

--- a/jdmaster.c
+++ b/jdmaster.c
@@ -278,7 +278,7 @@ jpeg_calc_output_dimensions(j_decompress_ptr cinfo)
 
   /* Prevent application from calling me at wrong times */
   if (cinfo->global_state != DSTATE_READY)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_calc_output_dimensions", cinfo->global_state);
 
   /* Compute core output image dimensions and DCT scaling choices. */
   jpeg_core_output_dimensions(cinfo);
@@ -701,7 +701,7 @@ jpeg_new_colormap(j_decompress_ptr cinfo)
 
   /* Prevent application from calling me at wrong times */
   if (cinfo->global_state != DSTATE_BUFIMAGE)
-    ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+    jabort_bad_state("jpeg_new_colormap", cinfo->global_state);
 
   if (cinfo->quantize_colors && cinfo->enable_external_quant &&
       cinfo->colormap != NULL) {

--- a/jdtrans.c
+++ b/jdtrans.c
@@ -86,7 +86,7 @@ jpeg_read_coefficients(j_decompress_ptr cinfo)
     return cinfo->coef->coef_arrays;
   }
   /* Oops, improper usage */
-  ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+  jabort_bad_state("jpeg_read_coefficients", cinfo->global_state);
   return NULL;                  /* keep compiler happy */
 }
 

--- a/jerror.c
+++ b/jerror.c
@@ -52,6 +52,22 @@ const char * const jpeg_std_message_table[] = {
 };
 
 
+
+/*
+ * Aborts the program when the library is called in an improper state.
+ *
+ * When this is called, it means that the libjpeg-turbo API has been called in
+ * an incorrect order.  This is a programming error and the caller cannot
+ * recover from it.  Thus, we'll make the library abort instead of
+ * transferring control back to the caller.
+ */
+GLOBAL(void)
+jabort_bad_state(const char *func, int state)
+{
+  fprintf(stderr, "Improper call to JPEG function %s in state %d\n", func, state);
+  abort();
+}
+
 /*
  * Error exit handler: must not return to caller.
  *

--- a/jpegint.h
+++ b/jpegint.h
@@ -300,6 +300,7 @@ struct jpeg_color_quantizer {
 #define RIGHT_SHIFT(x, shft)    ((x) >> (shft))
 #endif
 
+EXTERN(void) jabort_bad_state(const char *func, int state);
 
 /* Compression module initialization routines */
 EXTERN(void) jinit_compress_master(j_compress_ptr cinfo);


### PR DESCRIPTION
This is a work-in-progress PR to see what you think of it; it's not intended to be merged yet.

The recommended way to call libjpeg-turbo from library code is to setjmp()/longjmp() in the error_exit() handler.  This is extremely awkward for C libraries, and makes it impossible to use libjpeg-turbo correctly from other languages that cannot unwind across FFI boundaries.

I want to explore the possibility of removing this requirement.  Since application/library code already uses setjmp/longjmp, and to avoid ABI breaks, I'd like to see where this refactoring takes me:

* Make programming errors abort the library unconditionally; no giving control back to the calling program.  Programming errors include calling the library's API out of order, passing invalid arguments which are checked in the API entry points, etc.  Rationale: application writers should catch these early and fix them, instead of hiding them behind setjmp().

* Make internal library errors abort the library unconditionally - what would conventionally be assert() elsewhere, but are calls to ERREXIT() right now.  Rationale: libjpeg-turbo bugs are serious, and should not give the program the option to continue.  Programs with an extreme need for resiliency should use sandboxed image codecs in separate processes.

* Turn ERREXIT() calls due to invalid image data into something else that can be examined by the caller in the end.  Maybe set the whole cinfo in an error state, and make all API calls no-ops if the cinfo is in that state.  I don't know the libjpeg-turbo API well enough to see if it is possible for callers to know about errors outside of error_exit(), but I haven't gotten to that point in refactoring yet :)