### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -96,18 +96,18 @@ Build Requirements
 
 - Building libjpeg-turbo by vcpkg
 
-You can download and install libjpeg-turbo using the [vcpkg](https://github.com/Microsoft/vcpkg) 
-dependency manager:
-
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    ./vcpkg install libjpeg-turbo
-
-The libjpeg-turbo port in vcpkg is kept up to date by Microsoft team members 
-and community contributors. If the version is out of date, 
-please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+  You can download and install libjpeg-turbo using the [vcpkg](https://github.com/Microsoft/vcpkg) 
+  dependency manager:
+  
+      git clone https://github.com/Microsoft/vcpkg.git
+      cd vcpkg
+      ./bootstrap-vcpkg.sh
+      ./vcpkg integrate install
+      ./vcpkg install libjpeg-turbo
+  
+  The libjpeg-turbo port in vcpkg is kept up to date by Microsoft team 
+  members and community contributors. If the version is out of date, 
+  please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 
 Out-of-Tree Builds

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -94,6 +94,21 @@ Build Requirements
 
   * If using JDK 11 or later, CMake 3.10.x or later must also be used.
 
+- Building libjpeg-turbo by vcpkg
+
+You can download and install libjpeg-turbo using the [vcpkg](https://github.com/Microsoft/vcpkg) 
+dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install libjpeg-turbo
+
+The libjpeg-turbo port in vcpkg is kept up to date by Microsoft team members 
+and community contributors. If the version is out of date, 
+please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 
 Out-of-Tree Builds
 ------------------


### PR DESCRIPTION
Libjpeg-turbo is available as a port in vcpkg, a C++ library manager that simplifies installation for libjpeg-turbo and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build libjpeg-turbo, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.