### PR TITLE
Generate and install a cmake package configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1493,8 +1493,39 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/jconfig.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 include(cmakescripts/BuildPackages.cmake)
+include(CMakePackageConfigHelpers)
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmakescripts/cmake_uninstall.cmake.in"
   "cmake_uninstall.cmake" IMMEDIATE @ONLY)
 
 add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P cmake_uninstall.cmake)
+
+foreach(T turbojpeg turbojpeg-static jpeg jpeg-static simd)
+    if(TARGET ${T})
+        list(APPEND TARGETS ${T})
+    endif()
+endforeach()
+list(GET TARGETS 0 FIRST_TARGET)
+
+install(TARGETS ${TARGETS}
+  EXPORT LibJpegTurboTargets)
+
+# Makes the project importable from the build directory
+export(EXPORT LibJpegTurboTargets
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/LibJpegTurboTargets.cmake")
+
+configure_package_config_file(cmakescripts/LibJpegTurboConfig.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/LibJpegTurboConfig.cmake"
+  INSTALL_DESTINATION lib/cmake/)
+
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/LibJpegTurboConfigVersion.cmake
+  VERSION ${VERSION}
+  COMPATIBILITY AnyNewerVersion)
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/LibJpegTurboConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/LibJpegTurboConfigVersion.cmake
+  DESTINATION lib/cmake/)
+install(EXPORT LibJpegTurboTargets
+  FILE LibJpegTurboTargets.cmake
+  NAMESPACE turbojpeg::
+  DESTINATION lib/cmake/)

--- a/cmakescripts/LibJpegTurboConfig.cmake.in
+++ b/cmakescripts/LibJpegTurboConfig.cmake.in
@@ -1,0 +1,6 @@
+
+@PACKAGE_INIT@
+
+if(NOT TARGET turbojpeg::@FIRST_TARGET@)
+    include("${CMAKE_CURRENT_LIST_DIR}/LibJpegTurboTargets.cmake")
+endif()


### PR DESCRIPTION
This PR adds a cmake package configuration. This is helpful for downstream projects that can then just do:
```
find_package(LibJpegTurbo REQUIRED)
target_link_libraries(${PROJECT_NAME}
    turbojpeg::jpeg turbojpeg::turbojpeg)
```

Can you please advise if you find this worthwhile, and if anything needs to be added/changed to consider this PR?