### PR TITLE
Fix CLZ issues on Windows on Arm

### DIFF
--- a/jchuff.c
+++ b/jchuff.c
@@ -44,15 +44,19 @@
  * flags (this defines __thumb__).
  */
 
-/* NOTE: Both GCC and Clang define __GNUC__ */
-#if defined(__GNUC__) && (defined(__arm__) || defined(__aarch64__))
+#if defined(__arm__) || defined(__aarch64__) || defined(_M_ARM) || \
+    defined(_M_ARM64)
 #if !defined(__thumb__) || defined(__thumb2__)
 #define USE_CLZ_INTRINSIC
 #endif
 #endif
 
 #ifdef USE_CLZ_INTRINSIC
+#if defined(_MSC_VER) && !defined(__clang__)
+#define JPEG_NBITS_NONZERO(x)  (32 - _CountLeadingZeros(x))
+#else /* __GNUC__ */
 #define JPEG_NBITS_NONZERO(x)  (32 - __builtin_clz(x))
+#endif
 #define JPEG_NBITS(x)          (x ? JPEG_NBITS_NONZERO(x) : 0)
 #else
 #include "jpeg_nbits_table.h"

--- a/jcphuff.c
+++ b/jcphuff.c
@@ -51,15 +51,19 @@
  * flags (this defines __thumb__).
  */
 
-/* NOTE: Both GCC and Clang define __GNUC__ */
-#if defined(__GNUC__) && (defined(__arm__) || defined(__aarch64__))
+#if defined(__arm__) || defined(__aarch64__) || defined(_M_ARM) || \
+    defined(_M_ARM64)
 #if !defined(__thumb__) || defined(__thumb2__)
 #define USE_CLZ_INTRINSIC
 #endif
 #endif
 
 #ifdef USE_CLZ_INTRINSIC
+#if defined(_MSC_VER) && !defined(__clang__)
+#define JPEG_NBITS_NONZERO(x)  (32 - _CountLeadingZeros(x))
+#else /* __GNUC__ */
 #define JPEG_NBITS_NONZERO(x)  (32 - __builtin_clz(x))
+#endif
 #define JPEG_NBITS(x)          (x ? JPEG_NBITS_NONZERO(x) : 0)
 #else
 #include "jpeg_nbits_table.h"

--- a/simd/arm/aarch64/jchuff-neon.c
+++ b/simd/arm/aarch64/jchuff-neon.c
@@ -331,7 +331,7 @@ JOCTET *jsimd_huff_encode_one_block_neon(void *state, JOCTET *buffer,
     vst1q_u16(block_diff + 7 * DCTSIZE, row7_diff);
 
     while (bitmap != 0) {
-      r = BUILTIN_CLZL(bitmap);
+      r = BUILTIN_CLZLL(bitmap);
       i += r;
       bitmap <<= r;
       nbits = block_nbits[i];
@@ -370,7 +370,7 @@ JOCTET *jsimd_huff_encode_one_block_neon(void *state, JOCTET *buffer,
 
     /* Same as above but must mask diff bits and compute nbits on demand. */
     while (bitmap != 0) {
-      r = BUILTIN_CLZL(bitmap);
+      r = BUILTIN_CLZLL(bitmap);
       i += r;
       bitmap <<= r;
       lz = BUILTIN_CLZ(block_abs[i]);

--- a/simd/arm/jcphuff-neon.c
+++ b/simd/arm/jcphuff-neon.c
@@ -572,7 +572,7 @@ int jsimd_encode_mcu_AC_refine_prepare_neon
     /* EOB position is defined to be 0 if all coefficients != 1. */
     return 0;
   } else {
-    return 63 - BUILTIN_CLZL(bitmap);
+    return 63 - BUILTIN_CLZLL(bitmap);
   }
 #else
   /* Move bitmap to two 32-bit scalar registers. */

--- a/simd/arm/neon-compat.h.in
+++ b/simd/arm/neon-compat.h.in
@@ -26,10 +26,10 @@
 /* Define compiler-independent count-leading-zeros macros */
 #if defined(_MSC_VER) && !defined(__clang__)
 #define BUILTIN_CLZ(x)  _CountLeadingZeros(x)
-#define BUILTIN_CLZL(x)  _CountLeadingZeros64(x)
+#define BUILTIN_CLZLL(x)  _CountLeadingZeros64(x)
 #elif defined(__clang__) || defined(__GNUC__)
 #define BUILTIN_CLZ(x)  __builtin_clz(x)
-#define BUILTIN_CLZL(x)  __builtin_clzl(x)
+#define BUILTIN_CLZLL(x)  __builtin_clzll(x)
 #else
 #error "Unknown compiler"
 #endif


### PR DESCRIPTION
- Fixes Neon intrinsics Huffman encoding on Windows on Arm compiled with clang-cl. (Fixes https://github.com/libjpeg-turbo/libjpeg-turbo/issues/480)
- Uses CLZ instructions for scalar Huffman encoding paths for Windows on Arm - saves 128KB memory.

Verified that all unit tests pass for scalar and SIMD builds for:
- Windows on Arm (MSVC and clang-cl)
- Linux (GCC and Clang)