### PR TITLE
Use byte-swap builtins instead of inline asm on Arm

### DIFF
--- a/simd/arm/jchuff.h
+++ b/simd/arm/jchuff.h
@@ -56,24 +56,6 @@ typedef struct {
  */
 #if defined(__aarch64__) || defined(_M_ARM64)
 
-#if defined(_MSC_VER) && !defined(__clang__)
-#define SPLAT() { \
-  buffer[0] = (JOCTET)(put_buffer >> 56); \
-  buffer[1] = (JOCTET)(put_buffer >> 48); \
-  buffer[2] = (JOCTET)(put_buffer >> 40); \
-  buffer[3] = (JOCTET)(put_buffer >> 32); \
-  buffer[4] = (JOCTET)(put_buffer >> 24); \
-  buffer[5] = (JOCTET)(put_buffer >> 16); \
-  buffer[6] = (JOCTET)(put_buffer >>  8); \
-  buffer[7] = (JOCTET)(put_buffer      ); \
-}
-#else
-#define SPLAT() { \
-  __asm__("rev %x0, %x1" : "=r"(put_buffer) : "r"(put_buffer)); \
-  *((uint64_t *)buffer) = put_buffer; \
-}
-#endif
-
 #define FLUSH() { \
   if (put_buffer & 0x8080808080808080 & ~(put_buffer + 0x0101010101010101)) { \
     EMIT_BYTE(put_buffer >> 56) \
@@ -85,26 +67,12 @@ typedef struct {
     EMIT_BYTE(put_buffer >>  8) \
     EMIT_BYTE(put_buffer      ) \
   } else { \
-    SPLAT() \
+    *((uint64_t *)buffer) = BUILTIN_BSWAP64(put_buffer); \
     buffer += 8; \
   } \
 }
 
 #else
-
-#if defined(_MSC_VER) && !defined(__clang__)
-#define SPLAT() { \
-  buffer[0] = (JOCTET)(put_buffer >> 24); \
-  buffer[1] = (JOCTET)(put_buffer >> 16); \
-  buffer[2] = (JOCTET)(put_buffer >>  8); \
-  buffer[3] = (JOCTET)(put_buffer      ); \
-}
-#else
-#define SPLAT() { \
-  __asm__("rev %0, %1" : "=r"(put_buffer) : "r"(put_buffer)); \
-  *((uint32_t *)buffer) = put_buffer; \
-}
-#endif
 
 #define FLUSH() { \
   if (put_buffer & 0x80808080 & ~(put_buffer + 0x01010101)) { \
@@ -113,7 +81,7 @@ typedef struct {
     EMIT_BYTE(put_buffer >>  8) \
     EMIT_BYTE(put_buffer      ) \
   } else { \
-    SPLAT() \
+    *((uint32_t *)buffer) = BUILTIN_BSWAP32(put_buffer); \
     buffer += 4; \
   } \
 }

--- a/simd/arm/neon-compat.h.in
+++ b/simd/arm/neon-compat.h.in
@@ -23,13 +23,17 @@
 #cmakedefine HAVE_VLD1_U16_X2
 #cmakedefine HAVE_VLD1Q_U8_X4
 
-/* Define compiler-independent count-leading-zeros macros */
+/* Define compiler-independent count-leading-zeros and byte-swap macros */
 #if defined(_MSC_VER) && !defined(__clang__)
 #define BUILTIN_CLZ(x)  _CountLeadingZeros(x)
 #define BUILTIN_CLZLL(x)  _CountLeadingZeros64(x)
+#define BUILTIN_BSWAP32(x)  _byteswap_ulong(x)
+#define BUILTIN_BSWAP64(x)  _byteswap_uint64(x)
 #elif defined(__clang__) || defined(__GNUC__)
 #define BUILTIN_CLZ(x)  __builtin_clz(x)
 #define BUILTIN_CLZLL(x)  __builtin_clzll(x)
+#define BUILTIN_BSWAP32(x)  __builtin_bswap32(x)
+#define BUILTIN_BSWAP64(x)  __builtin_bswap64(x)
 #else
 #error "Unknown compiler"
 #endif


### PR DESCRIPTION
Define compiler-independent byte-swap macros and use them instead
of executing 'rev' via inline assembly code (or a slow shift-store
sequence on Windows).

Verified correctness on Linux (GCC and Clang) and Windows on Arm
(MSVC and clang-cl.)

Generated code does not change when compiling with Clang/LLVM
(32- or 64-bit), nor for 64-bit when compiling with GCC. 32-bit code
generated by GCC is slightly different but no perceptible performance
impact (+/- 0.5%.) 