### PR TITLE
Fix build with Apple's armv7-apple-ios toolchain

### DIFF
--- a/simd/arm/jsimd_neon.S
+++ b/simd/arm/jsimd_neon.S
@@ -31,9 +31,11 @@
 #endif
 
 .text
+#if !defined(__APPLE__)
 .fpu neon
 .arch armv7a
 .object_arch armv4
+#endif
 .arm
 .syntax unified
 


### PR DESCRIPTION
Apple's iOS toolchain hasn't incorporated the LLVM commit that enables
support for ".fpu neon", but does enable NEON by default.