### PR TITLE
Patch with SIMD optimization for e2k architecture.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,9 @@ elseif(CMAKE_SYSTEM_PROCESSOR_LC STREQUAL "aarch64" OR
 elseif(CMAKE_SYSTEM_PROCESSOR_LC MATCHES "ppc*" OR
   CMAKE_SYSTEM_PROCESSOR_LC MATCHES "powerpc*")
   set(CPU_TYPE powerpc)
+elseif(CMAKE_SYSTEM_PROCESSOR_LC STREQUAL "e2k" OR
+  CMAKE_SYSTEM_PROCESSOR_LC STREQUAL "elbrus")
+  set(CPU_TYPE e2k)
 else()
   set(CPU_TYPE ${CMAKE_SYSTEM_PROCESSOR_LC})
 endif()
@@ -548,6 +551,9 @@ endif()
 
 if(WITH_SIMD)
   add_subdirectory(simd)
+  if(HAVE_EML)
+    link_libraries(-leml)
+  endif()
 elseif(NOT WITH_12BIT)
   message(STATUS "SIMD extensions: None (WITH_SIMD = ${WITH_SIMD})")
 endif()
@@ -908,6 +914,8 @@ else()
   if((CPU_TYPE STREQUAL "powerpc" OR CPU_TYPE STREQUAL "arm64") AND
     NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
     set(DEFAULT_FLOATTEST fp-contract)
+  elseif(WITH_SIMD AND CPU_TYPE STREQUAL "e2k")
+    set(DEFAULT_FLOATTEST sse)
   else()
     set(DEFAULT_FLOATTEST no-fp-contract)
   endif()

--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -373,6 +373,53 @@ if(CMAKE_POSITION_INDEPENDENT_CODE OR ENABLE_SHARED)
   set_target_properties(simd PROPERTIES POSITION_INDEPENDENT_CODE 1)
 endif()
 
+###############################################################################
+# Elbrus (Intrinsics)
+###############################################################################
+
+elseif(CPU_TYPE STREQUAL "e2k")
+
+option(WITH_EML "Use Elbrus Math Library" TRUE)
+boolean_number(WITH_EML)
+
+if(WITH_EML)
+  set(CMAKE_REQUIRED_INCLUDES /usr/include/eml)
+  set(CMAKE_REQUIRED_LINK_OPTIONS -leml)
+  check_c_source_compiles("
+    #include <eml.h>
+    int main(void) {
+      eml_8u rgb[12] = { 0 }, y[4], cb[4], cr[4];
+      eml_Video_ColorRGB2YCC444_8U(rgb, y, cb, cr, 4);
+      eml_Video_ColorYCC2RGB444_8U(y, cb, cr, rgb, 4);
+      return 0;
+    }" HAVE_EML)
+  unset(CMAKE_REQUIRED_INCLUDES)
+  unset(CMAKE_REQUIRED_LINK_OPTIONS)
+endif()
+
+set(SIMD_SOURCES e2k/jquanti-e2k.c e2k/jquantf-e2k.c
+  e2k/jccolor-e2k.c e2k/jcgray-e2k.c e2k/jcsample-e2k.c
+  e2k/jdcolor-e2k.c e2k/jdmerge-e2k.c e2k/jdsample-e2k.c
+  e2k/jfdctint-e2k.c e2k/jfdctfst-e2k.c e2k/jfdctflt-e2k.c
+  e2k/jidctint-e2k.c e2k/jidctfst-e2k.c e2k/jidctflt-e2k.c)
+
+set_source_files_properties(${SIMD_SOURCES} PROPERTIES
+  COMPILE_FLAGS -msse4.1)
+
+set(SIMD_SOURCES ${SIMD_SOURCES} e2k/jsimd.c)
+
+if(HAVE_EML)
+  set_source_files_properties(${SIMD_SOURCES} PROPERTIES
+    COMPILE_DEFINITIONS HAVE_EML)
+  set_source_files_properties(${SIMD_SOURCES} PROPERTIES
+    INCLUDE_DIRECTORIES /usr/include/eml)
+endif()
+
+add_library(simd OBJECT ${SIMD_SOURCES})
+
+if(CMAKE_POSITION_INDEPENDENT_CODE OR ENABLE_SHARED)
+  set_target_properties(simd PROPERTIES POSITION_INDEPENDENT_CODE 1)
+endif()
 
 ###############################################################################
 # None

--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -120,7 +120,8 @@ if(CPU_TYPE STREQUAL "x86_64")
     x86_64/jquanti-sse2.asm
     x86_64/jccolor-avx2.asm x86_64/jcgray-avx2.asm x86_64/jcsample-avx2.asm
     x86_64/jdcolor-avx2.asm x86_64/jdmerge-avx2.asm x86_64/jdsample-avx2.asm
-    x86_64/jfdctint-avx2.asm x86_64/jidctint-avx2.asm x86_64/jquanti-avx2.asm)
+    x86_64/jfdctint-avx2.asm x86_64/jidctint-avx2.asm x86_64/jidctflt-avx2.asm
+    x86_64/jquanti-avx2.asm)
 else()
   set(SIMD_SOURCES i386/jsimdcpu.asm i386/jfdctflt-3dn.asm
     i386/jidctflt-3dn.asm i386/jquant-3dn.asm

--- a/simd/e2k/jccolext-e2k.c
+++ b/simd/e2k/jccolext-e2k.c
@@ -1,0 +1,210 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2014-2015, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2014, Jay Foad.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* This file is included by jccolor-e2k.c */
+
+#ifdef HAVE_EML
+#if RGB_RED == 0 && RGB_GREEN == 1 && RGB_BLUE == 2 && RGB_PIXELSIZE == 3
+#define EML_CONV_FN eml_Video_ColorRGB2YCC444_8U
+#elif RGB_RED == 1 && RGB_GREEN == 2 && RGB_BLUE == 3 && RGB_PIXELSIZE == 4
+#define EML_CONV_FN eml_Video_ColorARGB2YCC444_8U
+#elif RGB_RED == 2 && RGB_GREEN == 1 && RGB_BLUE == 0 && RGB_PIXELSIZE == 4
+#define EML_CONV_FN eml_Video_ColorBGRA2YCC444_8U
+#elif RGB_RED == 3 && RGB_GREEN == 2 && RGB_BLUE == 1 && RGB_PIXELSIZE == 4
+#define EML_CONV_FN eml_Video_ColorABGR2YCC444_8U
+#endif
+#endif
+
+void jsimd_rgb_ycc_convert_e2k(JDIMENSION img_width, JSAMPARRAY input_buf,
+                               JSAMPIMAGE output_buf,
+                               JDIMENSION output_row, int num_rows)
+{
+  JSAMPROW inptr, outptr0, outptr1, outptr2;
+  int pitch = img_width * RGB_PIXELSIZE, num_cols;
+  unsigned char __attribute__((aligned(16))) tmpbuf[RGB_PIXELSIZE * 16];
+
+  __m128i pb_zero = _mm_setzero_si128();
+  __m128i pb_shuf0 = _mm_setr_epi8(RGBG_INDEX);
+#if RGB_PIXELSIZE == 4
+  __m128i rgb3 = pb_zero;
+#else
+  __m128i pb_shuf4 = _mm_setr_epi8(RGBG_INDEX4(RGBG_INDEX));
+#endif
+  __m128i rgb0, rgb1 = pb_zero, rgb2 = pb_zero,
+    rgbg0, rgbg1, rgbg2, rgbg3, rg0, rg1, rg2, rg3, bg0, bg1, bg2, bg3;
+  __m128i y, yl, yh, y0, y1, y2, y3;
+  __m128i cb, cr, crl, crh, cbl, cbh;
+  __m128i cr0, cr1, cr2, cr3, cb0, cb1, cb2, cb3;
+
+  /* Constants */
+  __m128i pw_f0299_f0337 = _mm_setr_epi16(__4X2(F_0_299, F_0_337)),
+    pw_f0114_f0250 = _mm_setr_epi16(__4X2(F_0_114, F_0_250)),
+    pw_mf016_mf033 = _mm_setr_epi16(__4X2(-F_0_168, -F_0_331)),
+    pw_mf008_mf041 = _mm_setr_epi16(__4X2(-F_0_081, -F_0_418)),
+    pw_mf050_f000 = _mm_setr_epi16(__4X2(-F_0_500, 0)),
+    pd_onehalf = _mm_set1_epi32(ONE_HALF),
+    pd_onehalfm1_cj = _mm_set1_epi32(ONE_HALF - 1 + (CENTERJSAMPLE << SCALEBITS));
+
+  if (pitch > 0)
+  while (--num_rows >= 0) {
+    inptr = *input_buf++;
+    outptr0 = output_buf[0][output_row];
+    outptr1 = output_buf[1][output_row];
+    outptr2 = output_buf[2][output_row];
+    output_row++;
+
+#ifdef EML_CONV_FN
+    if (jsimd_use_eml && !(((size_t)inptr |
+        (size_t)outptr0 | (size_t)outptr1 | (size_t)outptr2) & 7)) {
+      EML_CONV_FN(inptr, outptr0, outptr1, outptr2, img_width);
+    } else
+#undef EML_CONV_FN
+#endif
+    for (num_cols = pitch; num_cols > 0;
+         num_cols -= RGB_PIXELSIZE * 16, inptr += RGB_PIXELSIZE * 16,
+         outptr0 += 16, outptr1 += 16, outptr2 += 16) {
+
+        if (num_cols < RGB_PIXELSIZE * 16 && (num_cols & 15)) {
+          /* Slow path */
+          memcpy(tmpbuf, inptr, min(num_cols, RGB_PIXELSIZE * 16));
+          rgb0 = VEC_LD(tmpbuf);
+          rgb1 = VEC_LD(tmpbuf + 16);
+          rgb2 = VEC_LD(tmpbuf + 32);
+#if RGB_PIXELSIZE == 4
+          rgb3 = VEC_LD(tmpbuf + 48);
+#endif
+        } else {
+          /* Fast path */
+          rgb0 = VEC_LD(inptr);
+          if (num_cols > 16) rgb1 = VEC_LD(inptr + 16);
+          if (num_cols > 32) rgb2 = VEC_LD(inptr + 32);
+#if RGB_PIXELSIZE == 4
+          if (num_cols > 48) rgb3 = VEC_LD(inptr + 48);
+#endif
+        }
+
+#if RGB_PIXELSIZE == 3
+      /* rgb0 = R0 G0 B0 R1 G1 B1 R2 G2 B2 R3 G3 B3 R4 G4 B4 R5
+       * rgb1 = G5 B5 R6 G6 B6 R7 G7 B7 R8 G8 B8 R9 G9 B9 Ra Ga
+       * rgb2 = Ba Rb Gb Bb Rc Gc Bc Rd Gd Bd Re Ge Be Rf Gf Bf
+       */
+      rgbg0 = _mm_shuffle_epi8(rgb0, pb_shuf0);
+      rgbg1 = _mm_shuffle_epi8(VEC_ALIGNR8(rgb1, rgb0), pb_shuf4);
+      rgbg2 = _mm_shuffle_epi8(VEC_ALIGNR8(rgb2, rgb1), pb_shuf0);
+      rgbg3 = _mm_shuffle_epi8(rgb2, pb_shuf4);
+#else
+      /* rgb0 = R0 G0 B0 X0 R1 G1 B1 X1 R2 G2 B2 X2 R3 G3 B3 X3
+       * rgb1 = R4 G4 B4 X4 R5 G5 B5 X5 R6 G6 B6 X6 R7 G7 B7 X7
+       * rgb2 = R8 G8 B8 X8 R9 G9 B9 X9 Ra Ga Ba Xa Rb Gb Bb Xb
+       * rgb3 = Rc Gc Bc Xc Rd Gd Bd Xd Re Ge Be Xe Rf Gf Bf Xf
+       */
+      rgbg0 = _mm_shuffle_epi8(rgb0, pb_shuf0);
+      rgbg1 = _mm_shuffle_epi8(rgb1, pb_shuf0);
+      rgbg2 = _mm_shuffle_epi8(rgb2, pb_shuf0);
+      rgbg3 = _mm_shuffle_epi8(rgb3, pb_shuf0);
+#endif
+      /* rgbg0 = R0 G0 R1 G1 R2 G2 R3 G3 B0 G0 B1 G1 B2 G2 B3 G3
+       * rgbg1 = R4 G4 R5 G5 R6 G6 R7 G7 B4 G4 B5 G5 B6 G6 B7 G7
+       * rgbg2 = R8 G8 R9 G9 Ra Ga Rb Gb B8 G8 B9 G9 Ba Ga Bb Gb
+       * rgbg3 = Rc Gc Rd Gd Re Ge Rf Gf Bc Gc Bd Gd Be Ge Bf Gf
+       *
+       * rg0 = R0 G0 R1 G1 R2 G2 R3 G3
+       * bg0 = B0 G0 B1 G1 B2 G2 B3 G3
+       * ...
+       */
+      rg0 = _mm_unpacklo_epi8(rgbg0, pb_zero);
+      bg0 = _mm_unpackhi_epi8(rgbg0, pb_zero);
+      rg1 = _mm_unpacklo_epi8(rgbg1, pb_zero);
+      bg1 = _mm_unpackhi_epi8(rgbg1, pb_zero);
+      rg2 = _mm_unpacklo_epi8(rgbg2, pb_zero);
+      bg2 = _mm_unpackhi_epi8(rgbg2, pb_zero);
+      rg3 = _mm_unpacklo_epi8(rgbg3, pb_zero);
+      bg3 = _mm_unpackhi_epi8(rgbg3, pb_zero);
+
+      /* (Original)
+       * Y  =  0.29900 * R + 0.58700 * G + 0.11400 * B
+       * Cb = -0.16874 * R - 0.33126 * G + 0.50000 * B + CENTERJSAMPLE
+       * Cr =  0.50000 * R - 0.41869 * G - 0.08131 * B + CENTERJSAMPLE
+       *
+       * (This implementation)
+       * Y  =  0.29900 * R + 0.33700 * G + 0.11400 * B + 0.25000 * G
+       * Cb = -0.16874 * R - 0.33126 * G + 0.50000 * B + CENTERJSAMPLE
+       * Cr =  0.50000 * R - 0.41869 * G - 0.08131 * B + CENTERJSAMPLE
+       */
+
+      /* Calculate Y values */
+      y0 = _mm_add_epi32(_mm_madd_epi16(rg0, pw_f0299_f0337), pd_onehalf);
+      y1 = _mm_add_epi32(_mm_madd_epi16(rg1, pw_f0299_f0337), pd_onehalf);
+      y2 = _mm_add_epi32(_mm_madd_epi16(rg2, pw_f0299_f0337), pd_onehalf);
+      y3 = _mm_add_epi32(_mm_madd_epi16(rg3, pw_f0299_f0337), pd_onehalf);
+      y0 = _mm_add_epi32(_mm_madd_epi16(bg0, pw_f0114_f0250), y0);
+      y1 = _mm_add_epi32(_mm_madd_epi16(bg1, pw_f0114_f0250), y1);
+      y2 = _mm_add_epi32(_mm_madd_epi16(bg2, pw_f0114_f0250), y2);
+      y3 = _mm_add_epi32(_mm_madd_epi16(bg3, pw_f0114_f0250), y3);
+
+      yl = PACK_HIGH16(y0, y1);
+      yh = PACK_HIGH16(y2, y3);
+      y = _mm_packus_epi16(yl, yh);
+      VEC_ST(outptr0, y);
+
+      /* Calculate Cb values */
+      cb0 = _mm_add_epi32(_mm_madd_epi16(rg0, pw_mf016_mf033), pd_onehalfm1_cj);
+      cb1 = _mm_add_epi32(_mm_madd_epi16(rg1, pw_mf016_mf033), pd_onehalfm1_cj);
+      cb2 = _mm_add_epi32(_mm_madd_epi16(rg2, pw_mf016_mf033), pd_onehalfm1_cj);
+      cb3 = _mm_add_epi32(_mm_madd_epi16(rg3, pw_mf016_mf033), pd_onehalfm1_cj);
+      cb0 = _mm_sub_epi32(cb0, _mm_madd_epi16(bg0, pw_mf050_f000));
+      cb1 = _mm_sub_epi32(cb1, _mm_madd_epi16(bg1, pw_mf050_f000));
+      cb2 = _mm_sub_epi32(cb2, _mm_madd_epi16(bg2, pw_mf050_f000));
+      cb3 = _mm_sub_epi32(cb3, _mm_madd_epi16(bg3, pw_mf050_f000));
+
+      cbl = PACK_HIGH16(cb0, cb1);
+      cbh = PACK_HIGH16(cb2, cb3);
+      cb = _mm_packus_epi16(cbl, cbh);
+      VEC_ST(outptr1, cb);
+
+      /* Calculate Cr values */
+      cr0 = _mm_add_epi32(_mm_madd_epi16(bg0, pw_mf008_mf041), pd_onehalfm1_cj);
+      cr1 = _mm_add_epi32(_mm_madd_epi16(bg1, pw_mf008_mf041), pd_onehalfm1_cj);
+      cr2 = _mm_add_epi32(_mm_madd_epi16(bg2, pw_mf008_mf041), pd_onehalfm1_cj);
+      cr3 = _mm_add_epi32(_mm_madd_epi16(bg3, pw_mf008_mf041), pd_onehalfm1_cj);
+      cr0 = _mm_sub_epi32(cr0, _mm_madd_epi16(rg0, pw_mf050_f000));
+      cr1 = _mm_sub_epi32(cr1, _mm_madd_epi16(rg1, pw_mf050_f000));
+      cr2 = _mm_sub_epi32(cr2, _mm_madd_epi16(rg2, pw_mf050_f000));
+      cr3 = _mm_sub_epi32(cr3, _mm_madd_epi16(rg3, pw_mf050_f000));
+
+      crl = PACK_HIGH16(cr0, cr1);
+      crh = PACK_HIGH16(cr2, cr3);
+      cr = _mm_packus_epi16(crl, crh);
+      VEC_ST(outptr2, cr);
+    }
+  }
+}
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#ifdef jsimd_rgb_ycc_convert_e2k
+#undef jsimd_rgb_ycc_convert_e2k
+#endif
+

--- a/simd/e2k/jccolor-e2k.c
+++ b/simd/e2k/jccolor-e2k.c
@@ -1,0 +1,102 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2014, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* RGB --> YCC CONVERSION */
+
+#include "jsimd_e2k.h"
+#ifdef HAVE_EML
+#include "eml.h"
+#endif
+
+
+#define F_0_081  5329                 /* FIX(0.08131) */
+#define F_0_114  7471                 /* FIX(0.11400) */
+#define F_0_168  11059                /* FIX(0.16874) */
+#define F_0_250  16384                /* FIX(0.25000) */
+#define F_0_299  19595                /* FIX(0.29900) */
+#define F_0_331  21709                /* FIX(0.33126) */
+#define F_0_418  27439                /* FIX(0.41869) */
+#define F_0_500  32768                /* FIX(0.50000) */
+#define F_0_587  38470                /* FIX(0.58700) */
+#define F_0_337  (F_0_587 - F_0_250)  /* FIX(0.58700) - FIX(0.25000) */
+#define F_0_413  (65536 - F_0_587)    /* FIX(1.00000) - FIX(0.58700) */
+
+#define SCALEBITS  16
+#define ONE_HALF  (1 << (SCALEBITS - 1))
+
+#define RGBG_INDEX4_(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) \
+  a + 4, b + 4, c + 4, d + 4, e + 4, f + 4, g + 4, h + 4, \
+  i + 4, j + 4, k + 4, l + 4, m + 4, n + 4, o + 4, p + 4
+#define RGBG_INDEX4(a) RGBG_INDEX4_(a)
+#define RGBG_INDEX_(c0, i) RGB_##c0 + i * RGB_PIXELSIZE, \
+  RGB_GREEN + i * RGB_PIXELSIZE
+#define RGBG_INDEX \
+  RGBG_INDEX_(RED, 0), RGBG_INDEX_(RED, 1), \
+  RGBG_INDEX_(RED, 2), RGBG_INDEX_(RED, 3), \
+  RGBG_INDEX_(BLUE, 0), RGBG_INDEX_(BLUE, 1), \
+  RGBG_INDEX_(BLUE, 2), RGBG_INDEX_(BLUE, 3)
+
+#include "jccolext-e2k.c"
+
+#define RGB_RED  EXT_RGB_RED
+#define RGB_GREEN  EXT_RGB_GREEN
+#define RGB_BLUE  EXT_RGB_BLUE
+#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
+#define jsimd_rgb_ycc_convert_e2k  jsimd_extrgb_ycc_convert_e2k
+#include "jccolext-e2k.c"
+
+#define RGB_RED  EXT_RGBX_RED
+#define RGB_GREEN  EXT_RGBX_GREEN
+#define RGB_BLUE  EXT_RGBX_BLUE
+#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
+#define jsimd_rgb_ycc_convert_e2k  jsimd_extrgbx_ycc_convert_e2k
+#include "jccolext-e2k.c"
+
+#define RGB_RED  EXT_BGR_RED
+#define RGB_GREEN  EXT_BGR_GREEN
+#define RGB_BLUE  EXT_BGR_BLUE
+#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
+#define jsimd_rgb_ycc_convert_e2k  jsimd_extbgr_ycc_convert_e2k
+#include "jccolext-e2k.c"
+
+#define RGB_RED  EXT_BGRX_RED
+#define RGB_GREEN  EXT_BGRX_GREEN
+#define RGB_BLUE  EXT_BGRX_BLUE
+#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
+#define jsimd_rgb_ycc_convert_e2k  jsimd_extbgrx_ycc_convert_e2k
+#include "jccolext-e2k.c"
+
+#define RGB_RED  EXT_XBGR_RED
+#define RGB_GREEN  EXT_XBGR_GREEN
+#define RGB_BLUE  EXT_XBGR_BLUE
+#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
+#define jsimd_rgb_ycc_convert_e2k  jsimd_extxbgr_ycc_convert_e2k
+#include "jccolext-e2k.c"
+
+#define RGB_RED  EXT_XRGB_RED
+#define RGB_GREEN  EXT_XRGB_GREEN
+#define RGB_BLUE  EXT_XRGB_BLUE
+#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
+#define jsimd_rgb_ycc_convert_e2k  jsimd_extxrgb_ycc_convert_e2k
+#include "jccolext-e2k.c"
+

--- a/simd/e2k/jcgray-e2k.c
+++ b/simd/e2k/jcgray-e2k.c
@@ -1,0 +1,93 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2014, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* RGB --> GRAYSCALE CONVERSION */
+
+#include "jsimd_e2k.h"
+
+
+#define F_0_114  7471                 /* FIX(0.11400) */
+#define F_0_250  16384                /* FIX(0.25000) */
+#define F_0_299  19595                /* FIX(0.29900) */
+#define F_0_587  38470                /* FIX(0.58700) */
+#define F_0_337  (F_0_587 - F_0_250)  /* FIX(0.58700) - FIX(0.25000) */
+
+#define SCALEBITS  16
+#define ONE_HALF  (1 << (SCALEBITS - 1))
+
+#define RGBG_INDEX4_(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) \
+  a + 4, b + 4, c + 4, d + 4, e + 4, f + 4, g + 4, h + 4, \
+  i + 4, j + 4, k + 4, l + 4, m + 4, n + 4, o + 4, p + 4
+#define RGBG_INDEX4(a) RGBG_INDEX4_(a)
+#define RGBG_INDEX_(c0, i) RGB_##c0 + i * RGB_PIXELSIZE, \
+  RGB_GREEN + i * RGB_PIXELSIZE
+#define RGBG_INDEX \
+  RGBG_INDEX_(RED, 0), RGBG_INDEX_(RED, 1), \
+  RGBG_INDEX_(RED, 2), RGBG_INDEX_(RED, 3), \
+  RGBG_INDEX_(BLUE, 0), RGBG_INDEX_(BLUE, 1), \
+  RGBG_INDEX_(BLUE, 2), RGBG_INDEX_(BLUE, 3)
+
+#include "jcgryext-e2k.c"
+
+#define RGB_RED  EXT_RGB_RED
+#define RGB_GREEN  EXT_RGB_GREEN
+#define RGB_BLUE  EXT_RGB_BLUE
+#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
+#define jsimd_rgb_gray_convert_e2k  jsimd_extrgb_gray_convert_e2k
+#include "jcgryext-e2k.c"
+
+#define RGB_RED  EXT_RGBX_RED
+#define RGB_GREEN  EXT_RGBX_GREEN
+#define RGB_BLUE  EXT_RGBX_BLUE
+#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
+#define jsimd_rgb_gray_convert_e2k  jsimd_extrgbx_gray_convert_e2k
+#include "jcgryext-e2k.c"
+
+#define RGB_RED  EXT_BGR_RED
+#define RGB_GREEN  EXT_BGR_GREEN
+#define RGB_BLUE  EXT_BGR_BLUE
+#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
+#define jsimd_rgb_gray_convert_e2k  jsimd_extbgr_gray_convert_e2k
+#include "jcgryext-e2k.c"
+
+#define RGB_RED  EXT_BGRX_RED
+#define RGB_GREEN  EXT_BGRX_GREEN
+#define RGB_BLUE  EXT_BGRX_BLUE
+#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
+#define jsimd_rgb_gray_convert_e2k  jsimd_extbgrx_gray_convert_e2k
+#include "jcgryext-e2k.c"
+
+#define RGB_RED  EXT_XBGR_RED
+#define RGB_GREEN  EXT_XBGR_GREEN
+#define RGB_BLUE  EXT_XBGR_BLUE
+#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
+#define jsimd_rgb_gray_convert_e2k  jsimd_extxbgr_gray_convert_e2k
+#include "jcgryext-e2k.c"
+
+#define RGB_RED  EXT_XRGB_RED
+#define RGB_GREEN  EXT_XRGB_GREEN
+#define RGB_BLUE  EXT_XRGB_BLUE
+#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
+#define jsimd_rgb_gray_convert_e2k  jsimd_extxrgb_gray_convert_e2k
+#include "jcgryext-e2k.c"
+

--- a/simd/e2k/jcgryext-e2k.c
+++ b/simd/e2k/jcgryext-e2k.c
@@ -1,0 +1,139 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2014-2015, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2014, Jay Foad.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* This file is included by jcgray-e2k.c */
+
+
+void jsimd_rgb_gray_convert_e2k(JDIMENSION img_width, JSAMPARRAY input_buf,
+                                JSAMPIMAGE output_buf,
+                                JDIMENSION output_row, int num_rows)
+{
+  JSAMPROW inptr, outptr;
+  int pitch = img_width * RGB_PIXELSIZE, num_cols;
+
+  __m128i pb_zero = _mm_setzero_si128();
+  __m128i pb_shuf0 = _mm_setr_epi8(RGBG_INDEX);
+#if RGB_PIXELSIZE == 4
+  __m128i rgb3 = pb_zero;
+#else
+  __m128i pb_shuf4 = _mm_setr_epi8(RGBG_INDEX4(RGBG_INDEX));
+#endif
+  __m128i rgb0, rgb1 = pb_zero, rgb2 = pb_zero,
+    rgbg0, rgbg1, rgbg2, rgbg3, rg0, rg1, rg2, rg3, bg0, bg1, bg2, bg3;
+  __m128i y, yl, yh, y0, y1, y2, y3;
+
+  /* Constants */
+  __m128i pw_f0299_f0337 = _mm_setr_epi16(__4X2(F_0_299, F_0_337)),
+    pw_f0114_f0250 = _mm_setr_epi16(__4X2(F_0_114, F_0_250)),
+    pd_onehalf = _mm_set1_epi32(ONE_HALF);
+
+  if (pitch > 0)
+  while (--num_rows >= 0) {
+    inptr = *input_buf++;
+    outptr = output_buf[0][output_row];
+    output_row++;
+
+    for (num_cols = pitch; num_cols > 0;
+         num_cols -= RGB_PIXELSIZE * 16, inptr += RGB_PIXELSIZE * 16,
+         outptr += 16) {
+
+      /* Little endian */
+      rgb0 = VEC_LD(inptr);
+      if (num_cols > 16) rgb1 = VEC_LD(inptr + 16);
+      if (num_cols > 32) rgb2 = VEC_LD(inptr + 32);
+#if RGB_PIXELSIZE == 4
+      if (num_cols > 48) rgb3 = VEC_LD(inptr + 48);
+#endif
+
+#if RGB_PIXELSIZE == 3
+      /* rgb0 = R0 G0 B0 R1 G1 B1 R2 G2 B2 R3 G3 B3 R4 G4 B4 R5
+       * rgb1 = G5 B5 R6 G6 B6 R7 G7 B7 R8 G8 B8 R9 G9 B9 Ra Ga
+       * rgb2 = Ba Rb Gb Bb Rc Gc Bc Rd Gd Bd Re Ge Be Rf Gf Bf
+       */
+      rgbg0 = _mm_shuffle_epi8(rgb0, pb_shuf0);
+      rgbg1 = _mm_shuffle_epi8(VEC_ALIGNR8(rgb1, rgb0), pb_shuf4);
+      rgbg2 = _mm_shuffle_epi8(VEC_ALIGNR8(rgb2, rgb1), pb_shuf0);
+      rgbg3 = _mm_shuffle_epi8(rgb2, pb_shuf4);
+#else
+      /* rgb0 = R0 G0 B0 X0 R1 G1 B1 X1 R2 G2 B2 X2 R3 G3 B3 X3
+       * rgb1 = R4 G4 B4 X4 R5 G5 B5 X5 R6 G6 B6 X6 R7 G7 B7 X7
+       * rgb2 = R8 G8 B8 X8 R9 G9 B9 X9 Ra Ga Ba Xa Rb Gb Bb Xb
+       * rgb3 = Rc Gc Bc Xc Rd Gd Bd Xd Re Ge Be Xe Rf Gf Bf Xf
+       */
+      rgbg0 = _mm_shuffle_epi8(rgb0, pb_shuf0);
+      rgbg1 = _mm_shuffle_epi8(rgb1, pb_shuf0);
+      rgbg2 = _mm_shuffle_epi8(rgb2, pb_shuf0);
+      rgbg3 = _mm_shuffle_epi8(rgb3, pb_shuf0);
+#endif
+      /* rgbg0 = R0 G0 R1 G1 R2 G2 R3 G3 B0 G0 B1 G1 B2 G2 B3 G3
+       * rgbg1 = R4 G4 R5 G5 R6 G6 R7 G7 B4 G4 B5 G5 B6 G6 B7 G7
+       * rgbg2 = R8 G8 R9 G9 Ra Ga Rb Gb B8 G8 B9 G9 Ba Ga Bb Gb
+       * rgbg3 = Rc Gc Rd Gd Re Ge Rf Gf Bc Gc Bd Gd Be Ge Bf Gf
+       *
+       * rg0 = R0 G0 R1 G1 R2 G2 R3 G3
+       * bg0 = B0 G0 B1 G1 B2 G2 B3 G3
+       * ...
+       */
+      rg0 = _mm_unpacklo_epi8(rgbg0, pb_zero);
+      bg0 = _mm_unpackhi_epi8(rgbg0, pb_zero);
+      rg1 = _mm_unpacklo_epi8(rgbg1, pb_zero);
+      bg1 = _mm_unpackhi_epi8(rgbg1, pb_zero);
+      rg2 = _mm_unpacklo_epi8(rgbg2, pb_zero);
+      bg2 = _mm_unpackhi_epi8(rgbg2, pb_zero);
+      rg3 = _mm_unpacklo_epi8(rgbg3, pb_zero);
+      bg3 = _mm_unpackhi_epi8(rgbg3, pb_zero);
+
+      /* (Original)
+       * Y  =  0.29900 * R + 0.58700 * G + 0.11400 * B
+       *
+       * (This implementation)
+       * Y  =  0.29900 * R + 0.33700 * G + 0.11400 * B + 0.25000 * G
+       */
+
+      /* Calculate Y values */
+
+      y0 = _mm_add_epi32(_mm_madd_epi16(rg0, pw_f0299_f0337), pd_onehalf);
+      y1 = _mm_add_epi32(_mm_madd_epi16(rg1, pw_f0299_f0337), pd_onehalf);
+      y2 = _mm_add_epi32(_mm_madd_epi16(rg2, pw_f0299_f0337), pd_onehalf);
+      y3 = _mm_add_epi32(_mm_madd_epi16(rg3, pw_f0299_f0337), pd_onehalf);
+      y0 = _mm_add_epi32(_mm_madd_epi16(bg0, pw_f0114_f0250), y0);
+      y1 = _mm_add_epi32(_mm_madd_epi16(bg1, pw_f0114_f0250), y1);
+      y2 = _mm_add_epi32(_mm_madd_epi16(bg2, pw_f0114_f0250), y2);
+      y3 = _mm_add_epi32(_mm_madd_epi16(bg3, pw_f0114_f0250), y3);
+
+      yl = PACK_HIGH16(y0, y1);
+      yh = PACK_HIGH16(y2, y3);
+      y = _mm_packus_epi16(yl, yh);
+      VEC_ST(outptr, y);
+    }
+  }
+}
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#ifdef jsimd_rgb_gray_convert_e2k
+#undef jsimd_rgb_gray_convert_e2k
+#endif
+

--- a/simd/e2k/jcsample-e2k.c
+++ b/simd/e2k/jcsample-e2k.c
@@ -1,0 +1,146 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2015, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* CHROMA DOWNSAMPLING */
+
+#include "jsimd_e2k.h"
+#include "jcsample.h"
+
+
+void jsimd_h2v1_downsample_e2k(JDIMENSION image_width,
+                               int max_v_samp_factor,
+                               JDIMENSION v_samp_factor,
+                               JDIMENSION width_in_blocks,
+                               JSAMPARRAY input_data,
+                               JSAMPARRAY output_data)
+{
+  int outrow, outcol;
+  JDIMENSION output_cols = width_in_blocks * DCTSIZE;
+  JSAMPROW inptr, outptr;
+
+  __m128i this0, next0, out;
+  __m128i this0e, this0o, next0e, next0o, outl, outh;
+
+  /* Constants */
+  __m128i pw_bias = _mm_set1_epi32(1 << 16),
+    even_mask = _mm_set1_epi16(255),
+    pb_zero = _mm_setzero_si128();
+
+  expand_right_edge(input_data, max_v_samp_factor, image_width,
+                    output_cols * 2);
+
+  for (outrow = 0; (JDIMENSION)outrow < v_samp_factor; outrow++) {
+    outptr = output_data[outrow];
+    inptr = input_data[outrow];
+
+    for (outcol = output_cols; outcol > 0;
+         outcol -= 16, inptr += 32, outptr += 16) {
+
+      this0 = VEC_LD(inptr);
+      this0e = _mm_and_si128(this0, even_mask);
+      this0o = _mm_srli_epi16(this0, 8);
+      outl = _mm_add_epi16(this0e, this0o);
+      outl = _mm_srli_epi16(_mm_add_epi16(outl, pw_bias), 1);
+
+      if (outcol > 8) {
+        next0 = VEC_LD(inptr + 16);
+        next0e = _mm_and_si128(next0, even_mask);
+        next0o = _mm_srli_epi16(next0, 8);
+        outh = _mm_add_epi16(next0e, next0o);
+        outh = _mm_srli_epi16(_mm_add_epi16(outh, pw_bias), 1);
+      } else
+        outh = pb_zero;
+
+      out = _mm_packus_epi16(outl, outh);
+      VEC_ST(outptr, out);
+    }
+  }
+}
+
+
+void
+jsimd_h2v2_downsample_e2k(JDIMENSION image_width, int max_v_samp_factor,
+                              JDIMENSION v_samp_factor,
+                              JDIMENSION width_in_blocks,
+                              JSAMPARRAY input_data, JSAMPARRAY output_data)
+{
+  int inrow, outrow, outcol;
+  JDIMENSION output_cols = width_in_blocks * DCTSIZE;
+  JSAMPROW inptr0, inptr1, outptr;
+
+  __m128i this0, next0, this1, next1, out;
+  __m128i this0e, this0o, next0e, next0o, this1e, this1o,
+    next1e, next1o, out0l, out0h, out1l, out1h, outl, outh;
+
+  /* Constants */
+  __m128i pw_bias = _mm_set1_epi32(1 | 2 << 16),
+    even_mask = _mm_set1_epi16(255),
+    pb_zero = _mm_setzero_si128();
+
+  expand_right_edge(input_data, max_v_samp_factor, image_width,
+                    output_cols * 2);
+
+  for (inrow = 0, outrow = 0; (JDIMENSION)outrow < v_samp_factor;
+       inrow += 2, outrow++) {
+
+    inptr0 = input_data[inrow];
+    inptr1 = input_data[inrow + 1];
+    outptr = output_data[outrow];
+
+    for (outcol = output_cols; outcol > 0;
+         outcol -= 16, inptr0 += 32, inptr1 += 32, outptr += 16) {
+
+      this0 = VEC_LD(inptr0);
+      this0e = _mm_and_si128(this0, even_mask);
+      this0o = _mm_srli_epi16(this0, 8);
+      out0l = _mm_add_epi16(this0e, this0o);
+
+      this1 = VEC_LD(inptr1);
+      this1e = _mm_and_si128(this1, even_mask);
+      this1o = _mm_srli_epi16(this1, 8);
+      out1l = _mm_add_epi16(this1e, this1o);
+
+      outl = _mm_add_epi16(out0l, out1l);
+      outl = _mm_srli_epi16(_mm_add_epi16(outl, pw_bias), 2);
+
+      if (outcol > 8) {
+        next0 = VEC_LD(inptr0 + 16);
+        next0e = _mm_and_si128(next0, even_mask);
+        next0o = _mm_srli_epi16(next0, 8);
+        out0h = _mm_add_epi16(next0e, next0o);
+
+        next1 = VEC_LD(inptr1 + 16);
+        next1e = _mm_and_si128(next1, even_mask);
+        next1o = _mm_srli_epi16(next1, 8);
+        out1h = _mm_add_epi16(next1e, next1o);
+
+        outh = _mm_add_epi16(out0h, out1h);
+        outh = _mm_srli_epi16(_mm_add_epi16(outh, pw_bias), 2);
+      } else
+        outh = pb_zero;
+
+      out = _mm_packus_epi16(outl, outh);
+      VEC_ST(outptr, out);
+    }
+  }
+}

--- a/simd/e2k/jcsample.h
+++ b/simd/e2k/jcsample.h
@@ -1,0 +1,28 @@
+/*
+ * jcsample.h
+ *
+ * This file was part of the Independent JPEG Group's software:
+ * Copyright (C) 1991-1996, Thomas G. Lane.
+ * For conditions of distribution and use, see the accompanying README.ijg
+ * file.
+ */
+
+LOCAL(void)
+expand_right_edge(JSAMPARRAY image_data, int num_rows, JDIMENSION input_cols,
+                  JDIMENSION output_cols)
+{
+  register JSAMPROW ptr;
+  register JSAMPLE pixval;
+  register int count;
+  int row;
+  int numcols = (int)(output_cols - input_cols);
+
+  if (numcols > 0) {
+    for (row = 0; row < num_rows; row++) {
+      ptr = image_data[row] + input_cols;
+      pixval = ptr[-1];         /* don't need GETJSAMPLE() here */
+      for (count = numcols; count > 0; count--)
+        *ptr++ = pixval;
+    }
+  }
+}

--- a/simd/e2k/jdcolext-e2k.c
+++ b/simd/e2k/jdcolext-e2k.c
@@ -1,0 +1,230 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2015, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* This file is included by jdcolor-e2k.c */
+
+#ifdef HAVE_EML
+#if RGB_RED == 0 && RGB_GREEN == 1 && RGB_BLUE == 2 && RGB_PIXELSIZE == 3
+#define EML_CONV_FN eml_Video_ColorYCC2RGB444_8U
+#elif RGB_RED == 1 && RGB_GREEN == 2 && RGB_BLUE == 3 && RGB_PIXELSIZE == 4
+#define EML_CONV_FN eml_Video_ColorYCC2ARGB444_8U
+#elif RGB_RED == 2 && RGB_GREEN == 1 && RGB_BLUE == 0 && RGB_PIXELSIZE == 4
+#define EML_CONV_FN eml_Video_ColorYCC2BGRA444_8U
+#endif
+#endif
+
+void jsimd_ycc_rgb_convert_e2k(JDIMENSION out_width, JSAMPIMAGE input_buf,
+                               JDIMENSION input_row, JSAMPARRAY output_buf,
+                               int num_rows)
+{
+  JSAMPROW outptr, inptr0, inptr1, inptr2;
+  int pitch = out_width * RGB_PIXELSIZE, num_cols;
+  unsigned char __attribute__((aligned(16))) tmpbuf[RGB_PIXELSIZE * 16];
+
+  __m128i rgb0, rgb1, rgb2, rgb3, y, cb, cr;
+  __m128i rg0, rg1, bx0, bx1, yl, yh, cbl, cbh,
+    crl, crh, rl, rh, gl, gh, bl, bh, g0w, g1w, g2w, g3w;
+  __m128i g0, g1, g2, g3;
+
+  /* Constants
+   * NOTE: The >> 1 is to compensate for the fact that vec_madds() returns 17
+   * high-order bits, not 16.
+   */
+  __m128i pw_f0402 = _mm_set1_epi16(F_0_402 >> 1),
+    pw_mf0228 = _mm_set1_epi16(-F_0_228 >> 1),
+    pw_mf0344_f0285 = _mm_setr_epi16(__4X2(-F_0_344, F_0_285)),
+    pb_255 = _mm_set1_epi8(-1),
+    pw_cj = _mm_set1_epi16(CENTERJSAMPLE),
+    pd_onehalf = _mm_set1_epi32(ONE_HALF),
+    pb_zero = _mm_setzero_si128();
+#if RGB_PIXELSIZE == 3
+    CONV_RGBX_RGB_INIT
+#endif
+
+  if (pitch > 0)
+  while (--num_rows >= 0) {
+    inptr0 = input_buf[0][input_row];
+    inptr1 = input_buf[1][input_row];
+    inptr2 = input_buf[2][input_row];
+    input_row++;
+    outptr = *output_buf++;
+
+#ifdef EML_CONV_FN
+    if (jsimd_use_eml &&
+        !(((size_t)inptr0 | (size_t)inptr1 | (size_t)inptr2 |
+        (size_t)outptr) & 7)) {
+      EML_CONV_FN(inptr0, inptr1, inptr2, outptr, out_width);
+    } else
+#undef EML_CONV_FN
+#endif
+    for (num_cols = pitch; num_cols > 0;
+         num_cols -= RGB_PIXELSIZE * 16, outptr += RGB_PIXELSIZE * 16,
+         inptr0 += 16, inptr1 += 16, inptr2 += 16) {
+
+      y = VEC_LD(inptr0);
+      yl = _mm_unpacklo_epi8(y, pb_zero);
+      yh = _mm_unpackhi_epi8(y, pb_zero);
+
+      cb = VEC_LD(inptr1);
+      cbl = _mm_unpacklo_epi8(cb, pb_zero);
+      cbh = _mm_unpackhi_epi8(cb, pb_zero);
+      cbl = _mm_sub_epi16(cbl, pw_cj);
+      cbh = _mm_sub_epi16(cbh, pw_cj);
+
+      cr = VEC_LD(inptr2);
+      crl = _mm_unpacklo_epi8(cr, pb_zero);
+      crh = _mm_unpackhi_epi8(cr, pb_zero);
+      crl = _mm_sub_epi16(crl, pw_cj);
+      crh = _mm_sub_epi16(crh, pw_cj);
+
+      /* (Original)
+       * R = Y                + 1.40200 * Cr
+       * G = Y - 0.34414 * Cb - 0.71414 * Cr
+       * B = Y + 1.77200 * Cb
+       *
+       * (This implementation)
+       * R = Y                + 0.40200 * Cr + Cr
+       * G = Y - 0.34414 * Cb + 0.28586 * Cr - Cr
+       * B = Y - 0.22800 * Cb + Cb + Cb
+       */
+      bl = _mm_mulhrs_epi16(cbl, pw_mf0228);
+      bh = _mm_mulhrs_epi16(cbh, pw_mf0228);
+      bl = _mm_add_epi16(bl, _mm_add_epi16(cbl, cbl));
+      bh = _mm_add_epi16(bh, _mm_add_epi16(cbh, cbh));
+      bl = _mm_add_epi16(bl, yl);
+      bh = _mm_add_epi16(bh, yh);
+
+      rl = _mm_mulhrs_epi16(crl, pw_f0402);
+      rh = _mm_mulhrs_epi16(crh, pw_f0402);
+      rl = _mm_add_epi16(rl, crl);
+      rh = _mm_add_epi16(rh, crh);
+      rl = _mm_add_epi16(rl, yl);
+      rh = _mm_add_epi16(rh, yh);
+
+      g0w = _mm_unpacklo_epi16(cbl, crl);
+      g1w = _mm_unpackhi_epi16(cbl, crl);
+      g0 = _mm_add_epi32(_mm_madd_epi16(g0w, pw_mf0344_f0285), pd_onehalf);
+      g1 = _mm_add_epi32(_mm_madd_epi16(g1w, pw_mf0344_f0285), pd_onehalf);
+      g2w = _mm_unpacklo_epi16(cbh, crh);
+      g3w = _mm_unpackhi_epi16(cbh, crh);
+      g2 = _mm_add_epi32(_mm_madd_epi16(g2w, pw_mf0344_f0285), pd_onehalf);
+      g3 = _mm_add_epi32(_mm_madd_epi16(g3w, pw_mf0344_f0285), pd_onehalf);
+
+      gl = PACK_HIGH16(g0, g1);
+      gh = PACK_HIGH16(g2, g3);
+      gl = _mm_sub_epi16(gl, crl);
+      gh = _mm_sub_epi16(gh, crh);
+      gl = _mm_add_epi16(gl, yl);
+      gh = _mm_add_epi16(gh, yh);
+
+      rl = _mm_packus_epi16(rl, rh);
+      gl = _mm_packus_epi16(gl, gh);
+      bl = _mm_packus_epi16(bl, bh);
+
+#if RGB_RED == 0
+#define C0 rl
+#elif RGB_GREEN == 0
+#define C0 gl
+#elif RGB_BLUE == 0
+#define C0 bl
+#else
+#define C0 pb_255
+#endif
+
+#if RGB_RED == 1
+#define C1 rl
+#elif RGB_GREEN == 1
+#define C1 gl
+#elif RGB_BLUE == 1
+#define C1 bl
+#else
+#define C1 pb_255
+#endif
+
+#if RGB_RED == 2
+#define C2 rl
+#elif RGB_GREEN == 2
+#define C2 gl
+#elif RGB_BLUE == 2
+#define C2 bl
+#else
+#define C2 pb_255
+#endif
+
+#if RGB_RED == 3
+#define C3 rl
+#elif RGB_GREEN == 3
+#define C3 gl
+#elif RGB_BLUE == 3
+#define C3 bl
+#else
+#define C3 pb_255
+#endif
+      rg0 = _mm_unpacklo_epi8(C0, C1);
+      rg1 = _mm_unpackhi_epi8(C0, C1);
+      bx0 = _mm_unpacklo_epi8(C2, C3);
+      bx1 = _mm_unpackhi_epi8(C2, C3);
+#undef C0
+#undef C1
+#undef C2
+#undef C3
+
+      rgb0 = _mm_unpacklo_epi16(rg0, bx0);
+      rgb1 = _mm_unpackhi_epi16(rg0, bx0);
+      rgb2 = _mm_unpacklo_epi16(rg1, bx1);
+      rgb3 = _mm_unpackhi_epi16(rg1, bx1);
+
+#if RGB_PIXELSIZE == 3
+      CONV_RGBX_RGB
+#endif
+
+      if (__builtin_expect(num_cols < RGB_PIXELSIZE * 16 && (num_cols & 15), 0)) {
+        /* Slow path */
+        VEC_ST(tmpbuf, rgb0);
+        VEC_ST(tmpbuf + 16, rgb1);
+        VEC_ST(tmpbuf + 32, rgb2);
+#if RGB_PIXELSIZE == 4
+        VEC_ST(tmpbuf + 48, rgb3);
+#endif
+        memcpy(outptr, tmpbuf, min(num_cols, RGB_PIXELSIZE * 16));
+        break;
+      } else {
+        /* Fast path */
+        VEC_ST(outptr, rgb0);
+        if (num_cols > 16) VEC_ST(outptr + 16, rgb1);
+        if (num_cols > 32) VEC_ST(outptr + 32, rgb2);
+#if RGB_PIXELSIZE == 4
+        if (num_cols > 48) VEC_ST(outptr + 48, rgb3);
+#endif
+      }
+    }
+  }
+}
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#ifdef jsimd_ycc_rgb_convert_e2k
+#undef jsimd_ycc_rgb_convert_e2k
+#endif
+

--- a/simd/e2k/jdcolor-e2k.c
+++ b/simd/e2k/jdcolor-e2k.c
@@ -1,0 +1,88 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2015, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* YCC --> RGB CONVERSION */
+
+#include "jsimd_e2k.h"
+#ifdef HAVE_EML
+#include "eml.h"
+#endif
+
+
+#define F_0_344  22554              /* FIX(0.34414) */
+#define F_0_714  46802              /* FIX(0.71414) */
+#define F_1_402  91881              /* FIX(1.40200) */
+#define F_1_772  116130             /* FIX(1.77200) */
+#define F_0_402  (F_1_402 - 65536)  /* FIX(1.40200) - FIX(1) */
+#define F_0_285  (65536 - F_0_714)  /* FIX(1) - FIX(0.71414) */
+#define F_0_228  (131072 - F_1_772) /* FIX(2) - FIX(1.77200) */
+
+#define SCALEBITS  16
+#define ONE_HALF  (1 << (SCALEBITS - 1))
+
+#define RGB_INDEX  0, 1, 2,  4, 5, 6,  8, 9, 10,  12, 13, 14
+
+#include "jdcolext-e2k.c"
+
+#define RGB_RED  EXT_RGB_RED
+#define RGB_GREEN  EXT_RGB_GREEN
+#define RGB_BLUE  EXT_RGB_BLUE
+#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
+#define jsimd_ycc_rgb_convert_e2k  jsimd_ycc_extrgb_convert_e2k
+#include "jdcolext-e2k.c"
+
+#define RGB_RED  EXT_RGBX_RED
+#define RGB_GREEN  EXT_RGBX_GREEN
+#define RGB_BLUE  EXT_RGBX_BLUE
+#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
+#define jsimd_ycc_rgb_convert_e2k  jsimd_ycc_extrgbx_convert_e2k
+#include "jdcolext-e2k.c"
+
+#define RGB_RED  EXT_BGR_RED
+#define RGB_GREEN  EXT_BGR_GREEN
+#define RGB_BLUE  EXT_BGR_BLUE
+#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
+#define jsimd_ycc_rgb_convert_e2k  jsimd_ycc_extbgr_convert_e2k
+#include "jdcolext-e2k.c"
+
+#define RGB_RED  EXT_BGRX_RED
+#define RGB_GREEN  EXT_BGRX_GREEN
+#define RGB_BLUE  EXT_BGRX_BLUE
+#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
+#define jsimd_ycc_rgb_convert_e2k  jsimd_ycc_extbgrx_convert_e2k
+#include "jdcolext-e2k.c"
+
+#define RGB_RED  EXT_XBGR_RED
+#define RGB_GREEN  EXT_XBGR_GREEN
+#define RGB_BLUE  EXT_XBGR_BLUE
+#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
+#define jsimd_ycc_rgb_convert_e2k  jsimd_ycc_extxbgr_convert_e2k
+#include "jdcolext-e2k.c"
+
+#define RGB_RED  EXT_XRGB_RED
+#define RGB_GREEN  EXT_XRGB_GREEN
+#define RGB_BLUE  EXT_XRGB_BLUE
+#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
+#define jsimd_ycc_rgb_convert_e2k  jsimd_ycc_extxrgb_convert_e2k
+#include "jdcolext-e2k.c"
+

--- a/simd/e2k/jdmerge-e2k.c
+++ b/simd/e2k/jdmerge-e2k.c
@@ -1,0 +1,91 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2015, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* MERGED YCC --> RGB CONVERSION AND UPSAMPLING */
+
+#include "jsimd_e2k.h"
+
+
+#define F_0_344  22554              /* FIX(0.34414) */
+#define F_0_714  46802              /* FIX(0.71414) */
+#define F_1_402  91881              /* FIX(1.40200) */
+#define F_1_772  116130             /* FIX(1.77200) */
+#define F_0_402  (F_1_402 - 65536)  /* FIX(1.40200) - FIX(1) */
+#define F_0_285  (65536 - F_0_714)  /* FIX(1) - FIX(0.71414) */
+#define F_0_228  (131072 - F_1_772) /* FIX(2) - FIX(1.77200) */
+
+#define SCALEBITS  16
+#define ONE_HALF  (1 << (SCALEBITS - 1))
+
+#define RGB_INDEX  0, 1, 2,  4, 5, 6,  8, 9, 10,  12, 13, 14
+
+#include "jdmrgext-e2k.c"
+
+#define RGB_RED  EXT_RGB_RED
+#define RGB_GREEN  EXT_RGB_GREEN
+#define RGB_BLUE  EXT_RGB_BLUE
+#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
+#define jsimd_h2v1_merged_upsample_e2k jsimd_h2v1_extrgb_merged_upsample_e2k
+#define jsimd_h2v2_merged_upsample_e2k jsimd_h2v2_extrgb_merged_upsample_e2k
+#include "jdmrgext-e2k.c"
+
+#define RGB_RED  EXT_RGBX_RED
+#define RGB_GREEN  EXT_RGBX_GREEN
+#define RGB_BLUE  EXT_RGBX_BLUE
+#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
+#define jsimd_h2v1_merged_upsample_e2k jsimd_h2v1_extrgbx_merged_upsample_e2k
+#define jsimd_h2v2_merged_upsample_e2k jsimd_h2v2_extrgbx_merged_upsample_e2k
+#include "jdmrgext-e2k.c"
+
+#define RGB_RED  EXT_BGR_RED
+#define RGB_GREEN  EXT_BGR_GREEN
+#define RGB_BLUE  EXT_BGR_BLUE
+#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
+#define jsimd_h2v1_merged_upsample_e2k jsimd_h2v1_extbgr_merged_upsample_e2k
+#define jsimd_h2v2_merged_upsample_e2k jsimd_h2v2_extbgr_merged_upsample_e2k
+#include "jdmrgext-e2k.c"
+
+#define RGB_RED  EXT_BGRX_RED
+#define RGB_GREEN  EXT_BGRX_GREEN
+#define RGB_BLUE  EXT_BGRX_BLUE
+#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
+#define jsimd_h2v1_merged_upsample_e2k jsimd_h2v1_extbgrx_merged_upsample_e2k
+#define jsimd_h2v2_merged_upsample_e2k jsimd_h2v2_extbgrx_merged_upsample_e2k
+#include "jdmrgext-e2k.c"
+
+#define RGB_RED  EXT_XBGR_RED
+#define RGB_GREEN  EXT_XBGR_GREEN
+#define RGB_BLUE  EXT_XBGR_BLUE
+#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
+#define jsimd_h2v1_merged_upsample_e2k jsimd_h2v1_extxbgr_merged_upsample_e2k
+#define jsimd_h2v2_merged_upsample_e2k jsimd_h2v2_extxbgr_merged_upsample_e2k
+#include "jdmrgext-e2k.c"
+
+#define RGB_RED  EXT_XRGB_RED
+#define RGB_GREEN  EXT_XRGB_GREEN
+#define RGB_BLUE  EXT_XRGB_BLUE
+#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
+#define jsimd_h2v1_merged_upsample_e2k jsimd_h2v1_extxrgb_merged_upsample_e2k
+#define jsimd_h2v2_merged_upsample_e2k jsimd_h2v2_extxrgb_merged_upsample_e2k
+#include "jdmrgext-e2k.c"
+

--- a/simd/e2k/jdmrgext-e2k.c
+++ b/simd/e2k/jdmrgext-e2k.c
@@ -1,0 +1,256 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2015, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* This file is included by jdmerge-e2k.c */
+
+
+void jsimd_h2v1_merged_upsample_e2k(JDIMENSION output_width,
+                                    JSAMPIMAGE input_buf,
+                                    JDIMENSION in_row_group_ctr,
+                                    JSAMPARRAY output_buf)
+{
+  JSAMPROW outptr, inptr0, inptr1, inptr2;
+  int pitch = output_width * RGB_PIXELSIZE, num_cols, yloop;
+  unsigned char __attribute__((aligned(16))) tmpbuf[RGB_PIXELSIZE * 16];
+
+  __m128i rgb0, rgb1, rgb2, rgb3, y, cb, cr;
+  __m128i rg0, rg1, bx0, bx1, ye, yo, cbl, cbh,
+    crl, crh, r_yl, r_yh, g_yl, g_yh, b_yl, b_yh, g_y0w, g_y1w, g_y2w, g_y3w,
+    rl, rh, gl, gh, bl, bh, re, ro, ge, go, be, bo;
+  __m128i g_y0, g_y1, g_y2, g_y3;
+
+  /* Constants
+   * NOTE: The >> 1 is to compensate for the fact that vec_madds() returns 17
+   * high-order bits, not 16.
+   */
+  __m128i pw_f0402 = _mm_set1_epi16(F_0_402 >> 1),
+    pw_mf0228 = _mm_set1_epi16(-F_0_228 >> 1),
+    pw_mf0344_f0285 = _mm_setr_epi16(__4X2(-F_0_344, F_0_285)),
+    pb_255 = _mm_set1_epi8(-1),
+    even_mask = _mm_set1_epi16(255),
+    pw_cj = _mm_set1_epi16(CENTERJSAMPLE),
+    pd_onehalf = _mm_set1_epi32(ONE_HALF),
+    pb_zero = _mm_setzero_si128();
+#if RGB_PIXELSIZE == 3
+    CONV_RGBX_RGB_INIT
+#endif
+
+  inptr0 = input_buf[0][in_row_group_ctr];
+  inptr1 = input_buf[1][in_row_group_ctr];
+  inptr2 = input_buf[2][in_row_group_ctr];
+  outptr = output_buf[0];
+
+  for (num_cols = pitch; num_cols > 0; inptr1 += 16, inptr2 += 16) {
+
+    cb = VEC_LD(inptr1);
+    cbl = _mm_unpacklo_epi8(cb, pb_zero);
+    cbh = _mm_unpackhi_epi8(cb, pb_zero);
+    cbl = _mm_sub_epi16(cbl, pw_cj);
+    cbh = _mm_sub_epi16(cbh, pw_cj);
+
+    cr = VEC_LD(inptr2);
+    crl = _mm_unpacklo_epi8(cr, pb_zero);
+    crh = _mm_unpackhi_epi8(cr, pb_zero);
+    crl = _mm_sub_epi16(crl, pw_cj);
+    crh = _mm_sub_epi16(crh, pw_cj);
+
+    /* (Original)
+     * R = Y                + 1.40200 * Cr
+     * G = Y - 0.34414 * Cb - 0.71414 * Cr
+     * B = Y + 1.77200 * Cb
+     *
+     * (This implementation)
+     * R = Y                + 0.40200 * Cr + Cr
+     * G = Y - 0.34414 * Cb + 0.28586 * Cr - Cr
+     * B = Y - 0.22800 * Cb + Cb + Cb
+     */
+    b_yl = _mm_mulhrs_epi16(cbl, pw_mf0228);
+    b_yh = _mm_mulhrs_epi16(cbh, pw_mf0228);
+    b_yl = _mm_add_epi16(b_yl, _mm_add_epi16(cbl, cbl));
+    b_yh = _mm_add_epi16(b_yh, _mm_add_epi16(cbh, cbh));
+
+    r_yl = _mm_mulhrs_epi16(crl, pw_f0402);
+    r_yh = _mm_mulhrs_epi16(crh, pw_f0402);
+    r_yl = _mm_add_epi16(r_yl, crl);
+    r_yh = _mm_add_epi16(r_yh, crh);
+
+    g_y0w = _mm_unpacklo_epi16(cbl, crl);
+    g_y1w = _mm_unpackhi_epi16(cbl, crl);
+    g_y0 = _mm_add_epi32(_mm_madd_epi16(g_y0w, pw_mf0344_f0285), pd_onehalf);
+    g_y1 = _mm_add_epi32(_mm_madd_epi16(g_y1w, pw_mf0344_f0285), pd_onehalf);
+    g_y2w = _mm_unpacklo_epi16(cbh, crh);
+    g_y3w = _mm_unpackhi_epi16(cbh, crh);
+    g_y2 = _mm_add_epi32(_mm_madd_epi16(g_y2w, pw_mf0344_f0285), pd_onehalf);
+    g_y3 = _mm_add_epi32(_mm_madd_epi16(g_y3w, pw_mf0344_f0285), pd_onehalf);
+
+    g_yl = PACK_HIGH16(g_y0, g_y1);
+    g_yh = PACK_HIGH16(g_y2, g_y3);
+    g_yl = _mm_sub_epi16(g_yl, crl);
+    g_yh = _mm_sub_epi16(g_yh, crh);
+
+    for (yloop = 0; yloop < 2 && num_cols > 0; yloop++,
+         num_cols -= RGB_PIXELSIZE * 16,
+         outptr += RGB_PIXELSIZE * 16, inptr0 += 16) {
+
+      y = VEC_LD(inptr0);
+      ye = _mm_and_si128(y, even_mask);
+      yo = _mm_srli_epi16(y, 8);
+
+      if (yloop == 0) {
+        be = _mm_add_epi16(b_yl, ye);
+        bo = _mm_add_epi16(b_yl, yo);
+        re = _mm_add_epi16(r_yl, ye);
+        ro = _mm_add_epi16(r_yl, yo);
+        ge = _mm_add_epi16(g_yl, ye);
+        go = _mm_add_epi16(g_yl, yo);
+      } else {
+        be = _mm_add_epi16(b_yh, ye);
+        bo = _mm_add_epi16(b_yh, yo);
+        re = _mm_add_epi16(r_yh, ye);
+        ro = _mm_add_epi16(r_yh, yo);
+        ge = _mm_add_epi16(g_yh, ye);
+        go = _mm_add_epi16(g_yh, yo);
+      }
+
+      rl = _mm_unpacklo_epi16(re, ro);
+      rh = _mm_unpackhi_epi16(re, ro);
+      gl = _mm_unpacklo_epi16(ge, go);
+      gh = _mm_unpackhi_epi16(ge, go);
+      bl = _mm_unpacklo_epi16(be, bo);
+      bh = _mm_unpackhi_epi16(be, bo);
+
+      rl = _mm_packus_epi16(rl, rh);
+      gl = _mm_packus_epi16(gl, gh);
+      bl = _mm_packus_epi16(bl, bh);
+
+#if RGB_RED == 0
+#define C0 rl
+#elif RGB_GREEN == 0
+#define C0 gl
+#elif RGB_BLUE == 0
+#define C0 bl
+#else
+#define C0 pb_255
+#endif
+
+#if RGB_RED == 1
+#define C1 rl
+#elif RGB_GREEN == 1
+#define C1 gl
+#elif RGB_BLUE == 1
+#define C1 bl
+#else
+#define C1 pb_255
+#endif
+
+#if RGB_RED == 2
+#define C2 rl
+#elif RGB_GREEN == 2
+#define C2 gl
+#elif RGB_BLUE == 2
+#define C2 bl
+#else
+#define C2 pb_255
+#endif
+
+#if RGB_RED == 3
+#define C3 rl
+#elif RGB_GREEN == 3
+#define C3 gl
+#elif RGB_BLUE == 3
+#define C3 bl
+#else
+#define C3 pb_255
+#endif
+      rg0 = _mm_unpacklo_epi8(C0, C1);
+      rg1 = _mm_unpackhi_epi8(C0, C1);
+      bx0 = _mm_unpacklo_epi8(C2, C3);
+      bx1 = _mm_unpackhi_epi8(C2, C3);
+#undef C0
+#undef C1
+#undef C2
+#undef C3
+
+      rgb0 = _mm_unpacklo_epi16(rg0, bx0);
+      rgb1 = _mm_unpackhi_epi16(rg0, bx0);
+      rgb2 = _mm_unpacklo_epi16(rg1, bx1);
+      rgb3 = _mm_unpackhi_epi16(rg1, bx1);
+
+#if RGB_PIXELSIZE == 3
+      CONV_RGBX_RGB
+#endif
+
+      if (__builtin_expect(num_cols < RGB_PIXELSIZE * 16 && (num_cols & 15), 0)) {
+        /* Slow path */
+        VEC_ST(tmpbuf, rgb0);
+        VEC_ST(tmpbuf + 16, rgb1);
+        VEC_ST(tmpbuf + 32, rgb2);
+#if RGB_PIXELSIZE == 4
+        VEC_ST(tmpbuf + 48, rgb3);
+#endif
+        memcpy(outptr, tmpbuf, min(num_cols, RGB_PIXELSIZE * 16));
+      } else {
+        /* Fast path */
+        VEC_ST(outptr, rgb0);
+        if (num_cols > 16) VEC_ST(outptr + 16, rgb1);
+        if (num_cols > 32) VEC_ST(outptr + 32, rgb2);
+#if RGB_PIXELSIZE == 4
+        if (num_cols > 48) VEC_ST(outptr + 48, rgb3);
+#endif
+      }
+    }
+  }
+}
+
+
+void jsimd_h2v2_merged_upsample_e2k(JDIMENSION output_width,
+                                    JSAMPIMAGE input_buf,
+                                    JDIMENSION in_row_group_ctr,
+                                    JSAMPARRAY output_buf)
+{
+  JSAMPROW inptr, outptr;
+
+  inptr = input_buf[0][in_row_group_ctr];
+  outptr = output_buf[0];
+
+  input_buf[0][in_row_group_ctr] = input_buf[0][in_row_group_ctr * 2];
+  jsimd_h2v1_merged_upsample_e2k(output_width, input_buf, in_row_group_ctr,
+                                 output_buf);
+
+  input_buf[0][in_row_group_ctr] = input_buf[0][in_row_group_ctr * 2 + 1];
+  output_buf[0] = output_buf[1];
+  jsimd_h2v1_merged_upsample_e2k(output_width, input_buf, in_row_group_ctr,
+                                 output_buf);
+
+  input_buf[0][in_row_group_ctr] = inptr;
+  output_buf[0] = outptr;
+}
+#undef RGB_RED
+#undef RGB_GREEN
+#undef RGB_BLUE
+#undef RGB_PIXELSIZE
+#ifdef jsimd_h2v1_merged_upsample_e2k
+#undef jsimd_h2v1_merged_upsample_e2k
+#undef jsimd_h2v2_merged_upsample_e2k
+#endif
+

--- a/simd/e2k/jdsample-e2k.c
+++ b/simd/e2k/jdsample-e2k.c
@@ -1,0 +1,334 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2015, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* CHROMA UPSAMPLING */
+
+#include "jsimd_e2k.h"
+
+
+void jsimd_h2v1_fancy_upsample_e2k(int max_v_samp_factor,
+                                   JDIMENSION downsampled_width,
+                                   JSAMPARRAY input_data,
+                                   JSAMPARRAY *output_data_ptr)
+{
+  JSAMPARRAY output_data = *output_data_ptr;
+  JSAMPROW inptr, outptr;
+  int inrow, incol;
+
+  __m128i pb_zero = _mm_setzero_si128();
+  __m128i this0, last0, p_last0, next0 = pb_zero, p_next0, out;
+  __m128i this0l, this0h, last0l, last0h,
+    next0l, next0h, outle, outhe, outlo, outho;
+
+  /* Constants */
+  __m128i pw_three = _mm_set1_epi16(3),
+    next_index_lastcol = _mm_setr_epi8(
+       1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 15),
+    pw_one = _mm_set1_epi16(1), pw_two = _mm_set1_epi16(2);
+
+  if (downsampled_width > 0)
+  for (inrow = 0; inrow < max_v_samp_factor; inrow++) {
+    inptr = input_data[inrow];
+    outptr = output_data[inrow];
+
+    if (downsampled_width & 15)
+      inptr[downsampled_width] = inptr[downsampled_width - 1];
+
+    this0 = VEC_LD(inptr);
+    last0 = _mm_bslli_si128(this0, 15);
+
+    for (incol = downsampled_width; incol > 0;
+         incol -= 16, inptr += 16, outptr += 32) {
+
+      p_last0 = _mm_alignr_epi8(this0, last0, 15);
+      last0 = this0;
+
+      if (__builtin_expect(incol <= 16, 0))
+        p_next0 = _mm_shuffle_epi8(this0, next_index_lastcol);
+      else {
+        next0 = VEC_LD(inptr + 16);
+        p_next0 = _mm_alignr_epi8(next0, this0, 1);
+      }
+
+      this0l = _mm_mullo_epi16(_mm_unpacklo_epi8(this0, pb_zero), pw_three);
+      last0l = _mm_unpacklo_epi8(p_last0, pb_zero);
+      next0l = _mm_unpacklo_epi8(p_next0, pb_zero);
+      last0l = _mm_add_epi16(last0l, pw_one);
+      next0l = _mm_add_epi16(next0l, pw_two);
+
+      outle = _mm_add_epi16(this0l, last0l);
+      outlo = _mm_add_epi16(this0l, next0l);
+      outle = _mm_srli_epi16(outle, 2);
+      outlo = _mm_srli_epi16(outlo, 2);
+
+      out = _mm_or_si128(outle, _mm_slli_epi16(outlo, 8));
+      VEC_ST(outptr, out);
+
+      if (__builtin_expect(incol <= 8, 0)) break;
+
+      this0h = _mm_mullo_epi16(_mm_unpackhi_epi8(this0, pb_zero), pw_three);
+      last0h = _mm_unpackhi_epi8(p_last0, pb_zero);
+      next0h = _mm_unpackhi_epi8(p_next0, pb_zero);
+      last0h = _mm_add_epi16(last0h, pw_one);
+      next0h = _mm_add_epi16(next0h, pw_two);
+
+      outhe = _mm_add_epi16(this0h, last0h);
+      outho = _mm_add_epi16(this0h, next0h);
+      outhe = _mm_srli_epi16(outhe, 2);
+      outho = _mm_srli_epi16(outho, 2);
+
+      out = _mm_or_si128(outhe, _mm_slli_epi16(outho, 8));
+      VEC_ST(outptr + 16, out);
+
+      this0 = next0;
+    }
+  }
+}
+
+
+void jsimd_h2v2_fancy_upsample_e2k(int max_v_samp_factor,
+                                   JDIMENSION downsampled_width,
+                                   JSAMPARRAY input_data,
+                                   JSAMPARRAY *output_data_ptr)
+{
+  JSAMPARRAY output_data = *output_data_ptr;
+  JSAMPROW inptr_1, inptr0, inptr1, outptr0, outptr1;
+  int inrow, outrow, incol;
+
+  __m128i pb_zero = _mm_setzero_si128();
+  __m128i this_1, this0, this1, out;
+  __m128i this_1l, this_1h, this0l, this0h, this1l, this1h,
+    lastcolsum_1h, lastcolsum1h,
+    p_lastcolsum_1l, p_lastcolsum_1h, p_lastcolsum1l, p_lastcolsum1h,
+    thiscolsum_1l, thiscolsum_1h, thiscolsum1l, thiscolsum1h,
+    nextcolsum_1l = pb_zero, nextcolsum_1h = pb_zero,
+    nextcolsum1l = pb_zero, nextcolsum1h = pb_zero,
+    p_nextcolsum_1l, p_nextcolsum_1h, p_nextcolsum1l, p_nextcolsum1h,
+    tmpl, tmph, outle, outhe, outlo, outho;
+
+  /* Constants */
+  __m128i pw_three = _mm_set1_epi16(3),
+    pw_seven = _mm_set1_epi16(7), pw_eight = _mm_set1_epi16(8),
+    next_index_lastcol = _mm_setr_epi8(
+       2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 14, 15);
+
+  if (downsampled_width > 0)
+  for (inrow = 0, outrow = 0; outrow < max_v_samp_factor; inrow++) {
+
+    inptr_1 = input_data[inrow - 1];
+    inptr0 = input_data[inrow];
+    inptr1 = input_data[inrow + 1];
+    outptr0 = output_data[outrow++];
+    outptr1 = output_data[outrow++];
+
+    if (downsampled_width & 15) {
+      inptr_1[downsampled_width] = inptr_1[downsampled_width - 1];
+      inptr0[downsampled_width] = inptr0[downsampled_width - 1];
+      inptr1[downsampled_width] = inptr1[downsampled_width - 1];
+    }
+
+    this0 = VEC_LD(inptr0);
+    this0l = _mm_unpacklo_epi8(this0, pb_zero);
+    this0h = _mm_unpackhi_epi8(this0, pb_zero);
+    this0l = _mm_mullo_epi16(this0l, pw_three);
+    this0h = _mm_mullo_epi16(this0h, pw_three);
+
+    this_1 = VEC_LD(inptr_1);
+    this_1l = _mm_unpacklo_epi8(this_1, pb_zero);
+    this_1h = _mm_unpackhi_epi8(this_1, pb_zero);
+    thiscolsum_1l = _mm_add_epi16(this0l, this_1l);
+    thiscolsum_1h = _mm_add_epi16(this0h, this_1h);
+    lastcolsum_1h = _mm_bslli_si128(thiscolsum_1l, 14);;
+
+    this1 = VEC_LD(inptr1);
+    this1l = _mm_unpacklo_epi8(this1, pb_zero);
+    this1h = _mm_unpackhi_epi8(this1, pb_zero);
+    thiscolsum1l = _mm_add_epi16(this0l, this1l);
+    thiscolsum1h = _mm_add_epi16(this0h, this1h);
+    lastcolsum1h = _mm_bslli_si128(thiscolsum1l, 14);
+
+    for (incol = downsampled_width; incol > 0;
+         incol -= 16, inptr_1 += 16, inptr0 += 16, inptr1 += 16,
+         outptr0 += 32, outptr1 += 32) {
+
+      p_lastcolsum_1l = _mm_alignr_epi8(thiscolsum_1l, lastcolsum_1h, 14);
+      p_lastcolsum_1h = _mm_alignr_epi8(thiscolsum_1h, thiscolsum_1l, 14);
+      p_lastcolsum1l = _mm_alignr_epi8(thiscolsum1l, lastcolsum1h, 14);
+      p_lastcolsum1h = _mm_alignr_epi8(thiscolsum1h, thiscolsum1l, 14);
+      lastcolsum_1h = thiscolsum_1h;
+      lastcolsum1h = thiscolsum1h;
+
+      if (__builtin_expect(incol <= 16, 0)) {
+        p_nextcolsum_1l = _mm_alignr_epi8(thiscolsum_1h, thiscolsum_1l, 2);
+        p_nextcolsum_1h = _mm_shuffle_epi8(thiscolsum_1h, next_index_lastcol);
+        p_nextcolsum1l = _mm_alignr_epi8(thiscolsum1h, thiscolsum1l, 2);
+        p_nextcolsum1h = _mm_shuffle_epi8(thiscolsum1h, next_index_lastcol);
+      } else {
+        this0 = VEC_LD(inptr0 + 16);
+        this0l = _mm_unpacklo_epi8(this0, pb_zero);
+        this0h = _mm_unpackhi_epi8(this0, pb_zero);
+        this0l = _mm_mullo_epi16(this0l, pw_three);
+        this0h = _mm_mullo_epi16(this0h, pw_three);
+
+        this_1 = VEC_LD(inptr_1 + 16);
+        this_1l = _mm_unpacklo_epi8(this_1, pb_zero);
+        this_1h = _mm_unpackhi_epi8(this_1, pb_zero);
+        nextcolsum_1l = _mm_add_epi16(this0l, this_1l);
+        nextcolsum_1h = _mm_add_epi16(this0h, this_1h);
+        p_nextcolsum_1l = _mm_alignr_epi8(thiscolsum_1h, thiscolsum_1l, 2);
+        p_nextcolsum_1h = _mm_alignr_epi8(nextcolsum_1l, thiscolsum_1h, 2);
+
+        this1 = VEC_LD(inptr1 + 16);
+        this1l = _mm_unpacklo_epi8(this1, pb_zero);
+        this1h = _mm_unpackhi_epi8(this1, pb_zero);
+        nextcolsum1l = _mm_add_epi16(this0l, this1l);
+        nextcolsum1h = _mm_add_epi16(this0h, this1h);
+        p_nextcolsum1l = _mm_alignr_epi8(thiscolsum1h, thiscolsum1l, 2);
+        p_nextcolsum1h = _mm_alignr_epi8(nextcolsum1l, thiscolsum1h, 2);
+      }
+
+      /* Process the upper row */
+
+      tmpl = _mm_mullo_epi16(thiscolsum_1l, pw_three);
+      outle = _mm_add_epi16(tmpl, p_lastcolsum_1l);
+      outle = _mm_add_epi16(outle, pw_eight);
+      outle = _mm_srli_epi16(outle, 4);
+
+      outlo = _mm_add_epi16(tmpl, p_nextcolsum_1l);
+      outlo = _mm_add_epi16(outlo, pw_seven);
+      outlo = _mm_srli_epi16(outlo, 4);
+
+      out = _mm_or_si128(outle, _mm_slli_epi16(outlo, 8));
+      VEC_ST(outptr0, out);
+
+      /* Process the lower row */
+
+      tmpl = _mm_mullo_epi16(thiscolsum1l, pw_three);
+      outle = _mm_add_epi16(tmpl, p_lastcolsum1l);
+      outle = _mm_add_epi16(outle, pw_eight);
+      outle = _mm_srli_epi16(outle, 4);
+
+      outlo = _mm_add_epi16(tmpl, p_nextcolsum1l);
+      outlo = _mm_add_epi16(outlo, pw_seven);
+      outlo = _mm_srli_epi16(outlo, 4);
+
+      out = _mm_or_si128(outle, _mm_slli_epi16(outlo, 8));
+      VEC_ST(outptr1, out);
+
+      if (__builtin_expect(incol <= 8, 0)) break;
+
+      tmph = _mm_mullo_epi16(thiscolsum_1h, pw_three);
+      outhe = _mm_add_epi16(tmph, p_lastcolsum_1h);
+      outhe = _mm_add_epi16(outhe, pw_eight);
+      outhe = _mm_srli_epi16(outhe, 4);
+
+      outho = _mm_add_epi16(tmph, p_nextcolsum_1h);
+      outho = _mm_add_epi16(outho, pw_seven);
+      outho = _mm_srli_epi16(outho, 4);
+
+      out = _mm_or_si128(outhe, _mm_slli_epi16(outho, 8));
+      VEC_ST(outptr0 + 16, out);
+
+      tmph = _mm_mullo_epi16(thiscolsum1h, pw_three);
+      outhe = _mm_add_epi16(tmph, p_lastcolsum1h);
+      outhe = _mm_add_epi16(outhe, pw_eight);
+      outhe = _mm_srli_epi16(outhe, 4);
+
+      outho = _mm_add_epi16(tmph, p_nextcolsum1h);
+      outho = _mm_add_epi16(outho, pw_seven);
+      outho = _mm_srli_epi16(outho, 4);
+
+      out = _mm_or_si128(outhe, _mm_slli_epi16(outho, 8));
+      VEC_ST(outptr1 + 16, out);
+
+      thiscolsum_1l = nextcolsum_1l;  thiscolsum_1h = nextcolsum_1h;
+      thiscolsum1l = nextcolsum1l;  thiscolsum1h = nextcolsum1h;
+    }
+  }
+}
+
+
+/* These are rarely used (mainly just for decompressing YCCK images) */
+
+void jsimd_h2v1_upsample_e2k(int max_v_samp_factor,
+                             JDIMENSION output_width,
+                             JSAMPARRAY input_data,
+                             JSAMPARRAY *output_data_ptr)
+{
+  JSAMPARRAY output_data = *output_data_ptr;
+  JSAMPROW inptr, outptr;
+  int inrow, incol;
+
+  __m128i in, inl, inh;
+
+  if (output_width > 0)
+  for (inrow = 0; inrow < max_v_samp_factor; inrow++) {
+    inptr = input_data[inrow];
+    outptr = output_data[inrow];
+
+    for (incol = output_width; incol > 0;
+         incol -= 32, inptr += 16, outptr += 32) {
+
+      in = VEC_LD(inptr);
+      inl = _mm_unpacklo_epi8(in, in);
+      inh = _mm_unpackhi_epi8(in, in);
+
+      VEC_ST(outptr, inl);
+      VEC_ST(outptr + 16, inh);
+    }
+  }
+}
+
+
+void jsimd_h2v2_upsample_e2k(int max_v_samp_factor,
+                             JDIMENSION output_width,
+                             JSAMPARRAY input_data,
+                             JSAMPARRAY *output_data_ptr)
+{
+  JSAMPARRAY output_data = *output_data_ptr;
+  JSAMPROW inptr, outptr0, outptr1;
+  int inrow, outrow, incol;
+
+  __m128i in, inl, inh;
+
+  if (output_width > 0)
+  for (inrow = 0, outrow = 0; outrow < max_v_samp_factor; inrow++) {
+
+    inptr = input_data[inrow];
+    outptr0 = output_data[outrow++];
+    outptr1 = output_data[outrow++];
+
+    for (incol = output_width; incol > 0;
+         incol -= 32, inptr += 16, outptr0 += 32, outptr1 += 32) {
+
+      in = VEC_LD(inptr);
+      inl = _mm_unpacklo_epi8(in, in);
+      inh = _mm_unpackhi_epi8(in, in);
+
+      VEC_ST(outptr0, inl);
+      VEC_ST(outptr1, inl);
+      VEC_ST(outptr0 + 16, inh);
+      VEC_ST(outptr1 + 16, inh);
+    }
+  }
+}

--- a/simd/e2k/jfdctflt-e2k.c
+++ b/simd/e2k/jfdctflt-e2k.c
@@ -1,0 +1,127 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2014, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* FLOAT FORWARD DCT */
+
+#include "jsimd_e2k.h"
+
+#define DO_FDCT(in, out) { \
+  tmp0 = _mm_add_ps(in##0, in##7); \
+  tmp7 = _mm_sub_ps(in##0, in##7); \
+  tmp1 = _mm_add_ps(in##1, in##6); \
+  tmp6 = _mm_sub_ps(in##1, in##6); \
+  tmp2 = _mm_add_ps(in##2, in##5); \
+  tmp5 = _mm_sub_ps(in##2, in##5); \
+  tmp3 = _mm_add_ps(in##3, in##4); \
+  tmp4 = _mm_sub_ps(in##3, in##4); \
+  \
+  /* Even part */ \
+  \
+  tmp10 = _mm_add_ps(tmp0, tmp3); \
+  tmp13 = _mm_sub_ps(tmp0, tmp3); \
+  tmp11 = _mm_add_ps(tmp1, tmp2); \
+  tmp12 = _mm_sub_ps(tmp1, tmp2); \
+  \
+  out##0 = _mm_add_ps(tmp10, tmp11); \
+  out##4 = _mm_sub_ps(tmp10, tmp11); \
+  \
+  z1 = _mm_mul_ps(_mm_add_ps(tmp12, tmp13), pd_f0707); \
+  out##2 = _mm_add_ps(tmp13, z1); \
+  out##6 = _mm_sub_ps(tmp13, z1); \
+  \
+  /* Odd part */ \
+  \
+  tmp10 = _mm_add_ps(tmp4, tmp5); \
+  tmp11 = _mm_add_ps(tmp5, tmp6); \
+  tmp12 = _mm_add_ps(tmp6, tmp7); \
+  \
+  z5 = _mm_mul_ps(_mm_sub_ps(tmp10, tmp12), pd_f0382); \
+  z2 = _mm_add_ps(_mm_mul_ps(tmp10, pd_f0541), z5); \
+  z4 = _mm_add_ps(_mm_mul_ps(tmp12, pd_f1306), z5); \
+  z3 = _mm_mul_ps(tmp11, pd_f0707); \
+  \
+  z11 = _mm_add_ps(tmp7, z3); \
+  z13 = _mm_sub_ps(tmp7, z3); \
+  \
+  out##5 = _mm_add_ps(z13, z2); \
+  out##3 = _mm_sub_ps(z13, z2); \
+  out##1 = _mm_add_ps(z11, z4); \
+  out##7 = _mm_sub_ps(z11, z4); \
+}
+
+#define LOAD_DATA(a, b, c, d, l, i) \
+  l##a = _mm_loadu_ps(data + a * 8 + i); \
+  l##b = _mm_loadu_ps(data + b * 8 + i); \
+  l##c = _mm_loadu_ps(data + c * 8 + i); \
+  l##d = _mm_loadu_ps(data + d * 8 + i);
+
+#define STORE_DATA(a, b, c, d, l, i) \
+  _mm_storeu_ps(data + a * 8 + i, l##a); \
+  _mm_storeu_ps(data + b * 8 + i, l##b); \
+  _mm_storeu_ps(data + c * 8 + i, l##c); \
+  _mm_storeu_ps(data + d * 8 + i, l##d);
+
+
+void jsimd_fdct_float_e2k(FAST_FLOAT *data)
+{
+  __m128 tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7,
+    tmp10, tmp11, tmp12, tmp13, z1, z2, z3, z4, z5, z11, z13;
+  __m128 l0, l1, l2, l3, l4, l5, l6, l7;
+  __m128 h0, h1, h2, h3, h4, h5, h6, h7;
+  __m128 x0, x1, x2, x3, x4, x5, x6, x7;
+  __m128 y0, y1, y2, y3, y4, y5, y6, y7;
+
+  /* Constants */
+  __m128 pd_f0382 = _mm_set1_ps(0.382683433f),
+    pd_f0541 = _mm_set1_ps(0.541196100f),
+    pd_f0707 = _mm_set1_ps(0.707106781f),
+    pd_f1306 = _mm_set1_ps(1.306562965f);
+
+  /* Pass 1: process columns */
+
+  LOAD_DATA(0, 1, 2, 3, x, 0)
+  LOAD_DATA(0, 1, 2, 3, y, 4)
+  TRANSPOSE_FLOAT(x0, x1, x2, x3, l0, l1, l2, l3)
+  TRANSPOSE_FLOAT(y0, y1, y2, y3, l4, l5, l6, l7)
+  DO_FDCT(l, l);
+
+  LOAD_DATA(4, 5, 6, 7, x, 0)
+  LOAD_DATA(4, 5, 6, 7, y, 4)
+  TRANSPOSE_FLOAT(x4, x5, x6, x7, h0, h1, h2, h3)
+  TRANSPOSE_FLOAT(y4, y5, y6, y7, h4, h5, h6, h7)
+  DO_FDCT(h, h);
+
+  /* Pass 2: process rows */
+
+  TRANSPOSE_FLOAT(l0, l1, l2, l3, x0, x1, x2, x3)
+  TRANSPOSE_FLOAT(h0, h1, h2, h3, x4, x5, x6, x7)
+  DO_FDCT(x, x);
+  STORE_DATA(0, 1, 2, 3, x, 0)
+  STORE_DATA(4, 5, 6, 7, x, 0)
+
+  TRANSPOSE_FLOAT(l4, l5, l6, l7, y0, y1, y2, y3)
+  TRANSPOSE_FLOAT(h4, h5, h6, h7, y4, y5, y6, y7)
+  DO_FDCT(y, y);
+  STORE_DATA(0, 1, 2, 3, y, 4)
+  STORE_DATA(4, 5, 6, 7, y, 4)
+}

--- a/simd/e2k/jfdctfst-e2k.c
+++ b/simd/e2k/jfdctfst-e2k.c
@@ -1,0 +1,145 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2014, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* FAST INTEGER FORWARD DCT */
+
+#include "jsimd_e2k.h"
+
+
+#define F_0_382  98   /* FIX(0.382683433) */
+#define F_0_541  139  /* FIX(0.541196100) */
+#define F_0_707  181  /* FIX(0.707106781) */
+#define F_1_306  334  /* FIX(1.306562965) */
+
+#define CONST_BITS  8
+#define PRE_MULTIPLY_SCALE_BITS  2
+#define CONST_SHIFT  (16 - PRE_MULTIPLY_SCALE_BITS - CONST_BITS)
+
+
+#define DO_FDCT() { \
+  /* Even part */ \
+  \
+  tmp10 = _mm_add_epi16(tmp0, tmp3); \
+  tmp13 = _mm_sub_epi16(tmp0, tmp3); \
+  tmp11 = _mm_add_epi16(tmp1, tmp2); \
+  tmp12 = _mm_sub_epi16(tmp1, tmp2); \
+  \
+  out0  = _mm_add_epi16(tmp10, tmp11); \
+  out4  = _mm_sub_epi16(tmp10, tmp11); \
+  \
+  z1 = _mm_add_epi16(tmp12, tmp13); \
+  z1 = _mm_slli_epi16(z1, PRE_MULTIPLY_SCALE_BITS); \
+  z1 = _mm_mulhi_epi16(z1, pw_0707); \
+  \
+  out2 = _mm_add_epi16(tmp13, z1); \
+  out6 = _mm_sub_epi16(tmp13, z1); \
+  \
+  /* Odd part */ \
+  \
+  tmp10 = _mm_add_epi16(tmp4, tmp5); \
+  tmp11 = _mm_add_epi16(tmp5, tmp6); \
+  tmp12 = _mm_add_epi16(tmp6, tmp7); \
+  \
+  tmp10 = _mm_slli_epi16(tmp10, PRE_MULTIPLY_SCALE_BITS); \
+  tmp12 = _mm_slli_epi16(tmp12, PRE_MULTIPLY_SCALE_BITS); \
+  z5 = _mm_sub_epi16(tmp10, tmp12); \
+  z5 = _mm_mulhi_epi16(z5, pw_0382); \
+  \
+  z2 = _mm_add_epi16(_mm_mulhi_epi16(tmp10, pw_0541), z5); \
+  z4 = _mm_add_epi16(_mm_mulhi_epi16(tmp12, pw_1306), z5); \
+  \
+  tmp11 = _mm_slli_epi16(tmp11, PRE_MULTIPLY_SCALE_BITS); \
+  z3 = _mm_mulhi_epi16(tmp11, pw_0707); \
+  \
+  z11 = _mm_add_epi16(tmp7, z3); \
+  z13 = _mm_sub_epi16(tmp7, z3); \
+  \
+  out5 = _mm_add_epi16(z13, z2); \
+  out3 = _mm_sub_epi16(z13, z2); \
+  out1 = _mm_add_epi16(z11, z4); \
+  out7 = _mm_sub_epi16(z11, z4); \
+}
+
+
+void jsimd_fdct_ifast_e2k(DCTELEM *data)
+{
+  __m128i row0, row1, row2, row3, row4, row5, row6, row7,
+    col0, col1, col2, col3, col4, col5, col6, col7,
+    tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp10, tmp11, tmp12, tmp13,
+    z1, z2, z3, z4, z5, z11, z13,
+    out0, out1, out2, out3, out4, out5, out6, out7;
+
+  /* Constants */
+  __m128i pw_0382 = _mm_set1_epi16(F_0_382 << CONST_SHIFT),
+    pw_0541 = _mm_set1_epi16(F_0_541 << CONST_SHIFT),
+    pw_0707 = _mm_set1_epi16(F_0_707 << CONST_SHIFT),
+    pw_1306 = _mm_set1_epi16(F_1_306 << CONST_SHIFT);
+
+  /* Pass 1: process rows */
+
+  row0 = VEC_LD(data + 0 * 8);
+  row1 = VEC_LD(data + 1 * 8);
+  row2 = VEC_LD(data + 2 * 8);
+  row3 = VEC_LD(data + 3 * 8);
+  row4 = VEC_LD(data + 4 * 8);
+  row5 = VEC_LD(data + 5 * 8);
+  row6 = VEC_LD(data + 6 * 8);
+  row7 = VEC_LD(data + 7 * 8);
+
+  TRANSPOSE(row, col);
+
+  tmp0 = _mm_add_epi16(col0, col7);
+  tmp7 = _mm_sub_epi16(col0, col7);
+  tmp1 = _mm_add_epi16(col1, col6);
+  tmp6 = _mm_sub_epi16(col1, col6);
+  tmp2 = _mm_add_epi16(col2, col5);
+  tmp5 = _mm_sub_epi16(col2, col5);
+  tmp3 = _mm_add_epi16(col3, col4);
+  tmp4 = _mm_sub_epi16(col3, col4);
+
+  DO_FDCT();
+
+  /* Pass 2: process columns */
+
+  TRANSPOSE(out, row);
+
+  tmp0 = _mm_add_epi16(row0, row7);
+  tmp7 = _mm_sub_epi16(row0, row7);
+  tmp1 = _mm_add_epi16(row1, row6);
+  tmp6 = _mm_sub_epi16(row1, row6);
+  tmp2 = _mm_add_epi16(row2, row5);
+  tmp5 = _mm_sub_epi16(row2, row5);
+  tmp3 = _mm_add_epi16(row3, row4);
+  tmp4 = _mm_sub_epi16(row3, row4);
+
+  DO_FDCT();
+
+  VEC_ST(data + 0 * 8, out0);
+  VEC_ST(data + 1 * 8, out1);
+  VEC_ST(data + 2 * 8, out2);
+  VEC_ST(data + 3 * 8, out3);
+  VEC_ST(data + 4 * 8, out4);
+  VEC_ST(data + 5 * 8, out5);
+  VEC_ST(data + 6 * 8, out6);
+  VEC_ST(data + 7 * 8, out7);
+}

--- a/simd/e2k/jfdctint-e2k.c
+++ b/simd/e2k/jfdctint-e2k.c
@@ -1,0 +1,255 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2014, 2020, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* ACCURATE INTEGER FORWARD DCT */
+
+#include "jsimd_e2k.h"
+
+
+#define F_0_298  2446   /* FIX(0.298631336) */
+#define F_0_390  3196   /* FIX(0.390180644) */
+#define F_0_541  4433   /* FIX(0.541196100) */
+#define F_0_765  6270   /* FIX(0.765366865) */
+#define F_0_899  7373   /* FIX(0.899976223) */
+#define F_1_175  9633   /* FIX(1.175875602) */
+#define F_1_501  12299  /* FIX(1.501321110) */
+#define F_1_847  15137  /* FIX(1.847759065) */
+#define F_1_961  16069  /* FIX(1.961570560) */
+#define F_2_053  16819  /* FIX(2.053119869) */
+#define F_2_562  20995  /* FIX(2.562915447) */
+#define F_3_072  25172  /* FIX(3.072711026) */
+
+#define CONST_BITS  13
+#define PASS1_BITS  2
+#define DESCALE_P1  (CONST_BITS - PASS1_BITS)
+#define DESCALE_P2  (CONST_BITS + PASS1_BITS)
+
+
+#define DO_FDCT_COMMON(PASS) { \
+  /* (Original) \
+   * z1 = (tmp12 + tmp13) * 0.541196100; \
+   * data2 = z1 + tmp13 * 0.765366865; \
+   * data6 = z1 + tmp12 * -1.847759065; \
+   * \
+   * (This implementation) \
+   * data2 = tmp13 * (0.541196100 + 0.765366865) + tmp12 * 0.541196100; \
+   * data6 = tmp13 * 0.541196100 + tmp12 * (0.541196100 - 1.847759065); \
+   */ \
+  \
+  tmp1312l = _mm_unpacklo_epi16(tmp13, tmp12); \
+  tmp1312h = _mm_unpackhi_epi16(tmp13, tmp12); \
+  \
+  out2l = _mm_add_epi32(_mm_madd_epi16(tmp1312l, pw_f130_f054), pd_descale_p##PASS); \
+  out2h = _mm_add_epi32(_mm_madd_epi16(tmp1312h, pw_f130_f054), pd_descale_p##PASS); \
+  out6l = _mm_add_epi32(_mm_madd_epi16(tmp1312l, pw_f054_mf130), pd_descale_p##PASS); \
+  out6h = _mm_add_epi32(_mm_madd_epi16(tmp1312h, pw_f054_mf130), pd_descale_p##PASS); \
+  \
+  out2l = _mm_srai_epi32(out2l, DESCALE_P##PASS); \
+  out2h = _mm_srai_epi32(out2h, DESCALE_P##PASS); \
+  out6l = _mm_srai_epi32(out6l, DESCALE_P##PASS); \
+  out6h = _mm_srai_epi32(out6h, DESCALE_P##PASS); \
+  \
+  out2 = _mm_packs_epi32(out2l, out2h); \
+  out6 = _mm_packs_epi32(out6l, out6h); \
+  \
+  /* Odd part */ \
+  \
+  z3 = _mm_add_epi16(tmp4, tmp6); \
+  z4 = _mm_add_epi16(tmp5, tmp7); \
+  \
+  /* (Original) \
+   * z5 = (z3 + z4) * 1.175875602; \
+   * z3 = z3 * -1.961570560;  z4 = z4 * -0.390180644; \
+   * z3 += z5;  z4 += z5; \
+   * \
+   * (This implementation) \
+   * z3 = z3 * (1.175875602 - 1.961570560) + z4 * 1.175875602; \
+   * z4 = z3 * 1.175875602 + z4 * (1.175875602 - 0.390180644); \
+   */ \
+  \
+  z34l = _mm_unpacklo_epi16(z3, z4); \
+  z34h = _mm_unpackhi_epi16(z3, z4); \
+  \
+  z3l = _mm_add_epi32(_mm_madd_epi16(z34l, pw_mf078_f117), pd_descale_p##PASS); \
+  z3h = _mm_add_epi32(_mm_madd_epi16(z34h, pw_mf078_f117), pd_descale_p##PASS); \
+  z4l = _mm_add_epi32(_mm_madd_epi16(z34l, pw_f117_f078), pd_descale_p##PASS); \
+  z4h = _mm_add_epi32(_mm_madd_epi16(z34h, pw_f117_f078), pd_descale_p##PASS); \
+  \
+  /* (Original) \
+   * z1 = tmp4 + tmp7;  z2 = tmp5 + tmp6; \
+   * tmp4 = tmp4 * 0.298631336;  tmp5 = tmp5 * 2.053119869; \
+   * tmp6 = tmp6 * 3.072711026;  tmp7 = tmp7 * 1.501321110; \
+   * z1 = z1 * -0.899976223;  z2 = z2 * -2.562915447; \
+   * data7 = tmp4 + z1 + z3;  data5 = tmp5 + z2 + z4; \
+   * data3 = tmp6 + z2 + z3;  data1 = tmp7 + z1 + z4; \
+   * \
+   * (This implementation) \
+   * tmp4 = tmp4 * (0.298631336 - 0.899976223) + tmp7 * -0.899976223; \
+   * tmp5 = tmp5 * (2.053119869 - 2.562915447) + tmp6 * -2.562915447; \
+   * tmp6 = tmp5 * -2.562915447 + tmp6 * (3.072711026 - 2.562915447); \
+   * tmp7 = tmp4 * -0.899976223 + tmp7 * (1.501321110 - 0.899976223); \
+   * data7 = tmp4 + z3;  data5 = tmp5 + z4; \
+   * data3 = tmp6 + z3;  data1 = tmp7 + z4; \
+   */ \
+  \
+  tmp47l = _mm_unpacklo_epi16(tmp4, tmp7); \
+  tmp47h = _mm_unpackhi_epi16(tmp4, tmp7); \
+  \
+  out7l = _mm_add_epi32(_mm_madd_epi16(tmp47l, pw_mf060_mf089), z3l); \
+  out7h = _mm_add_epi32(_mm_madd_epi16(tmp47h, pw_mf060_mf089), z3h); \
+  out1l = _mm_add_epi32(_mm_madd_epi16(tmp47l, pw_mf089_f060), z4l); \
+  out1h = _mm_add_epi32(_mm_madd_epi16(tmp47h, pw_mf089_f060), z4h); \
+  \
+  out7l = _mm_srai_epi32(out7l, DESCALE_P##PASS); \
+  out7h = _mm_srai_epi32(out7h, DESCALE_P##PASS); \
+  out1l = _mm_srai_epi32(out1l, DESCALE_P##PASS); \
+  out1h = _mm_srai_epi32(out1h, DESCALE_P##PASS); \
+  \
+  out7 = _mm_packs_epi32(out7l, out7h); \
+  out1 = _mm_packs_epi32(out1l, out1h); \
+  \
+  tmp56l = _mm_unpacklo_epi16(tmp5, tmp6); \
+  tmp56h = _mm_unpackhi_epi16(tmp5, tmp6); \
+  \
+  out5l = _mm_add_epi32(_mm_madd_epi16(tmp56l, pw_mf050_mf256), z4l); \
+  out5h = _mm_add_epi32(_mm_madd_epi16(tmp56h, pw_mf050_mf256), z4h); \
+  out3l = _mm_add_epi32(_mm_madd_epi16(tmp56l, pw_mf256_f050), z3l); \
+  out3h = _mm_add_epi32(_mm_madd_epi16(tmp56h, pw_mf256_f050), z3h); \
+  \
+  out5l = _mm_srai_epi32(out5l, DESCALE_P##PASS); \
+  out5h = _mm_srai_epi32(out5h, DESCALE_P##PASS); \
+  out3l = _mm_srai_epi32(out3l, DESCALE_P##PASS); \
+  out3h = _mm_srai_epi32(out3h, DESCALE_P##PASS); \
+  \
+  out5 = _mm_packs_epi32(out5l, out5h); \
+  out3 = _mm_packs_epi32(out3l, out3h); \
+}
+
+#define DO_FDCT_PASS1() { \
+  /* Even part */ \
+  \
+  tmp10 = _mm_add_epi16(tmp0, tmp3); \
+  tmp13 = _mm_sub_epi16(tmp0, tmp3); \
+  tmp11 = _mm_add_epi16(tmp1, tmp2); \
+  tmp12 = _mm_sub_epi16(tmp1, tmp2); \
+  \
+  out0  = _mm_add_epi16(tmp10, tmp11); \
+  out0  = _mm_slli_epi16(out0, PASS1_BITS); \
+  out4  = _mm_sub_epi16(tmp10, tmp11); \
+  out4  = _mm_slli_epi16(out4, PASS1_BITS); \
+  \
+  DO_FDCT_COMMON(1); \
+}
+
+#define DO_FDCT_PASS2() { \
+  /* Even part */ \
+  \
+  tmp10 = _mm_add_epi16(tmp0, tmp3); \
+  tmp13 = _mm_sub_epi16(tmp0, tmp3); \
+  tmp11 = _mm_add_epi16(tmp1, tmp2); \
+  tmp12 = _mm_sub_epi16(tmp1, tmp2); \
+  \
+  out0  = _mm_add_epi16(tmp10, tmp11); \
+  out0  = _mm_add_epi16(out0, pw_descale_p2x); \
+  out0  = _mm_srai_epi16(out0, PASS1_BITS); \
+  out4  = _mm_sub_epi16(tmp10, tmp11); \
+  out4  = _mm_add_epi16(out4, pw_descale_p2x); \
+  out4  = _mm_srai_epi16(out4, PASS1_BITS); \
+  \
+  DO_FDCT_COMMON(2); \
+}
+
+
+void jsimd_fdct_islow_e2k(DCTELEM *data)
+{
+  __m128i row0, row1, row2, row3, row4, row5, row6, row7,
+    col0, col1, col2, col3, col4, col5, col6, col7,
+    tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp10, tmp11, tmp12, tmp13,
+    tmp47l, tmp47h, tmp56l, tmp56h, tmp1312l, tmp1312h,
+    z3, z4, z34l, z34h,
+    out0, out1, out2, out3, out4, out5, out6, out7;
+  __m128i z3l, z3h, z4l, z4h,
+    out1l, out1h, out2l, out2h, out3l, out3h, out5l, out5h, out6l, out6h,
+    out7l, out7h;
+
+  /* Constants */
+  __m128i pw_f130_f054 = _mm_setr_epi16(__4X2(F_0_541 + F_0_765, F_0_541)),
+    pw_f054_mf130 = _mm_setr_epi16(__4X2(F_0_541, F_0_541 - F_1_847)),
+    pw_mf078_f117 = _mm_setr_epi16(__4X2(F_1_175 - F_1_961, F_1_175)),
+    pw_f117_f078 = _mm_setr_epi16(__4X2(F_1_175, F_1_175 - F_0_390)),
+    pw_mf060_mf089 = _mm_setr_epi16(__4X2(F_0_298 - F_0_899, -F_0_899)),
+    pw_mf089_f060 = _mm_setr_epi16(__4X2(-F_0_899, F_1_501 - F_0_899)),
+    pw_mf050_mf256 = _mm_setr_epi16(__4X2(F_2_053 - F_2_562, -F_2_562)),
+    pw_mf256_f050 = _mm_setr_epi16(__4X2(-F_2_562, F_3_072 - F_2_562)),
+    pw_descale_p2x = _mm_set1_epi16(1 << (PASS1_BITS - 1)),
+    pd_descale_p1 = _mm_set1_epi32(1 << (DESCALE_P1 - 1)),
+    pd_descale_p2 = _mm_set1_epi32(1 << (DESCALE_P2 - 1));
+
+  /* Pass 1: process rows */
+
+  row0 = VEC_LD(data + 0 * 8);
+  row1 = VEC_LD(data + 1 * 8);
+  row2 = VEC_LD(data + 2 * 8);
+  row3 = VEC_LD(data + 3 * 8);
+  row4 = VEC_LD(data + 4 * 8);
+  row5 = VEC_LD(data + 5 * 8);
+  row6 = VEC_LD(data + 6 * 8);
+  row7 = VEC_LD(data + 7 * 8);
+
+  TRANSPOSE(row, col);
+
+  tmp0 = _mm_add_epi16(col0, col7);
+  tmp7 = _mm_sub_epi16(col0, col7);
+  tmp1 = _mm_add_epi16(col1, col6);
+  tmp6 = _mm_sub_epi16(col1, col6);
+  tmp2 = _mm_add_epi16(col2, col5);
+  tmp5 = _mm_sub_epi16(col2, col5);
+  tmp3 = _mm_add_epi16(col3, col4);
+  tmp4 = _mm_sub_epi16(col3, col4);
+
+  DO_FDCT_PASS1();
+
+  /* Pass 2: process columns */
+
+  TRANSPOSE(out, row);
+
+  tmp0 = _mm_add_epi16(row0, row7);
+  tmp7 = _mm_sub_epi16(row0, row7);
+  tmp1 = _mm_add_epi16(row1, row6);
+  tmp6 = _mm_sub_epi16(row1, row6);
+  tmp2 = _mm_add_epi16(row2, row5);
+  tmp5 = _mm_sub_epi16(row2, row5);
+  tmp3 = _mm_add_epi16(row3, row4);
+  tmp4 = _mm_sub_epi16(row3, row4);
+
+  DO_FDCT_PASS2();
+
+  VEC_ST(data + 0 * 8, out0);
+  VEC_ST(data + 1 * 8, out1);
+  VEC_ST(data + 2 * 8, out2);
+  VEC_ST(data + 3 * 8, out3);
+  VEC_ST(data + 4 * 8, out4);
+  VEC_ST(data + 5 * 8, out5);
+  VEC_ST(data + 6 * 8, out6);
+  VEC_ST(data + 7 * 8, out7);
+}

--- a/simd/e2k/jidctflt-e2k.c
+++ b/simd/e2k/jidctflt-e2k.c
@@ -1,0 +1,215 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2014-2015, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* FLOAT INVERSE DCT */
+
+#include "jsimd_e2k.h"
+
+#define DO_IDCT(in, out) { \
+  /* Even part */ \
+  \
+  tmp10 = _mm_add_ps(in##0, in##4); \
+  tmp11 = _mm_sub_ps(in##0, in##4); \
+  \
+  tmp13 = _mm_add_ps(in##2, in##6); \
+  tmp12 = _mm_sub_ps(in##2, in##6); \
+  tmp12 = _mm_sub_ps(_mm_mul_ps(tmp12, pd_f1414), tmp13); \
+  \
+  tmp0 = _mm_add_ps(tmp10, tmp13); \
+  tmp3 = _mm_sub_ps(tmp10, tmp13); \
+  tmp1 = _mm_add_ps(tmp11, tmp12); \
+  tmp2 = _mm_sub_ps(tmp11, tmp12); \
+  \
+  /* Odd part */ \
+  \
+  z13 = _mm_add_ps(in##5, in##3); \
+  z10 = _mm_sub_ps(in##5, in##3); \
+  z11 = _mm_add_ps(in##1, in##7); \
+  z12 = _mm_sub_ps(in##1, in##7); \
+  \
+  tmp7 = _mm_add_ps(z11, z13); \
+  tmp11 = _mm_sub_ps(z11, z13); \
+  tmp11 = _mm_mul_ps(tmp11, pd_f1414); \
+  \
+  z5 = _mm_mul_ps(_mm_add_ps(z10, z12), pd_f1847); \
+  tmp10 = _mm_sub_ps(z5, _mm_mul_ps(z12, pd_f1082)); \
+  tmp12 = _mm_sub_ps(z5, _mm_mul_ps(z10, pd_f2613)); \
+  \
+  tmp6 = _mm_sub_ps(tmp12, tmp7); \
+  tmp5 = _mm_sub_ps(tmp11, tmp6); \
+  tmp4 = _mm_sub_ps(tmp10, tmp5); \
+  \
+  out##0 = _mm_add_ps(tmp0, tmp7); \
+  out##7 = _mm_sub_ps(tmp0, tmp7); \
+  out##1 = _mm_add_ps(tmp1, tmp6); \
+  out##6 = _mm_sub_ps(tmp1, tmp6); \
+  out##2 = _mm_add_ps(tmp2, tmp5); \
+  out##5 = _mm_sub_ps(tmp2, tmp5); \
+  out##3 = _mm_add_ps(tmp3, tmp4); \
+  out##4 = _mm_sub_ps(tmp3, tmp4); \
+}
+
+#define QUANT_MUL(a, b, c, d, l, lo, i) \
+  out0 = _mm_srai_epi32(_mm_unpack##lo##_epi16(col##a, col##a), 16); \
+  out1 = _mm_srai_epi32(_mm_unpack##lo##_epi16(col##b, col##b), 16); \
+  out2 = _mm_srai_epi32(_mm_unpack##lo##_epi16(col##c, col##c), 16); \
+  out3 = _mm_srai_epi32(_mm_unpack##lo##_epi16(col##d, col##d), 16); \
+  l##a = _mm_cvtepi32_ps(out0); \
+  l##b = _mm_cvtepi32_ps(out1); \
+  l##c = _mm_cvtepi32_ps(out2); \
+  l##d = _mm_cvtepi32_ps(out3); \
+  l##a = _mm_mul_ps(l##a, _mm_load_ps(dct_table + a * 8 + i)); \
+  l##b = _mm_mul_ps(l##b, _mm_load_ps(dct_table + b * 8 + i)); \
+  l##c = _mm_mul_ps(l##c, _mm_load_ps(dct_table + c * 8 + i)); \
+  l##d = _mm_mul_ps(l##d, _mm_load_ps(dct_table + d * 8 + i));
+
+
+void jsimd_idct_float_e2k(void *dct_table_, JCOEFPTR coef_block,
+                          JSAMPARRAY output_buf, JDIMENSION output_col)
+{
+  float *dct_table = (float *)dct_table_;
+
+  __m128i col0, col1, col2, col3, col4, col5, col6, col7,
+    out0, out1, out2, out3, out4, out5, out6, out7, row0, row1, row2, row3;
+  __m128 tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7,
+    tmp10, tmp11, tmp12, tmp13, z5, z10, z11, z12, z13;
+  __m128 l0, l1, l2, l3, l4, l5, l6, l7;
+  __m128 h0, h1, h2, h3, h4, h5, h6, h7;
+  __m128 x0, x1, x2, x3, x4, x5, x6, x7;
+  __m128 y0, y1, y2, y3, y4, y5, y6, y7;
+
+  /* Constants */
+  __m128 pd_f1414 = _mm_set1_ps(1.414213562f),
+    pd_f1847 = _mm_set1_ps(1.847759065f),
+    pd_f1082 = _mm_set1_ps(1.082392200f),
+    pd_f2613 = _mm_set1_ps(2.613125930f);
+
+  /* Pass 1: process columns */
+
+  col0 = VEC_LD(coef_block + 0 * 8);
+  col1 = VEC_LD(coef_block + 1 * 8);
+  col2 = VEC_LD(coef_block + 2 * 8);
+  col3 = VEC_LD(coef_block + 3 * 8);
+  col4 = VEC_LD(coef_block + 4 * 8);
+  col5 = VEC_LD(coef_block + 5 * 8);
+  col6 = VEC_LD(coef_block + 6 * 8);
+  col7 = VEC_LD(coef_block + 7 * 8);
+
+  out1 = _mm_or_si128(col1, col2);
+  out2 = _mm_or_si128(col3, col4);
+  out1 = _mm_or_si128(out1, out2);
+  out3 = _mm_or_si128(col5, col6);
+  out3 = _mm_or_si128(out3, col7);
+  out1 = _mm_or_si128(out1, out3);
+
+  if (VEC_ISZERO(out1)) {
+    /* AC terms all zero */
+
+    out0 = _mm_srai_epi32(_mm_unpacklo_epi16(col0, col0), 16);
+    out1 = _mm_srai_epi32(_mm_unpackhi_epi16(col0, col0), 16);
+    tmp0 = _mm_cvtepi32_ps(out0);
+    tmp1 = _mm_cvtepi32_ps(out1);
+    tmp0 = _mm_mul_ps(tmp0, _mm_load_ps(dct_table));
+    tmp1 = _mm_mul_ps(tmp1, _mm_load_ps(dct_table + 4));
+
+    l0 = h0 = _mm_shuffle_ps(tmp0, tmp0, 0x00);
+    l1 = h1 = _mm_shuffle_ps(tmp0, tmp0, 0x55);
+    l2 = h2 = _mm_shuffle_ps(tmp0, tmp0, 0xaa);
+    l3 = h3 = _mm_shuffle_ps(tmp0, tmp0, 0xff);
+    l4 = h4 = _mm_shuffle_ps(tmp1, tmp1, 0x00);
+    l5 = h5 = _mm_shuffle_ps(tmp1, tmp1, 0x55);
+    l6 = h6 = _mm_shuffle_ps(tmp1, tmp1, 0xaa);
+    l7 = h7 = _mm_shuffle_ps(tmp1, tmp1, 0xff);
+
+  } else {
+
+    QUANT_MUL(0, 2, 4, 6, l, lo, 0)
+    QUANT_MUL(1, 3, 5, 7, l, lo, 0)
+    DO_IDCT(l, x);
+
+    QUANT_MUL(0, 2, 4, 6, h, hi, 4)
+    QUANT_MUL(1, 3, 5, 7, h, hi, 4)
+    DO_IDCT(h, y);
+
+    TRANSPOSE_FLOAT(x0, x1, x2, x3, l0, l1, l2, l3)
+    TRANSPOSE_FLOAT(x4, x5, x6, x7, h0, h1, h2, h3)
+    TRANSPOSE_FLOAT(y0, y1, y2, y3, l4, l5, l6, l7)
+    TRANSPOSE_FLOAT(y4, y5, y6, y7, h4, h5, h6, h7)
+  }
+
+  /* Pass 2: process rows */
+
+  DO_IDCT(l, x);
+  DO_IDCT(h, y);
+
+#ifdef JSIMD_SAME_ROUNDING
+#define OUT_ROUND(i) \
+  tmp0 = _mm_add_ps(_mm_mul_ps(x##i, pd_f0125), pd_cj_rnd); \
+  tmp1 = _mm_add_ps(_mm_mul_ps(y##i, pd_f0125), pd_cj_rnd); \
+  out##i = _mm_packs_epi32(_mm_cvttps_epi32(tmp0), _mm_cvttps_epi32(tmp1));
+
+  {
+    __m128 pd_cj_rnd = _mm_set1_ps(0.5f + CENTERJSAMPLE),
+      pd_f0125 = _mm_set1_ps(0.125f);
+
+    OUT_ROUND(0) OUT_ROUND(1)
+    OUT_ROUND(2) OUT_ROUND(3)
+    OUT_ROUND(4) OUT_ROUND(5)
+    OUT_ROUND(6) OUT_ROUND(7)
+  }
+  row0 = _mm_packus_epi16(out0, out1);
+  row1 = _mm_packus_epi16(out2, out3);
+  row2 = _mm_packus_epi16(out4, out5);
+  row3 = _mm_packus_epi16(out6, out7);
+
+  TRANSPOSE8(row, col) TRANSPOSE8(col, row) TRANSPOSE8(row, col)
+#else  /* faster, slightly differ in rounding */
+#define OUT_ROUND(i, a, b) out##i = _mm_blendv_epi8( \
+  _mm_slli_epi32(_mm_castps_si128(_mm_add_ps(b, pd_round)), 16), \
+  _mm_castps_si128(_mm_add_ps(a, pd_round)), pd_mask);
+
+  {
+    __m128i pd_mask = _mm_set1_epi32(0xffff);
+    __m128 pd_round = _mm_set1_ps((3 << 22 | CENTERJSAMPLE) * 8);
+
+    OUT_ROUND(0, x0, x4) OUT_ROUND(1, y0, y4)
+    OUT_ROUND(2, x1, x5) OUT_ROUND(3, y1, y5)
+    OUT_ROUND(4, x2, x6) OUT_ROUND(5, y2, y6)
+    OUT_ROUND(6, x3, x7) OUT_ROUND(7, y3, y7)
+  }
+  row0 = _mm_packus_epi16(out0, out1);
+  row1 = _mm_packus_epi16(out2, out3);
+  row2 = _mm_packus_epi16(out4, out5);
+  row3 = _mm_packus_epi16(out6, out7);
+
+  TRANSPOSE8(row, out) TRANSPOSE8(out, col)
+#endif
+  VEC_STL(output_buf[0] + output_col, col0);
+  VEC_STH(output_buf[1] + output_col, col0);
+  VEC_STL(output_buf[2] + output_col, col1);
+  VEC_STH(output_buf[3] + output_col, col1);
+  VEC_STL(output_buf[4] + output_col, col2);
+  VEC_STH(output_buf[5] + output_col, col2);
+  VEC_STL(output_buf[6] + output_col, col3);
+  VEC_STH(output_buf[7] + output_col, col3);
+}

--- a/simd/e2k/jidctfst-e2k.c
+++ b/simd/e2k/jidctfst-e2k.c
@@ -1,0 +1,194 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2014-2015, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* FAST INTEGER INVERSE DCT */
+
+#include "jsimd_e2k.h"
+
+
+#define F_1_082  277              /* FIX(1.082392200) */
+#define F_1_414  362              /* FIX(1.414213562) */
+#define F_1_847  473              /* FIX(1.847759065) */
+#define F_2_613  669              /* FIX(2.613125930) */
+#define F_1_613  (F_2_613 - 256)  /* FIX(2.613125930) - FIX(1) */
+
+#define CONST_BITS  8
+#define PASS1_BITS  2
+#define PRE_MULTIPLY_SCALE_BITS  2
+#define CONST_SHIFT  (16 - PRE_MULTIPLY_SCALE_BITS - CONST_BITS)
+
+
+#define DO_IDCT(in) { \
+  /* Even part */ \
+  \
+  tmp10 = _mm_add_epi16(in##0, in##4); \
+  tmp11 = _mm_sub_epi16(in##0, in##4); \
+  tmp13 = _mm_add_epi16(in##2, in##6); \
+  \
+  tmp12 = _mm_sub_epi16(in##2, in##6); \
+  tmp12 = _mm_slli_epi16(tmp12, PRE_MULTIPLY_SCALE_BITS); \
+  tmp12 = _mm_mulhi_epi16(tmp12, pw_F1414); \
+  tmp12 = _mm_sub_epi16(tmp12, tmp13); \
+  \
+  tmp0 = _mm_add_epi16(tmp10, tmp13); \
+  tmp3 = _mm_sub_epi16(tmp10, tmp13); \
+  tmp1 = _mm_add_epi16(tmp11, tmp12); \
+  tmp2 = _mm_sub_epi16(tmp11, tmp12); \
+  \
+  /* Odd part */ \
+  \
+  z13 = _mm_add_epi16(in##5, in##3); \
+  z10 = _mm_sub_epi16(in##5, in##3); \
+  z10s = _mm_slli_epi16(z10, PRE_MULTIPLY_SCALE_BITS); \
+  z11 = _mm_add_epi16(in##1, in##7); \
+  z12s = _mm_sub_epi16(in##1, in##7); \
+  z12s = _mm_slli_epi16(z12s, PRE_MULTIPLY_SCALE_BITS); \
+  \
+  tmp11 = _mm_sub_epi16(z11, z13); \
+  tmp11 = _mm_slli_epi16(tmp11, PRE_MULTIPLY_SCALE_BITS); \
+  tmp11 = _mm_mulhi_epi16(tmp11, pw_F1414); \
+  \
+  tmp7 = _mm_add_epi16(z11, z13); \
+  \
+  /* To avoid overflow... \
+   * \
+   * (Original) \
+   * tmp12 = -2.613125930 * z10 + z5; \
+   * \
+   * (This implementation) \
+   * tmp12 = (-1.613125930 - 1) * z10 + z5; \
+   *       = -1.613125930 * z10 - z10 + z5; \
+   */ \
+  \
+  z5 = _mm_add_epi16(z10s, z12s); \
+  z5 = _mm_mulhi_epi16(z5, pw_F1847); \
+  \
+  tmp10 = _mm_mulhi_epi16(z12s, pw_F1082); \
+  tmp10 = _mm_sub_epi16(tmp10, z5); \
+  tmp12 = _mm_add_epi16(_mm_mulhi_epi16(z10s, pw_MF1613), z5); \
+  tmp12 = _mm_sub_epi16(tmp12, z10); \
+  \
+  tmp6 = _mm_sub_epi16(tmp12, tmp7); \
+  tmp5 = _mm_sub_epi16(tmp11, tmp6); \
+  tmp4 = _mm_add_epi16(tmp10, tmp5); \
+  \
+  out0 = _mm_add_epi16(tmp0, tmp7); \
+  out1 = _mm_add_epi16(tmp1, tmp6); \
+  out2 = _mm_add_epi16(tmp2, tmp5); \
+  out3 = _mm_sub_epi16(tmp3, tmp4); \
+  out4 = _mm_add_epi16(tmp3, tmp4); \
+  out5 = _mm_sub_epi16(tmp2, tmp5); \
+  out6 = _mm_sub_epi16(tmp1, tmp6); \
+  out7 = _mm_sub_epi16(tmp0, tmp7); \
+}
+
+
+void jsimd_idct_ifast_e2k(void *dct_table_, JCOEFPTR coef_block,
+                          JSAMPARRAY output_buf, JDIMENSION output_col)
+{
+  short *dct_table = (short *)dct_table_;
+
+  __m128i row0, row1, row2, row3, row4, row5, row6, row7,
+    col0, col1, col2, col3, col4, col5, col6, col7,
+    quant0, quant1, quant2, quant3, quant4, quant5, quant6, quant7,
+    tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp10, tmp11, tmp12, tmp13,
+    z5, z10, z10s, z11, z12s, z13,
+    out0, out1, out2, out3, out4, out5, out6, out7;
+
+  /* Constants */
+  __m128i pw_F1414 = _mm_set1_epi16(F_1_414 << CONST_SHIFT),
+    pw_F1847 = _mm_set1_epi16(F_1_847 << CONST_SHIFT),
+    pw_MF1613 = _mm_set1_epi16(-F_1_613 << CONST_SHIFT),
+    pw_F1082 = _mm_set1_epi16(F_1_082 << CONST_SHIFT);
+
+  /* Pass 1: process columns */
+
+  col0 = VEC_LD(coef_block + 0 * 8);
+  col1 = VEC_LD(coef_block + 1 * 8);
+  col2 = VEC_LD(coef_block + 2 * 8);
+  col3 = VEC_LD(coef_block + 3 * 8);
+  col4 = VEC_LD(coef_block + 4 * 8);
+  col5 = VEC_LD(coef_block + 5 * 8);
+  col6 = VEC_LD(coef_block + 6 * 8);
+  col7 = VEC_LD(coef_block + 7 * 8);
+
+  tmp1 = _mm_or_si128(col1, col2);
+  tmp2 = _mm_or_si128(col3, col4);
+  tmp1 = _mm_or_si128(tmp1, tmp2);
+  tmp3 = _mm_or_si128(col5, col6);
+  tmp3 = _mm_or_si128(tmp3, col7);
+  tmp1 = _mm_or_si128(tmp1, tmp3);
+
+  quant0 = VEC_LD(dct_table);
+  col0 = _mm_mullo_epi16(col0, quant0);
+
+  if (VEC_ISZERO(tmp1)) {
+    /* AC terms all zero */
+
+    row0 = VEC_SPLAT(col0, 0);
+    row1 = VEC_SPLAT(col0, 1);
+    row2 = VEC_SPLAT(col0, 2);
+    row3 = VEC_SPLAT(col0, 3);
+    row4 = VEC_SPLAT(col0, 4);
+    row5 = VEC_SPLAT(col0, 5);
+    row6 = VEC_SPLAT(col0, 6);
+    row7 = VEC_SPLAT(col0, 7);
+
+  } else {
+
+    quant1 = VEC_LD(dct_table + 1 * 8);
+    quant2 = VEC_LD(dct_table + 2 * 8);
+    quant3 = VEC_LD(dct_table + 3 * 8);
+    quant4 = VEC_LD(dct_table + 4 * 8);
+    quant5 = VEC_LD(dct_table + 5 * 8);
+    quant6 = VEC_LD(dct_table + 6 * 8);
+    quant7 = VEC_LD(dct_table + 7 * 8);
+
+    col1 = _mm_mullo_epi16(col1, quant1);
+    col2 = _mm_mullo_epi16(col2, quant2);
+    col3 = _mm_mullo_epi16(col3, quant3);
+    col4 = _mm_mullo_epi16(col4, quant4);
+    col5 = _mm_mullo_epi16(col5, quant5);
+    col6 = _mm_mullo_epi16(col6, quant6);
+    col7 = _mm_mullo_epi16(col7, quant7);
+
+    DO_IDCT(col);
+
+    TRANSPOSE(out, row);
+  }
+
+  /* Pass 2: process rows */
+
+  DO_IDCT(row);
+
+  out0 = _mm_srai_epi16(out0, PASS1_BITS + 3);
+  out1 = _mm_srai_epi16(out1, PASS1_BITS + 3);
+  out2 = _mm_srai_epi16(out2, PASS1_BITS + 3);
+  out3 = _mm_srai_epi16(out3, PASS1_BITS + 3);
+  out4 = _mm_srai_epi16(out4, PASS1_BITS + 3);
+  out5 = _mm_srai_epi16(out5, PASS1_BITS + 3);
+  out6 = _mm_srai_epi16(out6, PASS1_BITS + 3);
+  out7 = _mm_srai_epi16(out7, PASS1_BITS + 3);
+
+  IDCT_SAVE();
+}

--- a/simd/e2k/jidctint-e2k.c
+++ b/simd/e2k/jidctint-e2k.c
@@ -1,0 +1,302 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2014-2015, 2020, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* ACCURATE INTEGER INVERSE DCT */
+
+#include "jsimd_e2k.h"
+
+
+#define F_0_298  2446   /* FIX(0.298631336) */
+#define F_0_390  3196   /* FIX(0.390180644) */
+#define F_0_541  4433   /* FIX(0.541196100) */
+#define F_0_765  6270   /* FIX(0.765366865) */
+#define F_0_899  7373   /* FIX(0.899976223) */
+#define F_1_175  9633   /* FIX(1.175875602) */
+#define F_1_501  12299  /* FIX(1.501321110) */
+#define F_1_847  15137  /* FIX(1.847759065) */
+#define F_1_961  16069  /* FIX(1.961570560) */
+#define F_2_053  16819  /* FIX(2.053119869) */
+#define F_2_562  20995  /* FIX(2.562915447) */
+#define F_3_072  25172  /* FIX(3.072711026) */
+
+#define CONST_BITS  13
+#define PASS1_BITS  2
+#define DESCALE_P1  (CONST_BITS - PASS1_BITS)
+#define DESCALE_P2  (CONST_BITS + PASS1_BITS + 3)
+
+
+#define DO_IDCT(in, PASS) { \
+  /* Even part \
+   * \
+   * (Original) \
+   * z1 = (z2 + z3) * 0.541196100; \
+   * tmp2 = z1 + z3 * -1.847759065; \
+   * tmp3 = z1 + z2 * 0.765366865; \
+   * \
+   * (This implementation) \
+   * tmp2 = z2 * 0.541196100 + z3 * (0.541196100 - 1.847759065); \
+   * tmp3 = z2 * (0.541196100 + 0.765366865) + z3 * 0.541196100; \
+   */ \
+  \
+  in##26l = _mm_unpacklo_epi16(in##2, in##6); \
+  in##26h = _mm_unpackhi_epi16(in##2, in##6); \
+  \
+  tmp3l = _mm_madd_epi16(in##26l, pw_f130_f054); \
+  tmp3h = _mm_madd_epi16(in##26h, pw_f130_f054); \
+  tmp2l = _mm_madd_epi16(in##26l, pw_f054_mf130); \
+  tmp2h = _mm_madd_epi16(in##26h, pw_f054_mf130); \
+  \
+  tmp0 = _mm_add_epi16(in##0, in##4); \
+  tmp1 = _mm_sub_epi16(in##0, in##4); \
+  \
+  tmp0l = _mm_unpacklo_epi16(pw_zero, tmp0); \
+  tmp0h = _mm_unpackhi_epi16(pw_zero, tmp0); \
+  tmp0l = _mm_srai_epi32(tmp0l, 16 - CONST_BITS); \
+  tmp0h = _mm_srai_epi32(tmp0h, 16 - CONST_BITS); \
+  tmp0l = _mm_add_epi32(tmp0l, pd_descale_p##PASS); \
+  tmp0h = _mm_add_epi32(tmp0h, pd_descale_p##PASS); \
+  \
+  tmp10l = _mm_add_epi32(tmp0l, tmp3l); \
+  tmp10h = _mm_add_epi32(tmp0h, tmp3h); \
+  tmp13l = _mm_sub_epi32(tmp0l, tmp3l); \
+  tmp13h = _mm_sub_epi32(tmp0h, tmp3h); \
+  \
+  tmp1l = _mm_unpacklo_epi16(pw_zero, tmp1); \
+  tmp1h = _mm_unpackhi_epi16(pw_zero, tmp1); \
+  tmp1l = _mm_srai_epi32(tmp1l, 16 - CONST_BITS); \
+  tmp1h = _mm_srai_epi32(tmp1h, 16 - CONST_BITS); \
+  tmp1l = _mm_add_epi32(tmp1l, pd_descale_p##PASS); \
+  tmp1h = _mm_add_epi32(tmp1h, pd_descale_p##PASS); \
+  \
+  tmp11l = _mm_add_epi32(tmp1l, tmp2l); \
+  tmp11h = _mm_add_epi32(tmp1h, tmp2h); \
+  tmp12l = _mm_sub_epi32(tmp1l, tmp2l); \
+  tmp12h = _mm_sub_epi32(tmp1h, tmp2h); \
+  \
+  /* Odd part */ \
+  \
+  z3 = _mm_add_epi16(in##3, in##7); \
+  z4 = _mm_add_epi16(in##1, in##5); \
+  \
+  /* (Original) \
+   * z5 = (z3 + z4) * 1.175875602; \
+   * z3 = z3 * -1.961570560;  z4 = z4 * -0.390180644; \
+   * z3 += z5;  z4 += z5; \
+   * \
+   * (This implementation) \
+   * z3 = z3 * (1.175875602 - 1.961570560) + z4 * 1.175875602; \
+   * z4 = z3 * 1.175875602 + z4 * (1.175875602 - 0.390180644); \
+   */ \
+  \
+  z34l = _mm_unpacklo_epi16(z3, z4); \
+  z34h = _mm_unpackhi_epi16(z3, z4); \
+  \
+  z3l = _mm_madd_epi16(z34l, pw_mf078_f117); \
+  z3h = _mm_madd_epi16(z34h, pw_mf078_f117); \
+  z4l = _mm_madd_epi16(z34l, pw_f117_f078); \
+  z4h = _mm_madd_epi16(z34h, pw_f117_f078); \
+  \
+  /* (Original) \
+   * z1 = tmp0 + tmp3;  z2 = tmp1 + tmp2; \
+   * tmp0 = tmp0 * 0.298631336;  tmp1 = tmp1 * 2.053119869; \
+   * tmp2 = tmp2 * 3.072711026;  tmp3 = tmp3 * 1.501321110; \
+   * z1 = z1 * -0.899976223;  z2 = z2 * -2.562915447; \
+   * tmp0 += z1 + z3;  tmp1 += z2 + z4; \
+   * tmp2 += z2 + z3;  tmp3 += z1 + z4; \
+   * \
+   * (This implementation) \
+   * tmp0 = tmp0 * (0.298631336 - 0.899976223) + tmp3 * -0.899976223; \
+   * tmp1 = tmp1 * (2.053119869 - 2.562915447) + tmp2 * -2.562915447; \
+   * tmp2 = tmp1 * -2.562915447 + tmp2 * (3.072711026 - 2.562915447); \
+   * tmp3 = tmp0 * -0.899976223 + tmp3 * (1.501321110 - 0.899976223); \
+   * tmp0 += z3;  tmp1 += z4; \
+   * tmp2 += z3;  tmp3 += z4; \
+   */ \
+  \
+  in##71l = _mm_unpacklo_epi16(in##7, in##1); \
+  in##71h = _mm_unpackhi_epi16(in##7, in##1); \
+  \
+  tmp0l = _mm_add_epi32(_mm_madd_epi16(in##71l, pw_mf060_mf089), z3l); \
+  tmp0h = _mm_add_epi32(_mm_madd_epi16(in##71h, pw_mf060_mf089), z3h); \
+  tmp3l = _mm_add_epi32(_mm_madd_epi16(in##71l, pw_mf089_f060), z4l); \
+  tmp3h = _mm_add_epi32(_mm_madd_epi16(in##71h, pw_mf089_f060), z4h); \
+  \
+  in##53l = _mm_unpacklo_epi16(in##5, in##3); \
+  in##53h = _mm_unpackhi_epi16(in##5, in##3); \
+  \
+  tmp1l = _mm_add_epi32(_mm_madd_epi16(in##53l, pw_mf050_mf256), z4l); \
+  tmp1h = _mm_add_epi32(_mm_madd_epi16(in##53h, pw_mf050_mf256), z4h); \
+  tmp2l = _mm_add_epi32(_mm_madd_epi16(in##53l, pw_mf256_f050), z3l); \
+  tmp2h = _mm_add_epi32(_mm_madd_epi16(in##53h, pw_mf256_f050), z3h); \
+  \
+  /* Final output stage */ \
+  \
+  out0l = _mm_add_epi32(tmp10l, tmp3l); \
+  out0h = _mm_add_epi32(tmp10h, tmp3h); \
+  out7l = _mm_sub_epi32(tmp10l, tmp3l); \
+  out7h = _mm_sub_epi32(tmp10h, tmp3h); \
+  \
+  out0l = _mm_srai_epi32(out0l, DESCALE_P##PASS); \
+  out0h = _mm_srai_epi32(out0h, DESCALE_P##PASS); \
+  out7l = _mm_srai_epi32(out7l, DESCALE_P##PASS); \
+  out7h = _mm_srai_epi32(out7h, DESCALE_P##PASS); \
+  \
+  out0 = _mm_packs_epi32(out0l, out0h); \
+  out7 = _mm_packs_epi32(out7l, out7h); \
+  \
+  out1l = _mm_add_epi32(tmp11l, tmp2l); \
+  out1h = _mm_add_epi32(tmp11h, tmp2h); \
+  out6l = _mm_sub_epi32(tmp11l, tmp2l); \
+  out6h = _mm_sub_epi32(tmp11h, tmp2h); \
+  \
+  out1l = _mm_srai_epi32(out1l, DESCALE_P##PASS); \
+  out1h = _mm_srai_epi32(out1h, DESCALE_P##PASS); \
+  out6l = _mm_srai_epi32(out6l, DESCALE_P##PASS); \
+  out6h = _mm_srai_epi32(out6h, DESCALE_P##PASS); \
+  \
+  out1 = _mm_packs_epi32(out1l, out1h); \
+  out6 = _mm_packs_epi32(out6l, out6h); \
+  \
+  out2l = _mm_add_epi32(tmp12l, tmp1l); \
+  out2h = _mm_add_epi32(tmp12h, tmp1h); \
+  out5l = _mm_sub_epi32(tmp12l, tmp1l); \
+  out5h = _mm_sub_epi32(tmp12h, tmp1h); \
+  \
+  out2l = _mm_srai_epi32(out2l, DESCALE_P##PASS); \
+  out2h = _mm_srai_epi32(out2h, DESCALE_P##PASS); \
+  out5l = _mm_srai_epi32(out5l, DESCALE_P##PASS); \
+  out5h = _mm_srai_epi32(out5h, DESCALE_P##PASS); \
+  \
+  out2 = _mm_packs_epi32(out2l, out2h); \
+  out5 = _mm_packs_epi32(out5l, out5h); \
+  \
+  out3l = _mm_add_epi32(tmp13l, tmp0l); \
+  out3h = _mm_add_epi32(tmp13h, tmp0h); \
+  out4l = _mm_sub_epi32(tmp13l, tmp0l); \
+  out4h = _mm_sub_epi32(tmp13h, tmp0h); \
+  \
+  out3l = _mm_srai_epi32(out3l, DESCALE_P##PASS); \
+  out3h = _mm_srai_epi32(out3h, DESCALE_P##PASS); \
+  out4l = _mm_srai_epi32(out4l, DESCALE_P##PASS); \
+  out4h = _mm_srai_epi32(out4h, DESCALE_P##PASS); \
+  \
+  out3 = _mm_packs_epi32(out3l, out3h); \
+  out4 = _mm_packs_epi32(out4l, out4h); \
+}
+
+
+void jsimd_idct_islow_e2k(void *dct_table_, JCOEFPTR coef_block,
+                          JSAMPARRAY output_buf, JDIMENSION output_col)
+{
+  short *dct_table = (short *)dct_table_;
+
+  __m128i row0, row1, row2, row3, row4, row5, row6, row7,
+    col0, col1, col2, col3, col4, col5, col6, col7,
+    quant0, quant1, quant2, quant3, quant4, quant5, quant6, quant7,
+    tmp0, tmp1, tmp2, tmp3, z3, z4,
+    z34l, z34h, col71l, col71h, col26l, col26h, col53l, col53h,
+    row71l, row71h, row26l, row26h, row53l, row53h,
+    out0, out1, out2, out3, out4, out5, out6, out7;
+  __m128i tmp0l, tmp0h, tmp1l, tmp1h, tmp2l, tmp2h, tmp3l, tmp3h,
+    tmp10l, tmp10h, tmp11l, tmp11h, tmp12l, tmp12h, tmp13l, tmp13h,
+    z3l, z3h, z4l, z4h,
+    out0l, out0h, out1l, out1h, out2l, out2h, out3l, out3h, out4l, out4h,
+    out5l, out5h, out6l, out6h, out7l, out7h;
+
+  /* Constants */
+  __m128i pw_zero = _mm_setzero_si128(),
+    pw_f130_f054 = _mm_setr_epi16(__4X2(F_0_541 + F_0_765, F_0_541)),
+    pw_f054_mf130 = _mm_setr_epi16(__4X2(F_0_541, F_0_541 - F_1_847)),
+    pw_mf078_f117 = _mm_setr_epi16(__4X2(F_1_175 - F_1_961, F_1_175)),
+    pw_f117_f078 = _mm_setr_epi16(__4X2(F_1_175, F_1_175 - F_0_390)),
+    pw_mf060_mf089 = _mm_setr_epi16(__4X2(F_0_298 - F_0_899, -F_0_899)),
+    pw_mf089_f060 = _mm_setr_epi16(__4X2(-F_0_899, F_1_501 - F_0_899)),
+    pw_mf050_mf256 = _mm_setr_epi16(__4X2(F_2_053 - F_2_562, -F_2_562)),
+    pw_mf256_f050 = _mm_setr_epi16(__4X2(-F_2_562, F_3_072 - F_2_562)),
+    pd_descale_p1 = _mm_set1_epi32(1 << (DESCALE_P1 - 1)),
+    pd_descale_p2 = _mm_set1_epi32(1 << (DESCALE_P2 - 1));
+
+  /* Pass 1: process columns */
+
+  col0 = VEC_LD(coef_block + 0 * 8);
+  col1 = VEC_LD(coef_block + 1 * 8);
+  col2 = VEC_LD(coef_block + 2 * 8);
+  col3 = VEC_LD(coef_block + 3 * 8);
+  col4 = VEC_LD(coef_block + 4 * 8);
+  col5 = VEC_LD(coef_block + 5 * 8);
+  col6 = VEC_LD(coef_block + 6 * 8);
+  col7 = VEC_LD(coef_block + 7 * 8);
+
+  tmp1 = _mm_or_si128(col1, col2);
+  tmp2 = _mm_or_si128(col3, col4);
+  tmp1 = _mm_or_si128(tmp1, tmp2);
+  tmp3 = _mm_or_si128(col5, col6);
+  tmp3 = _mm_or_si128(tmp3, col7);
+  tmp1 = _mm_or_si128(tmp1, tmp3);
+
+  quant0 = VEC_LD(dct_table);
+  col0 = _mm_mullo_epi16(col0, quant0);
+
+  if (VEC_ISZERO(tmp1)) {
+    /* AC terms all zero */
+
+    col0 = _mm_slli_epi16(col0, PASS1_BITS);
+
+    row0 = VEC_SPLAT(col0, 0);
+    row1 = VEC_SPLAT(col0, 1);
+    row2 = VEC_SPLAT(col0, 2);
+    row3 = VEC_SPLAT(col0, 3);
+    row4 = VEC_SPLAT(col0, 4);
+    row5 = VEC_SPLAT(col0, 5);
+    row6 = VEC_SPLAT(col0, 6);
+    row7 = VEC_SPLAT(col0, 7);
+
+  } else {
+
+    quant1 = VEC_LD(dct_table + 1 * 8);
+    quant2 = VEC_LD(dct_table + 2 * 8);
+    quant3 = VEC_LD(dct_table + 3 * 8);
+    quant4 = VEC_LD(dct_table + 4 * 8);
+    quant5 = VEC_LD(dct_table + 5 * 8);
+    quant6 = VEC_LD(dct_table + 6 * 8);
+    quant7 = VEC_LD(dct_table + 7 * 8);
+
+    col1 = _mm_mullo_epi16(col1, quant1);
+    col2 = _mm_mullo_epi16(col2, quant2);
+    col3 = _mm_mullo_epi16(col3, quant3);
+    col4 = _mm_mullo_epi16(col4, quant4);
+    col5 = _mm_mullo_epi16(col5, quant5);
+    col6 = _mm_mullo_epi16(col6, quant6);
+    col7 = _mm_mullo_epi16(col7, quant7);
+
+    DO_IDCT(col, 1);
+
+    TRANSPOSE(out, row);
+  }
+
+  /* Pass 2: process rows */
+
+  DO_IDCT(row, 2);
+
+  IDCT_SAVE();
+}

--- a/simd/e2k/jquantf-e2k.c
+++ b/simd/e2k/jquantf-e2k.c
@@ -1,0 +1,120 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2014-2015, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* FLOAT QUANTIZATION AND SAMPLE CONVERSION */
+
+#include "jsimd_e2k.h"
+
+#define LOAD_ROW(row) in##row = VEC_LD8(sample_data[row] + start_col)
+#define STORE_ROW(i) \
+  in0 = _mm_unpacklo_epi16(out##i, pb_zero); \
+  in1 = _mm_unpackhi_epi16(out##i, pb_zero); \
+  in0 = _mm_sub_epi32(in0, pd_cj); \
+  in1 = _mm_sub_epi32(in1, pd_cj); \
+  _mm_storeu_ps(workspace + i * 8, _mm_cvtepi32_ps(in0)); \
+  _mm_storeu_ps(workspace + i * 8 + 4, _mm_cvtepi32_ps(in1));
+
+void jsimd_convsamp_float_e2k(JSAMPARRAY sample_data, JDIMENSION start_col,
+                              FAST_FLOAT *workspace)
+{
+  __m128i in0, in1, in2, in3, in4, in5, in6, in7;
+  __m128i out0, out1, out2, out3, out4, out5, out6, out7;
+
+  /* Constants */
+  __m128i pd_cj = _mm_set1_epi32(CENTERJSAMPLE),
+    pb_zero = _mm_setzero_si128();
+
+  LOAD_ROW(0);
+  LOAD_ROW(1);
+  LOAD_ROW(2);
+  LOAD_ROW(3);
+  LOAD_ROW(4);
+  LOAD_ROW(5);
+  LOAD_ROW(6);
+  LOAD_ROW(7);
+
+  out0 = _mm_unpacklo_epi8(in0, pb_zero);
+  out1 = _mm_unpacklo_epi8(in1, pb_zero);
+  out2 = _mm_unpacklo_epi8(in2, pb_zero);
+  out3 = _mm_unpacklo_epi8(in3, pb_zero);
+  out4 = _mm_unpacklo_epi8(in4, pb_zero);
+  out5 = _mm_unpacklo_epi8(in5, pb_zero);
+  out6 = _mm_unpacklo_epi8(in6, pb_zero);
+  out7 = _mm_unpacklo_epi8(in7, pb_zero);
+
+  STORE_ROW(0)
+  STORE_ROW(1)
+  STORE_ROW(2)
+  STORE_ROW(3)
+  STORE_ROW(4)
+  STORE_ROW(5)
+  STORE_ROW(6)
+  STORE_ROW(7)
+}
+
+void jsimd_quantize_float_e2k(JCOEFPTR coef_block, FAST_FLOAT *divisors,
+                              FAST_FLOAT *workspace)
+{
+  int i = 0;
+  __m128 row0, row1, row2, row3, recip0, recip1, recip2, recip3;
+  __m128i out0, out1;
+#ifdef JSIMD_SAME_ROUNDING
+  __m128 pd_f16k5 = _mm_set1_ps(16384.5f);
+  __m128i pw_m16k = _mm_set1_epi16(-16384);
+#endif
+
+  for (; i < 4; i++, workspace += 16, divisors += 16, coef_block += 16) {
+    row0 = _mm_loadu_ps(workspace + 0 * 4);
+    row1 = _mm_loadu_ps(workspace + 1 * 4);
+    row2 = _mm_loadu_ps(workspace + 2 * 4);
+    row3 = _mm_loadu_ps(workspace + 3 * 4);
+
+    recip0 = _mm_loadu_ps(divisors + 0 * 4);
+    recip1 = _mm_loadu_ps(divisors + 1 * 4);
+    recip2 = _mm_loadu_ps(divisors + 2 * 4);
+    recip3 = _mm_loadu_ps(divisors + 3 * 4);
+
+    row0 = _mm_mul_ps(row0, recip0);
+    row1 = _mm_mul_ps(row1, recip1);
+    row2 = _mm_mul_ps(row2, recip2);
+    row3 = _mm_mul_ps(row3, recip3);
+
+#ifdef JSIMD_SAME_ROUNDING
+    row0 = _mm_add_ps(row0, pd_f16k5);
+    row1 = _mm_add_ps(row1, pd_f16k5);
+    row2 = _mm_add_ps(row2, pd_f16k5);
+    row3 = _mm_add_ps(row3, pd_f16k5);
+
+    out0 = _mm_packs_epi32(_mm_cvttps_epi32(row0), _mm_cvttps_epi32(row1));
+    out1 = _mm_packs_epi32(_mm_cvttps_epi32(row2), _mm_cvttps_epi32(row3));
+
+    out0 = _mm_add_epi16(out0, pw_m16k);
+    out1 = _mm_add_epi16(out1, pw_m16k);
+#else
+    out0 = _mm_packs_epi32(_mm_cvtps_epi32(row0), _mm_cvtps_epi32(row1));
+    out1 = _mm_packs_epi32(_mm_cvtps_epi32(row2), _mm_cvtps_epi32(row3));
+#endif
+    VEC_ST(coef_block, out0);
+    VEC_ST(coef_block + 8, out1);
+  }
+}

--- a/simd/e2k/jquanti-e2k.c
+++ b/simd/e2k/jquanti-e2k.c
@@ -1,0 +1,234 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2014-2015, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* INTEGER QUANTIZATION AND SAMPLE CONVERSION */
+
+#include "jsimd_e2k.h"
+
+#define LOAD_ROW(row) in##row = VEC_LD8(sample_data[row] + start_col)
+
+void jsimd_convsamp_e2k(JSAMPARRAY sample_data, JDIMENSION start_col,
+                        DCTELEM *workspace)
+{
+  __m128i in0, in1, in2, in3, in4, in5, in6, in7;
+  __m128i out0, out1, out2, out3, out4, out5, out6, out7;
+
+  /* Constants */
+  __m128i pw_cj = _mm_set1_epi16(CENTERJSAMPLE),
+    pb_zero = _mm_setzero_si128();
+
+  LOAD_ROW(0);
+  LOAD_ROW(1);
+  LOAD_ROW(2);
+  LOAD_ROW(3);
+  LOAD_ROW(4);
+  LOAD_ROW(5);
+  LOAD_ROW(6);
+  LOAD_ROW(7);
+
+  out0 = _mm_unpacklo_epi8(in0, pb_zero);
+  out1 = _mm_unpacklo_epi8(in1, pb_zero);
+  out2 = _mm_unpacklo_epi8(in2, pb_zero);
+  out3 = _mm_unpacklo_epi8(in3, pb_zero);
+  out4 = _mm_unpacklo_epi8(in4, pb_zero);
+  out5 = _mm_unpacklo_epi8(in5, pb_zero);
+  out6 = _mm_unpacklo_epi8(in6, pb_zero);
+  out7 = _mm_unpacklo_epi8(in7, pb_zero);
+
+  out0 = _mm_sub_epi16(out0, pw_cj);
+  out1 = _mm_sub_epi16(out1, pw_cj);
+  out2 = _mm_sub_epi16(out2, pw_cj);
+  out3 = _mm_sub_epi16(out3, pw_cj);
+  out4 = _mm_sub_epi16(out4, pw_cj);
+  out5 = _mm_sub_epi16(out5, pw_cj);
+  out6 = _mm_sub_epi16(out6, pw_cj);
+  out7 = _mm_sub_epi16(out7, pw_cj);
+
+  VEC_ST(workspace + 0 * 8, out0);
+  VEC_ST(workspace + 1 * 8, out1);
+  VEC_ST(workspace + 2 * 8, out2);
+  VEC_ST(workspace + 3 * 8, out3);
+  VEC_ST(workspace + 4 * 8, out4);
+  VEC_ST(workspace + 5 * 8, out5);
+  VEC_ST(workspace + 6 * 8, out6);
+  VEC_ST(workspace + 7 * 8, out7);
+}
+
+
+#define WORD_BIT  16
+#define MULTIPLY(vs0, vs1, out) out = _mm_mulhi_epu16(vs0, vs1)
+
+void jsimd_quantize_e2k(JCOEFPTR coef_block, DCTELEM *divisors,
+                        DCTELEM *workspace)
+{
+  __m128i row0, row1, row2, row3, row4, row5, row6, row7,
+    row0s, row1s, row2s, row3s, row4s, row5s, row6s, row7s,
+    corr0, corr1, corr2, corr3, corr4, corr5, corr6, corr7,
+    recip0, recip1, recip2, recip3, recip4, recip5, recip6, recip7,
+    scale0, scale1, scale2, scale3, scale4, scale5, scale6, scale7;
+
+#if defined(__e2k__) && __iset__ < 3
+  row0 = VEC_LD(workspace + 0 * 8);
+  row1 = VEC_LD(workspace + 1 * 8);
+  row2 = VEC_LD(workspace + 2 * 8);
+  row3 = VEC_LD(workspace + 3 * 8);
+  row4 = VEC_LD(workspace + 4 * 8);
+  row5 = VEC_LD(workspace + 5 * 8);
+  row6 = VEC_LD(workspace + 6 * 8);
+  row7 = VEC_LD(workspace + 7 * 8);
+
+  /* Branch-less absolute value */
+  row0s = _mm_srai_epi16(row0, WORD_BIT - 1);
+  row1s = _mm_srai_epi16(row1, WORD_BIT - 1);
+  row2s = _mm_srai_epi16(row2, WORD_BIT - 1);
+  row3s = _mm_srai_epi16(row3, WORD_BIT - 1);
+  row4s = _mm_srai_epi16(row4, WORD_BIT - 1);
+  row5s = _mm_srai_epi16(row5, WORD_BIT - 1);
+  row6s = _mm_srai_epi16(row6, WORD_BIT - 1);
+  row7s = _mm_srai_epi16(row7, WORD_BIT - 1);
+  row0 = _mm_xor_si128(row0, row0s);
+  row1 = _mm_xor_si128(row1, row1s);
+  row2 = _mm_xor_si128(row2, row2s);
+  row3 = _mm_xor_si128(row3, row3s);
+  row4 = _mm_xor_si128(row4, row4s);
+  row5 = _mm_xor_si128(row5, row5s);
+  row6 = _mm_xor_si128(row6, row6s);
+  row7 = _mm_xor_si128(row7, row7s);
+  row0 = _mm_sub_epi16(row0, row0s);
+  row1 = _mm_sub_epi16(row1, row1s);
+  row2 = _mm_sub_epi16(row2, row2s);
+  row3 = _mm_sub_epi16(row3, row3s);
+  row4 = _mm_sub_epi16(row4, row4s);
+  row5 = _mm_sub_epi16(row5, row5s);
+  row6 = _mm_sub_epi16(row6, row6s);
+  row7 = _mm_sub_epi16(row7, row7s);
+#else
+  row0s = VEC_LD(workspace + 0 * 8);
+  row1s = VEC_LD(workspace + 1 * 8);
+  row2s = VEC_LD(workspace + 2 * 8);
+  row3s = VEC_LD(workspace + 3 * 8);
+  row4s = VEC_LD(workspace + 4 * 8);
+  row5s = VEC_LD(workspace + 5 * 8);
+  row6s = VEC_LD(workspace + 6 * 8);
+  row7s = VEC_LD(workspace + 7 * 8);
+  row0 = _mm_abs_epi16(row0s);
+  row1 = _mm_abs_epi16(row1s);
+  row2 = _mm_abs_epi16(row2s);
+  row3 = _mm_abs_epi16(row3s);
+  row4 = _mm_abs_epi16(row4s);
+  row5 = _mm_abs_epi16(row5s);
+  row6 = _mm_abs_epi16(row6s);
+  row7 = _mm_abs_epi16(row7s);
+#endif
+
+  corr0 = VEC_LD(divisors + DCTSIZE2 + 0 * 8);
+  corr1 = VEC_LD(divisors + DCTSIZE2 + 1 * 8);
+  corr2 = VEC_LD(divisors + DCTSIZE2 + 2 * 8);
+  corr3 = VEC_LD(divisors + DCTSIZE2 + 3 * 8);
+  corr4 = VEC_LD(divisors + DCTSIZE2 + 4 * 8);
+  corr5 = VEC_LD(divisors + DCTSIZE2 + 5 * 8);
+  corr6 = VEC_LD(divisors + DCTSIZE2 + 6 * 8);
+  corr7 = VEC_LD(divisors + DCTSIZE2 + 7 * 8);
+
+  row0 = _mm_add_epi16(row0, corr0);
+  row1 = _mm_add_epi16(row1, corr1);
+  row2 = _mm_add_epi16(row2, corr2);
+  row3 = _mm_add_epi16(row3, corr3);
+  row4 = _mm_add_epi16(row4, corr4);
+  row5 = _mm_add_epi16(row5, corr5);
+  row6 = _mm_add_epi16(row6, corr6);
+  row7 = _mm_add_epi16(row7, corr7);
+
+  recip0 = VEC_LD(divisors + 0 * 8);
+  recip1 = VEC_LD(divisors + 1 * 8);
+  recip2 = VEC_LD(divisors + 2 * 8);
+  recip3 = VEC_LD(divisors + 3 * 8);
+  recip4 = VEC_LD(divisors + 4 * 8);
+  recip5 = VEC_LD(divisors + 5 * 8);
+  recip6 = VEC_LD(divisors + 6 * 8);
+  recip7 = VEC_LD(divisors + 7 * 8);
+
+  MULTIPLY(row0, recip0, row0);
+  MULTIPLY(row1, recip1, row1);
+  MULTIPLY(row2, recip2, row2);
+  MULTIPLY(row3, recip3, row3);
+  MULTIPLY(row4, recip4, row4);
+  MULTIPLY(row5, recip5, row5);
+  MULTIPLY(row6, recip6, row6);
+  MULTIPLY(row7, recip7, row7);
+
+  scale0 = VEC_LD(divisors + DCTSIZE2 * 2 + 0 * 8);
+  scale1 = VEC_LD(divisors + DCTSIZE2 * 2 + 1 * 8);
+  scale2 = VEC_LD(divisors + DCTSIZE2 * 2 + 2 * 8);
+  scale3 = VEC_LD(divisors + DCTSIZE2 * 2 + 3 * 8);
+  scale4 = VEC_LD(divisors + DCTSIZE2 * 2 + 4 * 8);
+  scale5 = VEC_LD(divisors + DCTSIZE2 * 2 + 5 * 8);
+  scale6 = VEC_LD(divisors + DCTSIZE2 * 2 + 6 * 8);
+  scale7 = VEC_LD(divisors + DCTSIZE2 * 2 + 7 * 8);
+
+  MULTIPLY(row0, scale0, row0);
+  MULTIPLY(row1, scale1, row1);
+  MULTIPLY(row2, scale2, row2);
+  MULTIPLY(row3, scale3, row3);
+  MULTIPLY(row4, scale4, row4);
+  MULTIPLY(row5, scale5, row5);
+  MULTIPLY(row6, scale6, row6);
+  MULTIPLY(row7, scale7, row7);
+
+#if defined(__e2k__) && __iset__ < 3
+  row0 = _mm_xor_si128(row0, row0s);
+  row1 = _mm_xor_si128(row1, row1s);
+  row2 = _mm_xor_si128(row2, row2s);
+  row3 = _mm_xor_si128(row3, row3s);
+  row4 = _mm_xor_si128(row4, row4s);
+  row5 = _mm_xor_si128(row5, row5s);
+  row6 = _mm_xor_si128(row6, row6s);
+  row7 = _mm_xor_si128(row7, row7s);
+  row0 = _mm_sub_epi16(row0, row0s);
+  row1 = _mm_sub_epi16(row1, row1s);
+  row2 = _mm_sub_epi16(row2, row2s);
+  row3 = _mm_sub_epi16(row3, row3s);
+  row4 = _mm_sub_epi16(row4, row4s);
+  row5 = _mm_sub_epi16(row5, row5s);
+  row6 = _mm_sub_epi16(row6, row6s);
+  row7 = _mm_sub_epi16(row7, row7s);
+#else
+  row0 = _mm_sign_epi16(row0, row0s);
+  row1 = _mm_sign_epi16(row1, row1s);
+  row2 = _mm_sign_epi16(row2, row2s);
+  row3 = _mm_sign_epi16(row3, row3s);
+  row4 = _mm_sign_epi16(row4, row4s);
+  row5 = _mm_sign_epi16(row5, row5s);
+  row6 = _mm_sign_epi16(row6, row6s);
+  row7 = _mm_sign_epi16(row7, row7s);
+#endif
+
+  VEC_ST(coef_block + 0 * 8, row0);
+  VEC_ST(coef_block + 1 * 8, row1);
+  VEC_ST(coef_block + 2 * 8, row2);
+  VEC_ST(coef_block + 3 * 8, row3);
+  VEC_ST(coef_block + 4 * 8, row4);
+  VEC_ST(coef_block + 5 * 8, row5);
+  VEC_ST(coef_block + 6 * 8, row6);
+  VEC_ST(coef_block + 7 * 8, row7);
+}

--- a/simd/e2k/jsimd.c
+++ b/simd/e2k/jsimd.c
@@ -1,0 +1,822 @@
+/*
+ * jsimd_e2k.c
+ *
+ * Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+ * Copyright (C) 2009-2011, 2014-2016, 2018, D. R. Commander.
+ * Copyright (C) 2015-2016, 2018, Matthieu Darbois.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * Based on the x86 SIMD extension for IJG JPEG library,
+ * Copyright (C) 1999-2006, MIYASAKA Masaru.
+ * For conditions of distribution and use, see copyright notice in jsimdext.inc
+ *
+ * This file contains the interface between the "normal" portions
+ * of the library and the SIMD implementations when running on a
+ * PowerPC architecture.
+ */
+
+#define JPEG_INTERNALS
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "../../jsimd.h"
+#include "../../jdct.h"
+#include "../../jsimddct.h"
+#include "../jsimd.h"
+#include "jsimd_api_e2k.h"
+
+#ifdef HAVE_EML
+int jsimd_use_eml;
+#endif
+static unsigned int simd_support = ~0;
+
+/*
+ * Check what SIMD accelerations are supported.
+ *
+ * FIXME: This code is racy under a multi-threaded environment.
+ */
+LOCAL(void)
+init_simd(void)
+{
+#ifndef NO_GETENV
+  char *env = NULL;
+#endif
+
+  if (simd_support != ~0U)
+    return;
+
+  simd_support = JSIMD_SSE2;
+#ifdef HAVE_EML
+  jsimd_use_eml = 1;
+#endif
+
+#ifndef NO_GETENV
+  /* Force different settings through environment variables */
+#ifdef HAVE_EML
+  env = getenv("JSIMD_NOEML");
+  if ((env != NULL) && (strcmp(env, "1") == 0))
+    jsimd_use_eml = 0;
+#endif
+  env = getenv("JSIMD_FORCENONE");
+  if ((env != NULL) && (strcmp(env, "1") == 0))
+    simd_support = 0;
+#endif
+}
+
+GLOBAL(int)
+jsimd_can_rgb_ycc(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if ((RGB_PIXELSIZE != 3) && (RGB_PIXELSIZE != 4))
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_rgb_gray(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if ((RGB_PIXELSIZE != 3) && (RGB_PIXELSIZE != 4))
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_ycc_rgb(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if ((RGB_PIXELSIZE != 3) && (RGB_PIXELSIZE != 4))
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_ycc_rgb565(void)
+{
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_rgb_ycc_convert(j_compress_ptr cinfo, JSAMPARRAY input_buf,
+                      JSAMPIMAGE output_buf, JDIMENSION output_row,
+                      int num_rows)
+{
+  void (*e2kfct) (JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
+
+  switch (cinfo->in_color_space) {
+  case JCS_EXT_RGB:
+    e2kfct = jsimd_extrgb_ycc_convert_e2k;
+    break;
+  case JCS_EXT_RGBX:
+  case JCS_EXT_RGBA:
+    e2kfct = jsimd_extrgbx_ycc_convert_e2k;
+    break;
+  case JCS_EXT_BGR:
+    e2kfct = jsimd_extbgr_ycc_convert_e2k;
+    break;
+  case JCS_EXT_BGRX:
+  case JCS_EXT_BGRA:
+    e2kfct = jsimd_extbgrx_ycc_convert_e2k;
+    break;
+  case JCS_EXT_XBGR:
+  case JCS_EXT_ABGR:
+    e2kfct = jsimd_extxbgr_ycc_convert_e2k;
+    break;
+  case JCS_EXT_XRGB:
+  case JCS_EXT_ARGB:
+    e2kfct = jsimd_extxrgb_ycc_convert_e2k;
+    break;
+  default:
+    e2kfct = jsimd_rgb_ycc_convert_e2k;
+    break;
+  }
+
+  e2kfct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
+}
+
+GLOBAL(void)
+jsimd_rgb_gray_convert(j_compress_ptr cinfo, JSAMPARRAY input_buf,
+                       JSAMPIMAGE output_buf, JDIMENSION output_row,
+                       int num_rows)
+{
+  void (*e2kfct) (JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
+
+  switch (cinfo->in_color_space) {
+  case JCS_EXT_RGB:
+    e2kfct = jsimd_extrgb_gray_convert_e2k;
+    break;
+  case JCS_EXT_RGBX:
+  case JCS_EXT_RGBA:
+    e2kfct = jsimd_extrgbx_gray_convert_e2k;
+    break;
+  case JCS_EXT_BGR:
+    e2kfct = jsimd_extbgr_gray_convert_e2k;
+    break;
+  case JCS_EXT_BGRX:
+  case JCS_EXT_BGRA:
+    e2kfct = jsimd_extbgrx_gray_convert_e2k;
+    break;
+  case JCS_EXT_XBGR:
+  case JCS_EXT_ABGR:
+    e2kfct = jsimd_extxbgr_gray_convert_e2k;
+    break;
+  case JCS_EXT_XRGB:
+  case JCS_EXT_ARGB:
+    e2kfct = jsimd_extxrgb_gray_convert_e2k;
+    break;
+  default:
+    e2kfct = jsimd_rgb_gray_convert_e2k;
+    break;
+  }
+
+  e2kfct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
+}
+
+GLOBAL(void)
+jsimd_ycc_rgb_convert(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
+                      JDIMENSION input_row, JSAMPARRAY output_buf,
+                      int num_rows)
+{
+  void (*e2kfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY, int);
+
+  switch (cinfo->out_color_space) {
+  case JCS_EXT_RGB:
+    e2kfct = jsimd_ycc_extrgb_convert_e2k;
+    break;
+  case JCS_EXT_RGBX:
+  case JCS_EXT_RGBA:
+    e2kfct = jsimd_ycc_extrgbx_convert_e2k;
+    break;
+  case JCS_EXT_BGR:
+    e2kfct = jsimd_ycc_extbgr_convert_e2k;
+    break;
+  case JCS_EXT_BGRX:
+  case JCS_EXT_BGRA:
+    e2kfct = jsimd_ycc_extbgrx_convert_e2k;
+    break;
+  case JCS_EXT_XBGR:
+  case JCS_EXT_ABGR:
+    e2kfct = jsimd_ycc_extxbgr_convert_e2k;
+    break;
+  case JCS_EXT_XRGB:
+  case JCS_EXT_ARGB:
+    e2kfct = jsimd_ycc_extxrgb_convert_e2k;
+    break;
+  default:
+    e2kfct = jsimd_ycc_rgb_convert_e2k;
+    break;
+  }
+
+  e2kfct(cinfo->output_width, input_buf, input_row, output_buf, num_rows);
+}
+
+GLOBAL(void)
+jsimd_ycc_rgb565_convert(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
+                         JDIMENSION input_row, JSAMPARRAY output_buf,
+                         int num_rows)
+{
+}
+
+GLOBAL(int)
+jsimd_can_h2v2_downsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_h2v1_downsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_h2v2_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
+                      JSAMPARRAY input_data, JSAMPARRAY output_data)
+{
+  jsimd_h2v2_downsample_e2k(cinfo->image_width, cinfo->max_v_samp_factor,
+                                compptr->v_samp_factor,
+                                compptr->width_in_blocks, input_data,
+                                output_data);
+}
+
+GLOBAL(void)
+jsimd_h2v1_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
+                      JSAMPARRAY input_data, JSAMPARRAY output_data)
+{
+  jsimd_h2v1_downsample_e2k(cinfo->image_width, cinfo->max_v_samp_factor,
+                                compptr->v_samp_factor,
+                                compptr->width_in_blocks, input_data,
+                                output_data);
+}
+
+GLOBAL(int)
+jsimd_can_h2v2_upsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_h2v1_upsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_h2v2_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                    JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
+{
+  jsimd_h2v2_upsample_e2k(cinfo->max_v_samp_factor, cinfo->output_width,
+                              input_data, output_data_ptr);
+}
+
+GLOBAL(void)
+jsimd_h2v1_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                    JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
+{
+  jsimd_h2v1_upsample_e2k(cinfo->max_v_samp_factor, cinfo->output_width,
+                              input_data, output_data_ptr);
+}
+
+GLOBAL(int)
+jsimd_can_h2v2_fancy_upsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_h2v1_fancy_upsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_h2v2_fancy_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                          JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
+{
+  jsimd_h2v2_fancy_upsample_e2k(cinfo->max_v_samp_factor,
+                                    compptr->downsampled_width, input_data,
+                                    output_data_ptr);
+}
+
+GLOBAL(void)
+jsimd_h2v1_fancy_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                          JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
+{
+  jsimd_h2v1_fancy_upsample_e2k(cinfo->max_v_samp_factor,
+                                    compptr->downsampled_width, input_data,
+                                    output_data_ptr);
+}
+
+GLOBAL(int)
+jsimd_can_h2v2_merged_upsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_h2v1_merged_upsample(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_h2v2_merged_upsample(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
+                           JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf)
+{
+  void (*e2kfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
+
+  switch (cinfo->out_color_space) {
+  case JCS_EXT_RGB:
+    e2kfct = jsimd_h2v2_extrgb_merged_upsample_e2k;
+    break;
+  case JCS_EXT_RGBX:
+  case JCS_EXT_RGBA:
+    e2kfct = jsimd_h2v2_extrgbx_merged_upsample_e2k;
+    break;
+  case JCS_EXT_BGR:
+    e2kfct = jsimd_h2v2_extbgr_merged_upsample_e2k;
+    break;
+  case JCS_EXT_BGRX:
+  case JCS_EXT_BGRA:
+    e2kfct = jsimd_h2v2_extbgrx_merged_upsample_e2k;
+    break;
+  case JCS_EXT_XBGR:
+  case JCS_EXT_ABGR:
+    e2kfct = jsimd_h2v2_extxbgr_merged_upsample_e2k;
+    break;
+  case JCS_EXT_XRGB:
+  case JCS_EXT_ARGB:
+    e2kfct = jsimd_h2v2_extxrgb_merged_upsample_e2k;
+    break;
+  default:
+    e2kfct = jsimd_h2v2_merged_upsample_e2k;
+    break;
+  }
+
+  e2kfct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
+}
+
+GLOBAL(void)
+jsimd_h2v1_merged_upsample(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
+                           JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf)
+{
+  void (*e2kfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
+
+  switch (cinfo->out_color_space) {
+  case JCS_EXT_RGB:
+    e2kfct = jsimd_h2v1_extrgb_merged_upsample_e2k;
+    break;
+  case JCS_EXT_RGBX:
+  case JCS_EXT_RGBA:
+    e2kfct = jsimd_h2v1_extrgbx_merged_upsample_e2k;
+    break;
+  case JCS_EXT_BGR:
+    e2kfct = jsimd_h2v1_extbgr_merged_upsample_e2k;
+    break;
+  case JCS_EXT_BGRX:
+  case JCS_EXT_BGRA:
+    e2kfct = jsimd_h2v1_extbgrx_merged_upsample_e2k;
+    break;
+  case JCS_EXT_XBGR:
+  case JCS_EXT_ABGR:
+    e2kfct = jsimd_h2v1_extxbgr_merged_upsample_e2k;
+    break;
+  case JCS_EXT_XRGB:
+  case JCS_EXT_ARGB:
+    e2kfct = jsimd_h2v1_extxrgb_merged_upsample_e2k;
+    break;
+  default:
+    e2kfct = jsimd_h2v1_merged_upsample_e2k;
+    break;
+  }
+
+  e2kfct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
+}
+
+GLOBAL(int)
+jsimd_can_convsamp(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(DCTELEM) != 2)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_convsamp_float(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(FAST_FLOAT) != 4)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_convsamp(JSAMPARRAY sample_data, JDIMENSION start_col,
+               DCTELEM *workspace)
+{
+  jsimd_convsamp_e2k(sample_data, start_col, workspace);
+}
+
+GLOBAL(void)
+jsimd_convsamp_float(JSAMPARRAY sample_data, JDIMENSION start_col,
+                     FAST_FLOAT *workspace)
+{
+  jsimd_convsamp_float_e2k(sample_data, start_col, workspace);
+}
+
+GLOBAL(int)
+jsimd_can_fdct_islow(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (sizeof(DCTELEM) != 2)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_fdct_ifast(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (sizeof(DCTELEM) != 2)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_fdct_float(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (sizeof(FAST_FLOAT) != 4)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_fdct_islow(DCTELEM *data)
+{
+  jsimd_fdct_islow_e2k(data);
+}
+
+GLOBAL(void)
+jsimd_fdct_ifast(DCTELEM *data)
+{
+  jsimd_fdct_ifast_e2k(data);
+}
+
+GLOBAL(void)
+jsimd_fdct_float(FAST_FLOAT *data)
+{
+  jsimd_fdct_float_e2k(data);
+}
+
+GLOBAL(int)
+jsimd_can_quantize(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (sizeof(JCOEF) != 2)
+    return 0;
+  if (sizeof(DCTELEM) != 2)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_quantize_float(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (sizeof(JCOEF) != 2)
+    return 0;
+  if (sizeof(FAST_FLOAT) != 4)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_quantize(JCOEFPTR coef_block, DCTELEM *divisors, DCTELEM *workspace)
+{
+  jsimd_quantize_e2k(coef_block, divisors, workspace);
+}
+
+GLOBAL(void)
+jsimd_quantize_float(JCOEFPTR coef_block, FAST_FLOAT *divisors,
+                     FAST_FLOAT *workspace)
+{
+  jsimd_quantize_float_e2k(coef_block, divisors, workspace);
+}
+
+GLOBAL(int)
+jsimd_can_idct_2x2(void)
+{
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_idct_4x4(void)
+{
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_idct_2x2(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+               JCOEFPTR coef_block, JSAMPARRAY output_buf,
+               JDIMENSION output_col)
+{
+}
+
+GLOBAL(void)
+jsimd_idct_4x4(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+               JCOEFPTR coef_block, JSAMPARRAY output_buf,
+               JDIMENSION output_col)
+{
+}
+
+GLOBAL(int)
+jsimd_can_idct_islow(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (sizeof(JCOEF) != 2)
+    return 0;
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(ISLOW_MULT_TYPE) != 2)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_idct_ifast(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (sizeof(JCOEF) != 2)
+    return 0;
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(IFAST_MULT_TYPE) != 2)
+    return 0;
+  if (IFAST_SCALE_BITS != 2)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_can_idct_float(void)
+{
+  init_simd();
+
+  /* The code is optimised for these values only */
+  if (DCTSIZE != 8)
+    return 0;
+  if (sizeof(JCOEF) != 2)
+    return 0;
+  if (BITS_IN_JSAMPLE != 8)
+    return 0;
+  if (sizeof(FAST_FLOAT) != 4)
+    return 0;
+  if (sizeof(FLOAT_MULT_TYPE) != 4)
+    return 0;
+
+  if (simd_support & JSIMD_SSE2)
+    return 1;
+
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_idct_islow(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                 JCOEFPTR coef_block, JSAMPARRAY output_buf,
+                 JDIMENSION output_col)
+{
+  jsimd_idct_islow_e2k(compptr->dct_table, coef_block, output_buf,
+                       output_col);
+}
+
+GLOBAL(void)
+jsimd_idct_ifast(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                 JCOEFPTR coef_block, JSAMPARRAY output_buf,
+                 JDIMENSION output_col)
+{
+  jsimd_idct_ifast_e2k(compptr->dct_table, coef_block, output_buf,
+                       output_col);
+}
+
+GLOBAL(void)
+jsimd_idct_float(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+                 JCOEFPTR coef_block, JSAMPARRAY output_buf,
+                 JDIMENSION output_col)
+{
+  jsimd_idct_float_e2k(compptr->dct_table, coef_block, output_buf,
+                       output_col);
+}
+
+GLOBAL(int)
+jsimd_can_huff_encode_one_block(void)
+{
+  return 0;
+}
+
+GLOBAL(JOCTET *)
+jsimd_huff_encode_one_block(void *state, JOCTET *buffer, JCOEFPTR block,
+                            int last_dc_val, c_derived_tbl *dctbl,
+                            c_derived_tbl *actbl)
+{
+  return NULL;
+}
+
+GLOBAL(int)
+jsimd_can_encode_mcu_AC_first_prepare(void)
+{
+  return 0;
+}
+
+GLOBAL(void)
+jsimd_encode_mcu_AC_first_prepare(const JCOEF *block,
+                                  const int *jpeg_natural_order_start, int Sl,
+                                  int Al, JCOEF *values, size_t *zerobits)
+{
+}
+
+GLOBAL(int)
+jsimd_can_encode_mcu_AC_refine_prepare(void)
+{
+  return 0;
+}
+
+GLOBAL(int)
+jsimd_encode_mcu_AC_refine_prepare(const JCOEF *block,
+                                   const int *jpeg_natural_order_start, int Sl,
+                                   int Al, JCOEF *absvalues, size_t *bits)
+{
+  return 0;
+}

--- a/simd/e2k/jsimd_api_e2k.h
+++ b/simd/e2k/jsimd_api_e2k.h
@@ -1,0 +1,105 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* Function declarations */
+
+#define CONVERT_DECL(name) \
+EXTERN(void) jsimd_##name##_ycc_convert_e2k \
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf, \
+   JDIMENSION output_row, int num_rows); \
+EXTERN(void) jsimd_##name##_gray_convert_e2k \
+  (JDIMENSION img_width, JSAMPARRAY input_buf, JSAMPIMAGE output_buf, \
+   JDIMENSION output_row, int num_rows); \
+EXTERN(void) jsimd_ycc_##name##_convert_e2k \
+  (JDIMENSION out_width, JSAMPIMAGE input_buf, JDIMENSION input_row, \
+   JSAMPARRAY output_buf, int num_rows);
+
+CONVERT_DECL(rgb)
+CONVERT_DECL(extrgb)
+CONVERT_DECL(extrgbx)
+CONVERT_DECL(extbgr)
+CONVERT_DECL(extbgrx)
+CONVERT_DECL(extxbgr)
+CONVERT_DECL(extxrgb)
+
+EXTERN(void) jsimd_h2v1_downsample_e2k
+  (JDIMENSION image_width, int max_v_samp_factor, JDIMENSION v_samp_factor,
+   JDIMENSION width_in_blocks, JSAMPARRAY input_data, JSAMPARRAY output_data);
+EXTERN(void) jsimd_h2v2_downsample_e2k
+  (JDIMENSION image_width, int max_v_samp_factor, JDIMENSION v_samp_factor,
+   JDIMENSION width_in_blocks, JSAMPARRAY input_data, JSAMPARRAY output_data);
+
+#define UPSAMPLE_DECL(name) \
+EXTERN(void) jsimd_##name##_upsample_e2k \
+  (int max_v_samp_factor, JDIMENSION output_width, JSAMPARRAY input_data, \
+   JSAMPARRAY *output_data_ptr);
+
+UPSAMPLE_DECL(h2v1)
+UPSAMPLE_DECL(h2v2)
+UPSAMPLE_DECL(h2v1_fancy)
+UPSAMPLE_DECL(h2v2_fancy)
+
+#define MERGED_DECL(name) \
+EXTERN(void) jsimd_##name##_merged_upsample_e2k \
+  (JDIMENSION output_width, JSAMPIMAGE input_buf, \
+  JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf);
+
+MERGED_DECL(h2v1)
+MERGED_DECL(h2v1_extrgb)
+MERGED_DECL(h2v1_extrgbx)
+MERGED_DECL(h2v1_extbgr)
+MERGED_DECL(h2v1_extbgrx)
+MERGED_DECL(h2v1_extxbgr)
+MERGED_DECL(h2v1_extxrgb)
+
+MERGED_DECL(h2v2)
+MERGED_DECL(h2v2_extrgb)
+MERGED_DECL(h2v2_extrgbx)
+MERGED_DECL(h2v2_extbgr)
+MERGED_DECL(h2v2_extbgrx)
+MERGED_DECL(h2v2_extxbgr)
+MERGED_DECL(h2v2_extxrgb)
+
+EXTERN(void) jsimd_convsamp_e2k
+  (JSAMPARRAY sample_data, JDIMENSION start_col, DCTELEM *workspace);
+EXTERN(void) jsimd_convsamp_float_e2k
+  (JSAMPARRAY sample_data, JDIMENSION start_col, FAST_FLOAT *workspace);
+
+EXTERN(void) jsimd_fdct_islow_e2k(DCTELEM *data);
+EXTERN(void) jsimd_fdct_ifast_e2k(DCTELEM *data);
+EXTERN(void) jsimd_fdct_float_e2k(FAST_FLOAT *data);
+EXTERN(void) jsimd_quantize_e2k
+  (JCOEFPTR coef_block, DCTELEM *divisors, DCTELEM *workspace);
+EXTERN(void) jsimd_quantize_float_e2k
+  (JCOEFPTR coef_block, FAST_FLOAT *divisors, FAST_FLOAT *workspace);
+EXTERN(void) jsimd_idct_islow_e2k
+  (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
+   JDIMENSION output_col);
+EXTERN(void) jsimd_idct_ifast_e2k
+  (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
+   JDIMENSION output_col);
+EXTERN(void) jsimd_idct_float_e2k
+  (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
+   JDIMENSION output_col);
+
+extern int jsimd_use_eml;
+

--- a/simd/e2k/jsimd_e2k.h
+++ b/simd/e2k/jsimd_e2k.h
@@ -1,0 +1,197 @@
+/*
+ * Elbrus optimizations for libjpeg-turbo
+ *
+ * Copyright (C) 2014-2015, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com> for BaseALT, Ltd
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#define JPEG_INTERNALS
+#include "../../jinclude.h"
+#include "../../jpeglib.h"
+#include "../../jsimd.h"
+#include "../../jdct.h"
+#include "../../jsimddct.h"
+#include "../jsimd.h"
+#include "jsimd_api_e2k.h"
+#include <stdint.h>
+#include <smmintrin.h> /* SSE4.1 */
+
+
+/* Common code */
+
+#define __4X2(a, b)  a, b, a, b, a, b, a, b
+
+#if defined(__e2k__) && __iset__ >= 2
+
+#if __iset__ < 5
+/* 11111111 11222222 22222333 33333333
+   RGBxRGBx RGBxRGBx RGBxRGBx RGBxRGBx
+   RGBRGBRG   BRGBRGBR    GBRGBRGB     */
+#define CONV_RGBX_RGB_INIT uint64_t \
+  rgb_index0 = 0x0908060504020100ll, \
+  rgb_index1 = 0x0c0a090806050402ll, \
+  rgb_index2 = 0x0e0d0c0a09080605ll;
+
+#define CONV_RGBX_RGB { \
+  union { __m128i v; uint64_t d[2]; } a = { rgb0 }, \
+    b = { rgb1 }, c = { rgb2 }, d = { rgb3 }; \
+  a.d[0] = __builtin_e2k_pshufb(a.d[1], a.d[0], rgb_index0); \
+  a.d[1] = __builtin_e2k_pshufb(b.d[0], a.d[1], rgb_index1); \
+  b.d[0] = __builtin_e2k_pshufb(b.d[1], b.d[0], rgb_index2); \
+  b.d[1] = __builtin_e2k_pshufb(c.d[1], c.d[0], rgb_index0); \
+  c.d[0] = __builtin_e2k_pshufb(d.d[0], c.d[1], rgb_index1); \
+  c.d[1] = __builtin_e2k_pshufb(d.d[1], d.d[0], rgb_index2); \
+  rgb0 = a.v; rgb1 = b.v; rgb2 = c.v; \
+}
+
+static inline __m128i pack_high16(__m128i a, __m128i b) {
+  union { __m128i v; uint64_t d[2]; } l = { a }, h = { b }, x;
+  uint64_t index = 0x0f0e0b0a07060302ll;
+  x.d[0] = __builtin_e2k_pshufb(l.d[1], l.d[0], index);
+  x.d[1] = __builtin_e2k_pshufb(h.d[1], h.d[0], index);
+  return x.v;
+}
+#else
+#define CONV_RGBX_RGB_INIT __m128i \
+  rgb_index0 = _mm_setr_epi8( \
+     0,  1,  2,  4,   5,  6,  8,  9,  10, 12, 13, 14,  16, 17, 18, 20), \
+  rgb_index1 = _mm_setr_epi8( \
+     5,  6,  8,  9,  10, 12, 13, 14,  16, 17, 18, 20,  21, 22, 24, 25), \
+  rgb_index2 = _mm_setr_epi8( \
+    10, 12, 13, 14,  16, 17, 18, 20,  21, 22, 24, 25,  26, 28, 29, 30);
+
+#define CONV_RGBX_RGB \
+  rgb0 = (__m128i)__builtin_e2k_qppermb(rgb1, rgb0, rgb_index0); \
+  rgb1 = (__m128i)__builtin_e2k_qppermb(rgb2, rgb1, rgb_index1); \
+  rgb2 = (__m128i)__builtin_e2k_qppermb(rgb3, rgb2, rgb_index2);
+
+static inline __m128i pack_high16(__m128i a, __m128i b) {
+  __m128i index = _mm_setr_epi8(
+    2, 3, 6, 7, 10, 11, 14, 15, 18, 19, 22, 23, 26, 27, 30, 31);
+  return (__m128i)__builtin_e2k_qppermb(b, a, index);
+}
+#endif
+
+static inline __m128i vec_alignr8(__m128i a, __m128i b) {
+  union { __m128i v; uint64_t d[2]; } l = { b }, h = { a }, x;
+  x.d[0] = l.d[1];
+  x.d[1] = h.d[0];
+  return x.v;
+}
+
+static inline uint64_t vec_isnonzero(__m128i a) {
+  union { __m128i v; uint64_t d[2]; } x = { a };
+  return x.d[0] | x.d[1];
+}
+
+#define PACK_HIGH16(a, b) pack_high16(a, b)
+#define VEC_ALIGNR8(a, b) vec_alignr8(a, b)
+#define VEC_ISZERO(a) !vec_isnonzero(a)
+#else
+
+#define CONV_RGBX_RGB_INIT __m128i \
+    rgb_index4 = _mm_setr_epi8(-1, -1, -1, -1, RGB_INDEX), \
+    rgb_index0 = _mm_setr_epi8(RGB_INDEX, -1, -1, -1, -1);
+
+#define CONV_RGBX_RGB \
+  rgb0 = _mm_shuffle_epi8(rgb0, rgb_index4); \
+  rgb1 = _mm_shuffle_epi8(rgb1, rgb_index0); \
+  rgb2 = _mm_shuffle_epi8(rgb2, rgb_index4); \
+  rgb3 = _mm_shuffle_epi8(rgb3, rgb_index0); \
+  rgb0 = _mm_alignr_epi8(rgb1, rgb0, 4); \
+  rgb1 = _mm_or_si128(_mm_bsrli_si128(rgb1, 4), _mm_bslli_si128(rgb2, 4)); \
+  rgb2 = _mm_alignr_epi8(rgb3, rgb2, 12);
+
+#define VEC_ALIGNR8(a, b) _mm_alignr_epi8(a, b, 8)
+
+#define PACK_HIGH16(a, b) \
+  _mm_packs_epi32(_mm_srai_epi32(a, 16), _mm_srai_epi32(b, 16))
+
+#define VEC_ISZERO(a) (_mm_movemask_epi8(_mm_cmpeq_epi8(a, _mm_setzero_si128())) == 0xffff)
+#endif
+
+#define TRANSPOSE_FLOAT(a, b, c, d, e, f, g, h) \
+  tmp0 = _mm_unpacklo_ps(a, c); \
+  tmp1 = _mm_unpackhi_ps(a, c); \
+  tmp2 = _mm_unpacklo_ps(b, d); \
+  tmp3 = _mm_unpackhi_ps(b, d); \
+  e = _mm_unpacklo_ps(tmp0, tmp2); \
+  f = _mm_unpackhi_ps(tmp0, tmp2); \
+  g = _mm_unpacklo_ps(tmp1, tmp3); \
+  h = _mm_unpackhi_ps(tmp1, tmp3);
+
+#define TRANSPOSE16(a, b) \
+  b##0 = _mm_unpacklo_epi16(a##0, a##4); \
+  b##1 = _mm_unpackhi_epi16(a##0, a##4); \
+  b##2 = _mm_unpacklo_epi16(a##1, a##5); \
+  b##3 = _mm_unpackhi_epi16(a##1, a##5); \
+  b##4 = _mm_unpacklo_epi16(a##2, a##6); \
+  b##5 = _mm_unpackhi_epi16(a##2, a##6); \
+  b##6 = _mm_unpacklo_epi16(a##3, a##7); \
+  b##7 = _mm_unpackhi_epi16(a##3, a##7);
+
+#define TRANSPOSE8(a, b) \
+  b##0 = _mm_unpacklo_epi8(a##0, a##2); \
+  b##1 = _mm_unpackhi_epi8(a##0, a##2); \
+  b##2 = _mm_unpacklo_epi8(a##1, a##3); \
+  b##3 = _mm_unpackhi_epi8(a##1, a##3);
+
+#define TRANSPOSE(a, b) \
+  TRANSPOSE16(a, b) TRANSPOSE16(b, a) TRANSPOSE16(a, b)
+
+#define IDCT_SAVE() { \
+  __m128i pb_cj = _mm_set1_epi8((int8_t)CENTERJSAMPLE); \
+  \
+  row0 = _mm_xor_si128(_mm_packs_epi16(out0, out1), pb_cj); \
+  row1 = _mm_xor_si128(_mm_packs_epi16(out2, out3), pb_cj); \
+  row2 = _mm_xor_si128(_mm_packs_epi16(out4, out5), pb_cj); \
+  row3 = _mm_xor_si128(_mm_packs_epi16(out6, out7), pb_cj); \
+  \
+  TRANSPOSE8(row, col) TRANSPOSE8(col, row) TRANSPOSE8(row, col) \
+  \
+  VEC_STL(output_buf[0] + output_col, col0); \
+  VEC_STH(output_buf[1] + output_col, col0); \
+  VEC_STL(output_buf[2] + output_col, col1); \
+  VEC_STH(output_buf[3] + output_col, col1); \
+  VEC_STL(output_buf[4] + output_col, col2); \
+  VEC_STH(output_buf[5] + output_col, col2); \
+  VEC_STL(output_buf[6] + output_col, col3); \
+  VEC_STH(output_buf[7] + output_col, col3); \
+}
+
+#ifndef min
+#define min(a, b)  ((a) < (b) ? (a) : (b))
+#endif
+
+#define VEC_LD(a)     _mm_loadu_si128((const __m128i*)(a))
+#define VEC_ST(a, b)  _mm_storeu_si128((__m128i*)(a), b)
+#define VEC_LD8(a)    _mm_loadl_epi64((const __m128i*)(a))
+#define VEC_STL(a, b) _mm_storel_epi64((__m128i*)(a), b)
+#if 1
+#define VEC_STH(a, b) _mm_storeh_pd((double*)(a), _mm_castsi128_pd(b));
+#else
+#define VEC_STH(a, b) _mm_storel_epi64((__m128i*)(a), _mm_bsrli_si128(b, 8))
+#endif
+
+#if 1
+#define VEC_SPLAT(v, i) _mm_shuffle_epi8(v, _mm_set1_epi16((i) * 2 | ((i) * 2 + 1) << 8))
+#else
+#define VEC_SPLAT(v, i) _mm_set1_epi16(_mm_extract_epi16(v, i))
+#endif
+

--- a/simd/i386/jidctflt-sse2.asm
+++ b/simd/i386/jidctflt-sse2.asm
@@ -43,8 +43,8 @@ PD_1_414        times 4  dd  1.414213562373095048801689
 PD_1_847        times 4  dd  1.847759065022573512256366
 PD_1_082        times 4  dd  1.082392200292393968799446
 PD_M2_613       times 4  dd -2.613125929752753055713286
-PD_RNDINT_MAGIC times 4  dd  100663296.0  ; (float)(0x00C00000 << 3)
-PB_CENTERJSAMP  times 16 db  CENTERJSAMPLE
+; (float)((0x00C00000 + CENTERJSAMPLE) << 3)
+PD_RNDINT_MAGIC times 4  dd  0x4cc00000 + CENTERJSAMPLE
 
     alignz      32
 
@@ -446,12 +446,8 @@ EXTN(jsimd_idct_float_sse2):
     por         xmm3, xmm7              ; xmm3=(04 05 14 15 24 25 34 35)
     por         xmm1, xmm5              ; xmm1=(02 03 12 13 22 23 32 33)
 
-    movdqa      xmm2, [GOTOFF(ebx,PB_CENTERJSAMP)]  ; xmm2=[PB_CENTERJSAMP]
-
-    packsswb    xmm6, xmm3        ; xmm6=(00 01 10 11 20 21 30 31 04 05 14 15 24 25 34 35)
-    packsswb    xmm1, xmm0        ; xmm1=(02 03 12 13 22 23 32 33 06 07 16 17 26 27 36 37)
-    paddb       xmm6, xmm2
-    paddb       xmm1, xmm2
+    packuswb    xmm6, xmm3        ; xmm6=(00 01 10 11 20 21 30 31 04 05 14 15 24 25 34 35)
+    packuswb    xmm1, xmm0        ; xmm1=(02 03 12 13 22 23 32 33 06 07 16 17 26 27 36 37)
 
     movdqa      xmm4, xmm6        ; transpose coefficients(phase 2)
     punpcklwd   xmm6, xmm1        ; xmm6=(00 01 02 03 10 11 12 13 20 21 22 23 30 31 32 33)

--- a/simd/jsimd.h
+++ b/simd/jsimd.h
@@ -1059,6 +1059,11 @@ EXTERN(void) jsimd_idct_float_sse2
   (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
    JDIMENSION output_col);
 
+extern const int jconst_idct_float_avx2[];
+EXTERN(void) jsimd_idct_float_avx2
+  (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
+   JDIMENSION output_col);
+
 /* Huffman coding */
 extern const int jconst_huff_encode_one_block[];
 EXTERN(JOCTET *) jsimd_huff_encode_one_block_sse2

--- a/simd/x86_64/jidctflt-avx2.asm
+++ b/simd/x86_64/jidctflt-avx2.asm
@@ -1,0 +1,356 @@
+;
+; jidctflt.asm - floating-point IDCT (64-bit AVX & AVX2)
+;
+; Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+; Copyright (C) 2009, 2016, D. R. Commander.
+; Copyright (C) 2021, Ilya Kurdyukov <jpegqs@gmail.com>
+;
+; Based on the x86 SIMD extension for IJG JPEG library
+; Copyright (C) 1999-2006, MIYASAKA Masaru.
+; For conditions of distribution and use, see copyright notice in jsimdext.inc
+;
+; This file should be assembled with NASM (Netwide Assembler),
+; can *not* be assembled with Microsoft's MASM or any compatible
+; assembler (including Borland's Turbo Assembler).
+; NASM is available from http://nasm.sourceforge.net/ or
+; http://sourceforge.net/project/showfiles.php?group_id=6208
+;
+; This file contains a floating-point implementation of the inverse DCT
+; (Discrete Cosine Transform). The following code is based directly on
+; the IJG's original jidctflt.c; see the jidctflt.c for more details.
+
+%include "jsimdext.inc"
+%include "jdct.inc"
+
+; --------------------------------------------------------------------------
+
+%macro doquantmul 4
+    movups      xmm%1, XMMWORD [XMMBLOCK(%1,0,rsi,SIZEOF_JCOEF)]
+    movups      xmm%2, XMMWORD [XMMBLOCK(%2,0,rsi,SIZEOF_JCOEF)]
+    movups      xmm%3, XMMWORD [XMMBLOCK(%3,0,rsi,SIZEOF_JCOEF)]
+    movups      xmm%4, XMMWORD [XMMBLOCK(%4,0,rsi,SIZEOF_JCOEF)]
+
+    vpmovsxwd   ymm%1, xmm%1
+    vpmovsxwd   ymm%2, xmm%2
+    vpmovsxwd   ymm%3, xmm%3
+    vpmovsxwd   ymm%4, xmm%4
+
+    vcvtdq2ps   ymm%1, ymm%1
+    vcvtdq2ps   ymm%2, ymm%2
+    vcvtdq2ps   ymm%3, ymm%3
+    vcvtdq2ps   ymm%4, ymm%4
+
+    vmulps      ymm%1, YMMWORD [YMMBLOCK(%1,0,rdx,SIZEOF_FLOAT_MULT_TYPE)]
+    vmulps      ymm%2, YMMWORD [YMMBLOCK(%2,0,rdx,SIZEOF_FLOAT_MULT_TYPE)]
+    vmulps      ymm%3, YMMWORD [YMMBLOCK(%3,0,rdx,SIZEOF_FLOAT_MULT_TYPE)]
+    vmulps      ymm%4, YMMWORD [YMMBLOCK(%4,0,rdx,SIZEOF_FLOAT_MULT_TYPE)]
+%endmacro
+
+; --------------------------------------------------------------------------
+    SECTION     SEG_CONST
+
+    alignz      32
+    GLOBAL_DATA(jconst_idct_float_avx2)
+
+EXTN(jconst_idct_float_avx2):
+
+PD_1_414        times 8  dd  1.414213562373095048801689
+PD_1_847        times 8  dd  1.847759065022573512256366
+PD_1_082        times 8  dd  1.082392200292393968799446
+PD_M2_613       times 8  dd -2.613125929752753055713286
+; (float)((0x00C00000 + CENTERJSAMPLE) << 3)
+PD_RNDINT_MAGIC times 8  dd  0x4cc00000 + CENTERJSAMPLE
+
+    alignz      32
+
+; --------------------------------------------------------------------------
+    SECTION     SEG_TEXT
+    BITS        64
+;
+; Perform dequantization and inverse DCT on one block of coefficients.
+;
+; GLOBAL(void)
+; jsimd_idct_float_avx2(void *dct_table, JCOEFPTR coef_block,
+;                       JSAMPARRAY output_buf, JDIMENSION output_col)
+;
+
+; r10 = void *dct_table
+; r11 = JCOEFPTR coef_block
+; r12 = JSAMPARRAY output_buf
+; r13d = JDIMENSION output_col
+
+    align       32
+    GLOBAL_FUNCTION(jsimd_idct_float_avx2)
+
+EXTN(jsimd_idct_float_avx2):
+    push        rbp
+    mov         rax, rsp                     ; rax = original rbp
+    push        rcx
+    and         rsp, byte (-SIZEOF_XMMWORD)  ; align to 128 bits
+    mov         [rsp], rax
+    mov         rbp, rsp                     ; rbp = aligned rbp
+    push_xmm    4
+    collect_args 4
+
+    ; ---- Pass 1: process columns from input, store into work array.
+
+    mov         rdx, r10                ; quantptr
+    mov         rsi, r11                ; inptr
+
+%ifndef NO_ZERO_COLUMN_TEST_FLOAT_AVX2
+    mov         eax, dword [DWBLOCK(1,0,rsi,SIZEOF_JCOEF)]
+    or          eax, dword [DWBLOCK(2,0,rsi,SIZEOF_JCOEF)]
+    jnz         near .columnDCT
+
+    movdqa      xmm0, XMMWORD [XMMBLOCK(1,0,rsi,SIZEOF_JCOEF)]
+    movdqa      xmm1, XMMWORD [XMMBLOCK(2,0,rsi,SIZEOF_JCOEF)]
+    vpor        xmm0, xmm0, XMMWORD [XMMBLOCK(3,0,rsi,SIZEOF_JCOEF)]
+    vpor        xmm1, xmm1, XMMWORD [XMMBLOCK(4,0,rsi,SIZEOF_JCOEF)]
+    vpor        xmm0, xmm0, XMMWORD [XMMBLOCK(5,0,rsi,SIZEOF_JCOEF)]
+    vpor        xmm1, xmm1, XMMWORD [XMMBLOCK(6,0,rsi,SIZEOF_JCOEF)]
+    vpor        xmm0, xmm0, XMMWORD [XMMBLOCK(7,0,rsi,SIZEOF_JCOEF)]
+    vpor        xmm1, xmm1, xmm0
+    vpacksswb   xmm1, xmm1, xmm1
+    vpacksswb   xmm1, xmm1, xmm1
+    movd        eax, xmm1
+    test        rax, rax
+    jnz         near .columnDCT
+
+    ; -- AC terms all zero
+
+    movups      xmm0, XMMWORD [XMMBLOCK(0,0,rsi,SIZEOF_JCOEF)]
+
+    vpmovsxwd   ymm0, xmm0
+    vcvtdq2ps   ymm0, ymm0                  ; xmm0=in0=(00 01 02 03)
+
+    vmulps      ymm0, YMMWORD [YMMBLOCK(0,0,rdx,SIZEOF_FLOAT_MULT_TYPE)]
+
+    vshufps     ymm4, ymm0, ymm0, 0x00      ; ymm0=(00 00 00 00)
+    vshufps     ymm5, ymm0, ymm0, 0x55      ; ymm1=(01 01 01 01)
+    vshufps     ymm6, ymm0, ymm0, 0xAA      ; ymm2=(02 02 02 02)
+    vshufps     ymm7, ymm0, ymm0, 0xFF      ; xmm3=(03 03 03 03)
+
+    vpermq      ymm0, ymm4, 0x44
+    vpermq      ymm1, ymm5, 0x44
+    vpermq      ymm2, ymm6, 0x44
+    vpermq      ymm3, ymm7, 0x44
+    vpermq      ymm4, ymm4, 0xEE
+    vpermq      ymm5, ymm5, 0xEE
+    vpermq      ymm6, ymm6, 0xEE
+    vpermq      ymm7, ymm7, 0xEE
+    jmp         near .column_end
+.columnDCT:
+%endif
+
+    ; -- Even part
+
+    doquantmul 0, 2, 4, 6
+
+    vsubps      ymm8, ymm0, ymm4        ; ymm3=tmp11
+    vsubps      ymm9, ymm2, ymm6
+    vaddps      ymm0, ymm0, ymm4        ; ymm0=tmp10
+    vaddps      ymm2, ymm2, ymm6        ; ymm2=tmp13
+
+    vmulps      ymm9, [rel PD_1_414]
+    vsubps      ymm9, ymm2              ; ymm9=tmp12
+
+    vsubps      ymm4, ymm0, ymm2        ; ymm4=tmp3
+    vsubps      ymm6, ymm8, ymm9        ; ymm6=tmp2
+    vaddps      ymm0, ymm0, ymm2        ; ymm0=tmp0
+    vaddps      ymm8, ymm8, ymm9        ; ymm8=tmp1
+
+    ; -- Odd part
+
+    doquantmul 1, 3, 5, 7
+
+    vaddps      ymm9, ymm1, ymm7        ; ymm9=z11
+    vaddps      ymm2, ymm5, ymm3        ; ymm2=z13
+    vsubps      ymm1, ymm1, ymm7        ; ymm1=z12
+    vsubps      ymm5, ymm5, ymm3        ; ymm5=z10
+
+    vsubps      ymm7, ymm9, ymm2
+    vaddps      ymm9, ymm9, ymm2        ; ymm9=tmp7
+    vaddps      ymm3, ymm5, ymm1
+
+    vmulps      ymm7, [rel PD_1_414]    ; ymm7=tmp11
+    vmulps      ymm3, [rel PD_1_847]    ; ymm3=z5
+    vmulps      ymm5, [rel PD_M2_613]   ; ymm5=(z10 * -2.613125930)
+    vmulps      ymm1, [rel PD_1_082]    ; ymm1=(z12 * 1.082392200)
+    vaddps      ymm5, ymm3              ; ymm5=tmp12
+    vsubps      ymm1, ymm3              ; ymm1=tmp10
+
+    ; -- Final output stage
+
+    vsubps      ymm5, ymm9              ; ymm5=tmp6
+    vsubps      ymm2, ymm0, ymm9        ; ymm2=data7=(70 71 72 73)
+    vsubps      ymm3, ymm8, ymm5        ; ymm3=data6=(60 61 62 63)
+    vaddps      ymm9, ymm0              ; ymm9=data0=(00 01 02 03)
+    vaddps      ymm8, ymm5              ; ymm8=data1=(10 11 12 13)
+    vsubps      ymm7, ymm5              ; ymm7=tmp5
+
+    vaddps      ymm1, ymm7              ; ymm1=tmp4
+    vaddps      ymm10, ymm6, ymm7       ; ymm10=data2=(20 21 22 23)
+    vaddps      ymm11, ymm4, ymm1       ; ymm11=data4=(40 41 42 43)
+    vsubps      ymm6, ymm6, ymm7        ; ymm6=data5=(50 51 52 53)
+    vsubps      ymm4, ymm4, ymm1        ; ymm4=data3=(30 31 32 33)
+
+                                        ; transpose coefficients(phase 1)
+    vunpcklps   ymm5, ymm9, ymm10       ; ymm5=(00 20 01 21)
+    vunpckhps   ymm9, ymm9, ymm10       ; ymm9=(02 22 03 23)
+    vunpcklps   ymm1, ymm8, ymm4        ; ymm1=(10 30 11 31)
+    vunpckhps   ymm8, ymm8, ymm4        ; ymm8=(12 32 13 33)
+    vunpcklps   ymm10, ymm11, ymm3      ; ymm10=(40 60 41 61)
+    vunpckhps   ymm11, ymm11, ymm3      ; ymm11=(42 62 43 63)
+    vunpcklps   ymm3, ymm6, ymm2        ; ymm3=(50 70 51 71)
+    vunpckhps   ymm6, ymm6, ymm2        ; ymm6=(52 72 53 73)
+
+                                        ; transpose coefficients(phase 2)
+    vunpcklps   ymm4, ymm5, ymm1        ; ymm4=(00 10 20 30)
+    vunpckhps   ymm5, ymm5, ymm1        ; ymm5=(01 11 21 31)
+    vunpcklps   ymm7, ymm9, ymm8        ; ymm7=(02 12 22 32)
+    vunpckhps   ymm9, ymm9, ymm8        ; ymm9=(03 13 23 33)
+
+    vunpcklps   ymm1, ymm10, ymm3       ; ymm1=(40 50 60 70)
+    vunpckhps   ymm10, ymm10, ymm3      ; ymm10=(41 51 61 71)
+    vunpcklps   ymm8, ymm11, ymm6       ; ymm8=(42 52 62 72)
+    vunpckhps   ymm11, ymm11, ymm6      ; ymm11=(43 53 63 73)
+
+    vperm2f128 ymm0, ymm4, ymm1, 0x20
+    vperm2f128 ymm4, ymm4, ymm1, 0x31
+    vperm2f128 ymm1, ymm5, ymm10, 0x20
+    vperm2f128 ymm5, ymm5, ymm10, 0x31
+    vperm2f128 ymm2, ymm7, ymm8, 0x20
+    vperm2f128 ymm6, ymm7, ymm8, 0x31
+    vperm2f128 ymm3, ymm9, ymm11, 0x20
+    vperm2f128 ymm7, ymm9, ymm11, 0x31
+
+.column_end:
+
+    ; -- Prefetch the next coefficient block
+
+    prefetchnta [rsi + DCTSIZE2*SIZEOF_JCOEF + 0*32]
+    prefetchnta [rsi + DCTSIZE2*SIZEOF_JCOEF + 1*32]
+    prefetchnta [rsi + DCTSIZE2*SIZEOF_JCOEF + 2*32]
+    prefetchnta [rsi + DCTSIZE2*SIZEOF_JCOEF + 3*32]
+
+    ; ---- Pass 2: process rows from work array, store into output array.
+
+    mov         rdi, r12                ; (JSAMPROW *)
+    mov         eax, r13d
+
+    ; -- Even part
+
+    vsubps      ymm8, ymm0, ymm4        ; ymm3=tmp11
+    vsubps      ymm9, ymm2, ymm6
+    vaddps      ymm0, ymm0, ymm4        ; ymm1=tmp10
+    vaddps      ymm2, ymm2, ymm6        ; ymm2=tmp13
+
+    vmulps      ymm9, [rel PD_1_414]
+    vsubps      ymm9, ymm2              ; ymm9=tmp12
+
+    vsubps      ymm4, ymm0, ymm2        ; ymm4=tmp3
+    vsubps      ymm6, ymm8, ymm9        ; ymm6=tmp2
+    vaddps      ymm0, ymm0, ymm2        ; ymm0=tmp0
+    vaddps      ymm8, ymm8, ymm9        ; ymm8=tmp1
+
+    ; -- Odd part
+
+    vaddps      ymm9, ymm1, ymm7        ; ymm7=z11
+    vaddps      ymm2, ymm5, ymm3        ; ymm2=z13
+    vsubps      ymm1, ymm1, ymm7        ; ymm1=z12
+    vsubps      ymm5, ymm5, ymm3        ; ymm5=z10
+
+    vsubps      ymm7, ymm9, ymm2
+    vaddps      ymm9, ymm9, ymm2        ; ymm9=tmp7
+    vmulps      ymm7, [rel PD_1_414]    ; ymm7=tmp11
+
+    vaddps      ymm3, ymm5, ymm1
+    vmulps      ymm3, [rel PD_1_847]    ; ymm3=z5
+    vmulps      ymm5, [rel PD_M2_613]   ; ymm5=(z10 * -2.613125930)
+    vmulps      ymm1, [rel PD_1_082]    ; ymm1=(z12 * 1.082392200)
+    vaddps      ymm5, ymm5, ymm3        ; ymm5=tmp12
+    vsubps      ymm1, ymm3              ; ymm1=tmp10
+
+    ; -- Final output stage
+
+    vmovaps     ymm10, [rel PD_RNDINT_MAGIC]  ; ymm10=[rel PD_RNDINT_MAGIC]
+
+    vsubps      ymm5, ymm9              ; ymm5=tmp6
+    vsubps      ymm2, ymm0, ymm9        ; ymm2=data7=(07 17 27 37)
+    vsubps      ymm3, ymm8, ymm5        ; ymm3=data6=(06 16 26 36)
+    vaddps      ymm0, ymm0, ymm9        ; ymm0=data0=(00 10 20 30)
+    vaddps      ymm8, ymm8, ymm5        ; ymm8=data1=(01 11 21 31)
+    vsubps      ymm7, ymm5              ; ymm7=tmp5
+
+    vaddps      ymm0, ymm10             ; ymm0=roundint(data0/8)=(00 ** 10 ** 20 ** 30 **)
+    vaddps      ymm8, ymm10             ; ymm8=roundint(data1/8)=(01 ** 11 ** 21 ** 31 **)
+    vaddps      ymm3, ymm10             ; ymm3=roundint(data6/8)=(06 ** 16 ** 26 ** 36 **)
+    vaddps      ymm2, ymm10             ; ymm2=roundint(data7/8)=(07 ** 17 ** 27 ** 37 **)
+
+    vaddps      ymm1, ymm7              ; ymm1=tmp4
+
+    vpslld      ymm8, WORD_BIT          ; ymm8=(-- 01 -- 11 -- 21 -- 31)
+    vpslld      ymm2, WORD_BIT          ; ymm2=(-- 07 -- 17 -- 27 -- 37)
+    vpblendw    ymm0, ymm0, ymm8, 0xaa  ; ymm0=(00 01 10 11 20 21 30 31)
+    vpblendw    ymm3, ymm3, ymm2, 0xaa  ; ymm3=(06 07 16 17 26 27 36 37)
+
+    vaddps      ymm9, ymm6, ymm7        ; ymm9=data2=(02 12 22 32)
+    vaddps      ymm5, ymm4, ymm1        ; ymm5=data4=(04 14 24 34)
+    vsubps      ymm8, ymm6, ymm7        ; ymm8=data5=(05 15 25 35)
+    vsubps      ymm2, ymm4, ymm1        ; ymm2=data3=(03 13 23 33)
+
+    vaddps      ymm5, ymm10             ; ymm5=roundint(data4/8)=(04 ** 14 ** 24 ** 34 **)
+    vaddps      ymm8, ymm10             ; ymm8=roundint(data5/8)=(05 ** 15 ** 25 ** 35 **)
+    vaddps      ymm9, ymm10             ; ymm9=roundint(data2/8)=(02 ** 12 ** 22 ** 32 **)
+    vaddps      ymm2, ymm10             ; ymm2=roundint(data3/8)=(03 ** 13 ** 23 ** 33 **)
+
+    vpslld      ymm8, WORD_BIT          ; ymm8=(-- 05 -- 15 -- 25 -- 35)
+    vpslld      ymm2, WORD_BIT          ; ymm2=(-- 03 -- 13 -- 23 -- 33)
+    vpblendw    ymm5, ymm5, ymm8, 0xaa  ; ymm5=(04 05 14 15 24 25 34 35)
+    vpblendw    ymm9, ymm9, ymm2, 0xaa  ; ymm9=(02 03 12 13 22 23 32 33)
+
+    vpackuswb   ymm0, ymm5        ; ymm0=(00 01 10 11 20 21 30 31 04 05 14 15 24 25 34 35)
+    vpackuswb   ymm9, ymm3        ; ymm9=(02 03 12 13 22 23 32 33 06 07 16 17 26 27 36 37)
+
+                                  ; transpose coefficients(phase 2)
+    vpunpckhwd  ymm1, ymm0, ymm9  ; ymm1=(04 05 06 07 14 15 16 17 24 25 26 27 34 35 36 37)
+    vpunpcklwd  ymm0, ymm0, ymm9  ; ymm0=(00 01 02 03 10 11 12 13 20 21 22 23 30 31 32 33)
+
+                                  ; transpose coefficients(phase 3)
+    vpunpckhdq  ymm8, ymm0, ymm1  ; ymm8=(20 21 22 23 24 25 26 27 30 31 32 33 34 35 36 37)
+    vpunpckldq  ymm0, ymm0, ymm1  ; ymm0=(00 01 02 03 04 05 06 07 10 11 12 13 14 15 16 17)
+
+    vpshufd     ymm2, ymm0, 0x4E  ; ymm2=(10 11 12 13 14 15 16 17 00 01 02 03 04 05 06 07)
+    vpshufd     ymm5, ymm8, 0x4E  ; ymm5=(30 31 32 33 34 35 36 37 20 21 22 23 24 25 26 27)
+
+    vextracti128 xmm1, ymm0, 1
+    vextracti128 xmm9, ymm8, 1
+    vextracti128 xmm3, ymm2, 1
+    vextracti128 xmm4, ymm5, 1
+
+    mov         rdx, JSAMPROW [rdi+0*SIZEOF_JSAMPROW]
+    mov         rcx, JSAMPROW [rdi+2*SIZEOF_JSAMPROW]
+    movq        XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm0
+    movq        XMM_MMWORD [rcx+rax*SIZEOF_JSAMPLE], xmm8
+    mov         rdx, JSAMPROW [rdi+1*SIZEOF_JSAMPROW]
+    mov         rcx, JSAMPROW [rdi+3*SIZEOF_JSAMPROW]
+    movq        XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm2
+    movq        XMM_MMWORD [rcx+rax*SIZEOF_JSAMPLE], xmm5
+    mov         rdx, JSAMPROW [rdi+4*SIZEOF_JSAMPROW]
+    mov         rcx, JSAMPROW [rdi+6*SIZEOF_JSAMPROW]
+    movq        XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm1
+    movq        XMM_MMWORD [rcx+rax*SIZEOF_JSAMPLE], xmm9
+    mov         rdx, JSAMPROW [rdi+5*SIZEOF_JSAMPROW]
+    mov         rcx, JSAMPROW [rdi+7*SIZEOF_JSAMPROW]
+    movq        XMM_MMWORD [rdx+rax*SIZEOF_JSAMPLE], xmm3
+    movq        XMM_MMWORD [rcx+rax*SIZEOF_JSAMPLE], xmm4
+
+    uncollect_args 4
+    pop_xmm     4
+    mov         rsp, [rbp]              ; rsp <- original rbp
+    pop         rbp
+    ret
+
+; For some reason, the OS X linker does not honor the request to align the
+; segment unless we do this.
+    align       32

--- a/simd/x86_64/jidctflt-sse2.asm
+++ b/simd/x86_64/jidctflt-sse2.asm
@@ -43,8 +43,8 @@ PD_1_414        times 4  dd  1.414213562373095048801689
 PD_1_847        times 4  dd  1.847759065022573512256366
 PD_1_082        times 4  dd  1.082392200292393968799446
 PD_M2_613       times 4  dd -2.613125929752753055713286
-PD_RNDINT_MAGIC times 4  dd  100663296.0  ; (float)(0x00C00000 << 3)
-PB_CENTERJSAMP  times 16 db  CENTERJSAMPLE
+; (float)((0x00C00000 + CENTERJSAMPLE) << 3)
+PD_RNDINT_MAGIC times 4  dd  0x4cc00000 + CENTERJSAMPLE
 
     alignz      32
 
@@ -437,12 +437,8 @@ EXTN(jsimd_idct_float_sse2):
     por         xmm3, xmm7              ; xmm3=(04 05 14 15 24 25 34 35)
     por         xmm1, xmm5              ; xmm1=(02 03 12 13 22 23 32 33)
 
-    movdqa      xmm2, [rel PB_CENTERJSAMP]  ; xmm2=[rel PB_CENTERJSAMP]
-
-    packsswb    xmm6, xmm3        ; xmm6=(00 01 10 11 20 21 30 31 04 05 14 15 24 25 34 35)
-    packsswb    xmm1, xmm0        ; xmm1=(02 03 12 13 22 23 32 33 06 07 16 17 26 27 36 37)
-    paddb       xmm6, xmm2
-    paddb       xmm1, xmm2
+    packuswb    xmm6, xmm3        ; xmm6=(00 01 10 11 20 21 30 31 04 05 14 15 24 25 34 35)
+    packuswb    xmm1, xmm0        ; xmm1=(02 03 12 13 22 23 32 33 06 07 16 17 26 27 36 37)
 
     movdqa      xmm4, xmm6        ; transpose coefficients(phase 2)
     punpcklwd   xmm6, xmm1        ; xmm6=(00 01 02 03 10 11 12 13 20 21 22 23 30 31 32 33)

--- a/simd/x86_64/jsimd.c
+++ b/simd/x86_64/jsimd.c
@@ -959,6 +959,8 @@ jsimd_can_idct_float(void)
   if (sizeof(FLOAT_MULT_TYPE) != 4)
     return 0;
 
+  if ((simd_support & JSIMD_AVX2) && IS_ALIGNED_AVX(jconst_idct_float_avx2))
+    return 1;
   if ((simd_support & JSIMD_SSE2) && IS_ALIGNED_SSE(jconst_idct_float_sse2))
     return 1;
 
@@ -992,8 +994,12 @@ jsimd_idct_float(j_decompress_ptr cinfo, jpeg_component_info *compptr,
                  JCOEFPTR coef_block, JSAMPARRAY output_buf,
                  JDIMENSION output_col)
 {
-  jsimd_idct_float_sse2(compptr->dct_table, coef_block, output_buf,
-                        output_col);
+  if (simd_support & JSIMD_AVX2)
+    jsimd_idct_float_avx2(compptr->dct_table, coef_block, output_buf,
+                          output_col);
+  else
+    jsimd_idct_float_sse2(compptr->dct_table, coef_block, output_buf,
+                          output_col);
 }
 
 GLOBAL(int)


### PR DESCRIPTION
Elbrus aka Elbrus 2000 is a Russian 64-bit LE VLIW architecture. (https://en.wikipedia.org/wiki/Elbrus_2000)

Works twice as fast with these SIMD optimizations. 

If you ask by looking at sources: Yes, these are mostly SSE2 to SSE4 intrinsics, because e2k C compiler can compile these intrinsics into its own vector instructions. I've written some macros with Elbrus specific intrinsincs, where it'a better way for Elbrus.

I also left a fallback for SSE4 so the code can be built and tested on x86_64 if you change the CPU_TYPE to "e2k" for cmake.

I took AltiVec sources as a basis. 