### PR TITLE
Fix building with non-gcc/clang/msvc compiler

### DIFF
--- a/jchuff.c
+++ b/jchuff.c
@@ -8,6 +8,7 @@
  * Copyright (C) 2015, Matthieu Darbois.
  * Copyright (C) 2018, Matthias Räncker.
  * Copyright (C) 2020, Arm Limited.
+ * Copyright (C) 2021, The Qt Company
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -46,7 +47,7 @@
 
 #if defined(__arm__) || defined(__aarch64__) || defined(_M_ARM) || \
     defined(_M_ARM64)
-#if !defined(__thumb__) || defined(__thumb2__)
+#if (!defined(__thumb__) || defined(__thumb2__)) && (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))
 #define USE_CLZ_INTRINSIC
 #endif
 #endif

--- a/jcphuff.c
+++ b/jcphuff.c
@@ -7,6 +7,7 @@
  * Copyright (C) 2011, 2015, 2018, 2021, D. R. Commander.
  * Copyright (C) 2016, 2018, Matthieu Darbois.
  * Copyright (C) 2020, Arm Limited.
+ * Copyright (C) 2021, The Qt Company
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -54,7 +55,7 @@
 
 #if defined(__arm__) || defined(__aarch64__) || defined(_M_ARM) || \
     defined(_M_ARM64)
-#if !defined(__thumb__) || defined(__thumb2__)
+#if (!defined(__thumb__) || defined(__thumb2__)) && (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))
 #define USE_CLZ_INTRINSIC
 #endif
 #endif


### PR DESCRIPTION
Revealed when trying to build for INTEGRITY