### PR TITLE
 simd: limit DSPr2 support to hardware float devices

### DIFF
--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -284,8 +284,8 @@ message(STATUS "CMAKE_ASM_FLAGS = ${EFFECTIVE_ASM_FLAGS}")
 set(CMAKE_REQUIRED_FLAGS -mdspr2)
 
 check_c_source_compiles("
-  #if !(defined(__mips__) && __mips_isa_rev >= 2)
-  #error MIPS DSPr2 is currently only available on MIPS32r2 platforms.
+  #if !(defined(__mips__) && !defined(__mips_soft_float) && __mips_isa_rev >= 2)
+  #error MIPS DSPr2 is currently only available on MIPS32r2 platforms with hardware float.
   #endif
   int main(void) {
     int c = 0, a = 0, b = 0;

--- a/simd/mips/jsimd.c
+++ b/simd/mips/jsimd.c
@@ -692,10 +692,8 @@ jsimd_can_convsamp_float(void)
   if (sizeof(ISLOW_MULT_TYPE) != 2)
     return 0;
 
-#ifndef __mips_soft_float
   if (simd_support & JSIMD_DSPR2)
     return 1;
-#endif
 
   return 0;
 }
@@ -711,9 +709,7 @@ GLOBAL(void)
 jsimd_convsamp_float(JSAMPARRAY sample_data, JDIMENSION start_col,
                      FAST_FLOAT *workspace)
 {
-#ifndef __mips_soft_float
   jsimd_convsamp_float_dspr2(sample_data, start_col, workspace);
-#endif
 }
 
 GLOBAL(int)
@@ -809,10 +805,8 @@ jsimd_can_quantize_float(void)
   if (sizeof(ISLOW_MULT_TYPE) != 2)
     return 0;
 
-#ifndef __mips_soft_float
   if (simd_support & JSIMD_DSPR2)
     return 1;
-#endif
 
   return 0;
 }
@@ -827,9 +821,7 @@ GLOBAL(void)
 jsimd_quantize_float(JCOEFPTR coef_block, FAST_FLOAT *divisors,
                      FAST_FLOAT *workspace)
 {
-#ifndef __mips_soft_float
   jsimd_quantize_float_dspr2(coef_block, divisors, workspace);
-#endif
 }
 
 GLOBAL(int)

--- a/simd/mips/jsimd_dspr2.S
+++ b/simd/mips/jsimd_dspr2.S
@@ -2810,8 +2810,6 @@ LEAF_DSPR2(jsimd_quantize_dspr2)
 END(jsimd_quantize_dspr2)
 
 
-#ifndef __mips_soft_float
-
 /*****************************************************************************/
 LEAF_DSPR2(jsimd_quantize_float_dspr2)
 /*
@@ -2891,8 +2889,6 @@ LEAF_DSPR2(jsimd_quantize_float_dspr2)
      nop
 
 END(jsimd_quantize_float_dspr2)
-
-#endif
 
 
 /*****************************************************************************/
@@ -4114,8 +4110,6 @@ LEAF_DSPR2(jsimd_convsamp_dspr2)
 END(jsimd_convsamp_dspr2)
 
 
-#ifndef __mips_soft_float
-
 /*****************************************************************************/
 LEAF_DSPR2(jsimd_convsamp_float_dspr2)
 /*
@@ -4473,7 +4467,5 @@ LEAF_DSPR2(jsimd_convsamp_float_dspr2)
      nop
 
 END(jsimd_convsamp_float_dspr2)
-
-#endif
 
 /*****************************************************************************/


### PR DESCRIPTION
Testing with minidlna, it produces bogus results when creating a new JPEG
image on a soft float device.

The MIPS mode was probably written with hardware float devices in mind.

Here's an example: https://imgur.com/a/ljAik3j

The image is produced with minidlna. It downscales the image for compatibility with the DLNA standard.

Disabling DSPr2 support manually produces a correct album art image.