### PR TITLE
jchuff.h: workaround a clang/llvm miscompilation on ARM 32-bit Thumb

### DIFF
--- a/simd/arm/jchuff.h
+++ b/simd/arm/jchuff.h
@@ -81,7 +81,8 @@ typedef struct {
     EMIT_BYTE(put_buffer >>  8) \
     EMIT_BYTE(put_buffer      ) \
   } else { \
-    *((uint32_t *)buffer) = BUILTIN_BSWAP32(put_buffer); \
+    uint32_t tmp = BUILTIN_BSWAP32(put_buffer); \
+    memcpy(buffer, &tmp, sizeof(tmp)); \
     buffer += 4; \
   } \
 }


### PR DESCRIPTION
This commits workarounds an issue [1] affecting various versions of
clang/llvm (from clang 9.0 to 12.0) including the versions provided by
the Android NDK (r21e, r22b), causing the FLUSH macro to be miscompiled
on ARM 32-bit Thumb.

The following part of the FLUSH macro:

    *((uint32_t *)buffer) = BUILTIN_BSWAP32(put_buffer);
    buffer += 4;

Gets compiled (using -O2 -mthumb) to:

    rev     r0, r0
    stmia   r1!, {r0}

Causing a crash (sigbus: illegal alignment) when the destination buffer
is not aligned.

This workaround (using memcpy) compiles to:

    rev     r0, r0
    str.w   r0, [r1], #4

Which is not subject to alignment issues.

[1]: https://bugs.llvm.org/show_bug.cgi?id=50785