### PR TITLE
fix __VA_ARGS__ compatibility for c11 and c17

### DIFF
--- a/tjutil.h
+++ b/tjutil.h
@@ -30,7 +30,7 @@
 #ifndef __MINGW32__
 #include <stdio.h>
 #define snprintf(str, n, format, ...) \
-  _snprintf_s(str, n, _TRUNCATE, format, __VA_ARGS__)
+  _snprintf_s(str, n, _TRUNCATE, format, ## __VA_ARGS__)
 #endif
 #define strcasecmp  stricmp
 #define strncasecmp  strnicmp


### PR DESCRIPTION
In `tjutil.h`
```
#define snprintf(str, n, format, ...) \
  _snprintf_s(str, n, _TRUNCATE, format, __VA_ARGS__)
```

When build in c11 or c17, if `snprintf` has no var args, building failed.

This PR fix the problem.
