### PR TITLE
Build: add missing dependency for jpegtran icc test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1015,7 +1015,8 @@ foreach(libtype ${TEST_LIBTYPES})
     DEPENDS djpeg-${libtype}-rgb-islow)
 
   add_bittest(jpegtran icc "-copy;all;-icc;${TESTIMAGES}/test2.icc"
-    testout_rgb_islow2.jpg testout_rgb_islow.jpg ${MD5_JPEG_RGB_ISLOW2})
+    testout_rgb_islow2.jpg testout_rgb_islow.jpg
+    ${MD5_JPEG_RGB_ISLOW2} cjpeg-${libtype}-rgb-islow)
 
   if(NOT WITH_12BIT)
     # CC: RGB->RGB565  SAMP: fullsize  IDCT: islow  ENT: huff


### PR DESCRIPTION
The jpegtran icc test must run after cjpeg rgb-islow test, since the
latter generates testout_rgb_islow.jpg.

---

Very similar change to #321. Observed on hydra at https://hydra.nixos.org/build/117594627/nixlog/2 ([build](https://hydra.nixos.org/build/117594627)):
```
 12/151 Test  #46: jpegtran-shared-icc ...............................***Failed    0.03 sec
Premature end of JPEG file
JPEG datastream contains no image
...
 63/151 Test  #47: jpegtran-shared-icc-cmp ...........................***Failed    0.12 sec
Could not obtain MD5 sum: No such file or directory
```