### PR TITLE
Fix cropping in progressive mode

### DIFF
--- a/jdcoefct.c
+++ b/jdcoefct.c
@@ -512,11 +512,11 @@ decompress_smooth_data(j_decompress_ptr cinfo, JSAMPIMAGE output_buf)
       if (first_row && block_row == 0)
         prev_block_row = buffer_ptr;
       else
-        prev_block_row = buffer[block_row - 1];
+        prev_block_row = buffer[block_row - 1] + cinfo->master->first_MCU_col[ci];
       if (last_row && block_row == block_rows - 1)
         next_block_row = buffer_ptr;
       else
-        next_block_row = buffer[block_row + 1];
+        next_block_row = buffer[block_row + 1] + cinfo->master->first_MCU_col[ci];
       /* We fetch the surrounding DC values using a sliding-register approach.
        * Initialize all nine here so as to do the right thing on narrow pics.
        */


### PR DESCRIPTION
This fixes missing offsets in previous and next row when using cropping
together with progressive jpegs.

Closes #456.