### PR TITLE
simd: don't add -mdspr2 to CFLAGS

### DIFF
--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -281,8 +281,6 @@ string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UC)
 set(EFFECTIVE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${CMAKE_ASM_FLAGS_${CMAKE_BUILD_TYPE_UC}}")
 message(STATUS "CMAKE_ASM_FLAGS = ${EFFECTIVE_ASM_FLAGS}")
 
-set(CMAKE_REQUIRED_FLAGS -mdspr2)
-
 check_c_source_compiles("
   #if !(defined(__mips__) && __mips_isa_rev >= 2)
   #error MIPS DSPr2 is currently only available on MIPS32r2 platforms.


### PR DESCRIPTION
This forces DSPr2 to be enabled, even when it doesn't make sense.
In OpenWrt, the default platform of mips_24kc does not support DSPr2 at the hardware level
but does support it at the toolchain level.

I'm also seeing strange results:

```
DSPr2 build:

root@OpenWrt:/tmp# time djpeg wallhaven-8363o2.jpg > /dev/null
real	0m 1.24s
user	0m 1.19s
sys	0m 0.02s
root@OpenWrt:/tmp# time djpeg wallhaven-8363o2.jpg > /dev/null
real	0m 1.26s
user	0m 1.17s
sys	0m 0.05s
root@OpenWrt:/tmp# time djpeg wallhaven-8363o2.jpg > /dev/null
real	0m 1.25s
user	0m 1.21s
sys	0m 0.00s
root@OpenWrt:/tmp# time djpeg wallhaven-8363o2.jpg > /dev/null
real	0m 1.24s
user	0m 1.19s
sys	0m 0.02s

non-DSPr2 build:

root@OpenWrt:/tmp# time djpeg wallhaven-8363o2.jpg > /dev/null
real	0m 1.07s
user	0m 1.04s
sys	0m 0.00s
root@OpenWrt:/tmp# time djpeg wallhaven-8363o2.jpg > /dev/null
real	0m 1.07s
user	0m 1.05s
sys	0m 0.00s
root@OpenWrt:/tmp# time djpeg wallhaven-8363o2.jpg > /dev/null
real	0m 1.06s
user	0m 1.02s
sys	0m 0.01s
root@OpenWrt:/tmp# time djpeg wallhaven-8363o2.jpg > /dev/null
real	0m 1.05s
user	0m 1.00s
sys	0m 0.02s
root@OpenWrt:/tmp# time djpeg wallhaven-8363o2.jpg > /dev/null
real	0m 1.05s
user	0m 1.00s
sys	0m 0.02s
root@OpenWrt:/tmp# time djpeg wallhaven-8363o2.jpg > /dev/null
real	0m 1.09s
user	0m 1.03s
sys	0m 0.03s
```

DSPr2 should in theory be faster. Although I have no idea by how much.

This problem could be manifesting itself as I'm running in QEMU and not real hardware.