### PR TITLE
simd/arm64/jsimd_neon.S: Use an appropriate .section directive for windows

### DIFF
--- a/simd/arm64/jsimd_neon.S
+++ b/simd/arm64/jsimd_neon.S
@@ -33,6 +33,8 @@
 
 #if defined(__APPLE__)
 .section __DATA, __const
+#elif defined(_WIN32)
+.section .rdata
 #else
 .section .rodata, "a", %progbits
 #endif


### PR DESCRIPTION
This fixes building for windows/arm64 with a mingw toolchain.