### PR TITLE
(Turbojpeg): Fix linking when C_PROGRESSIVE_SUPPORTED is undefined

### DIFF
--- a/turbojpeg.c
+++ b/turbojpeg.c
@@ -281,12 +281,14 @@ static int setCompDefaults(struct jpeg_compress_struct *cinfo, int pixelFormat,
   else
     jpeg_set_colorspace(cinfo, JCS_YCbCr);
 
+#ifdef C_PROGRESSIVE_SUPPORTED
   if (flags & TJFLAG_PROGRESSIVE)
     jpeg_simple_progression(cinfo);
 #ifndef NO_GETENV
   else if ((env = getenv("TJ_PROGRESSIVE")) != NULL && strlen(env) > 0 &&
            !strcmp(env, "1"))
     jpeg_simple_progression(cinfo);
+#endif
 #endif
 
   cinfo->comp_info[0].h_samp_factor = tjMCUWidth[subsamp] / 8;
@@ -1932,8 +1934,10 @@ DLLEXPORT int tjTransform(tjhandle handle, const unsigned char *jpegBuf,
       jpeg_mem_dest_tj(cinfo, &dstBufs[i], &dstSizes[i], alloc);
     jpeg_copy_critical_parameters(dinfo, cinfo);
     dstcoefs = jtransform_adjust_parameters(dinfo, cinfo, srccoefs, &xinfo[i]);
+#ifdef C_PROGRESSIVE_SUPPORTED
     if (flags & TJFLAG_PROGRESSIVE || t[i].options & TJXOPT_PROGRESSIVE)
       jpeg_simple_progression(cinfo);
+#endif
     if (!(t[i].options & TJXOPT_NOOUTPUT)) {
       jpeg_write_coefficients(cinfo, dstcoefs);
       jcopy_markers_execute(dinfo, cinfo, t[i].options & TJXOPT_COPYNONE ?


### PR DESCRIPTION
This fixes a latent regression introduced in 0713c1b and aba6ae5. 

**Description of bug:** Final linking fails when jmorecfg.h undefines C_PROGRESSIVE_SUPPORTED.

**Affected versions:** 1.3.90+

**Step to reproduce:**
1. clone repo
2. Edit jmorecfg.h to #undef C_PROGRESSIVE_SUPPORTED
3. Run cmake
4. Run make

**Resulting error:**
`[ 88%] Building C object CMakeFiles/tjbench-static.dir/tjutil.c.o
[ 89%] Linking C executable tjbench-static
libturbojpeg.a(turbojpeg.c.o): In function `setCompDefaults':
turbojpeg.c:(.text+0x364): undefined reference to `jpeg_simple_progression'
libturbojpeg.a(turbojpeg.c.o): In function `tjTransform':
turbojpeg.c:(.text+0xa163): undefined reference to `jpeg_simple_progression'
collect2: error: ld returned 1 exit status
CMakeFiles/tjbench-static.dir/build.make:121: recipe for target 'tjbench-static' failed
make[2]: *** [tjbench-static] Error 1
CMakeFiles/Makefile2:205: recipe for target 'CMakeFiles/tjbench-static.dir/all' failed
make[1]: *** [CMakeFiles/tjbench-static.dir/all] Error 2
Makefile:140: recipe for target 'all' failed
make: *** [all] Error 2`

**Observed on:** See [my intentionally failed builds](https://travis-ci.com/fsbruva/libjpeg-turbo/builds/141020993)
Ubuntu 16.05 AMD64, ppc, arm & s390x (clang and gcc)
Ubuntu 18.04 AMD64 (clang and gcc) 
Ubuntu 14.04 AMD64 (clang and gcc)
macOS 10.11, 10.12, 10.13, 10.14
FreeBSD 11.2-RELEASE AMD64 (clang)

**Proposed fix:** Add preprocessor conditional for the 3 uses of jpeg_simple_progression within turbjpeg.c.

**Explanation:** Within jcparam.c, the code for function jpeg_simple_progression() is conditionally compiled based on the C_PROGRESSIVE_SUPPORTED preprocessor variable being defined at [L405](https://github.com/libjpeg-turbo/libjpeg-turbo/blob/52291467e1d24ed5c99186b93722e740902bd19c/jcparam.c#L405-L468) However, within turbojpeg.c, no such check exists, causing final linking to fail when jmorecfg.h undefines C_PROGRESSIVE_SUPPORTED.