### PR TITLE
Check for a null pointer before adding to it

### DIFF
--- a/jdsample.c
+++ b/jdsample.c
@@ -95,9 +95,10 @@ sep_upsample(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
   if (num_rows > out_rows_avail)
     num_rows = out_rows_avail;
 
-  (*cinfo->cconvert->color_convert) (cinfo, upsample->color_buf,
-                                     (JDIMENSION)upsample->next_row_out,
-                                     output_buf + *out_row_ctr, (int)num_rows);
+  if (output_buf)
+    (*cinfo->cconvert->color_convert) (cinfo, upsample->color_buf,
+                                       (JDIMENSION)upsample->next_row_out,
+                                       output_buf + *out_row_ctr, (int)num_rows);
 
   /* Adjust counts */
   *out_row_ctr += num_rows;


### PR DESCRIPTION
When `sep_upsample` is called via `jpeg_skip_scanlines`, `output_buf` is null. Prevent adding to a null pointer by checking for null.

Fixes issue 470.