### PR TITLE
Fix -Wimplicit-fallthrough for Clang.

### DIFF
--- a/jcmaster.c
+++ b/jcmaster.c
@@ -493,7 +493,7 @@ prepare_for_pass(j_compress_ptr cinfo)
     master->pass_type = output_pass;
     master->pass_number++;
 #endif
-    FALLTHROUGH;
+    FALLTHROUGH;  /*FALLTHROUGH*/
   case output_pass:
     /* Do a data-output pass. */
     /* We need not repeat per-scan setup if prior optimization pass did it. */

--- a/jcmaster.c
+++ b/jcmaster.c
@@ -493,7 +493,7 @@ prepare_for_pass(j_compress_ptr cinfo)
     master->pass_type = output_pass;
     master->pass_number++;
 #endif
-    /*FALLTHROUGH*/
+    FALLTHROUGH;
   case output_pass:
     /* Do a data-output pass. */
     /* We need not repeat per-scan setup if prior optimization pass did it. */

--- a/jconfigint.h.in
+++ b/jconfigint.h.in
@@ -32,3 +32,14 @@
 #define HAVE_BITSCANFORWARD
 #endif
 #endif
+
+/* Attribute to annotate explicit fallthrough. */
+#if defined __has_attribute
+#if __has_attribute(fallthrough)
+#define FALLTHROUGH __attribute__((fallthrough))
+#else
+#define FALLTHROUGH
+#endif
+#else
+#define FALLTHROUGH
+#endif

--- a/jdapimin.c
+++ b/jdapimin.c
@@ -23,6 +23,7 @@
 #include "jinclude.h"
 #include "jpeglib.h"
 #include "jdmaster.h"
+#include "jconfigint.h"
 
 
 /*
@@ -308,7 +309,7 @@ jpeg_consume_input(j_decompress_ptr cinfo)
     /* Initialize application's data source module */
     (*cinfo->src->init_source) (cinfo);
     cinfo->global_state = DSTATE_INHEADER;
-    FALLTHROUGH;
+    FALLTHROUGH;                       /*FALLTHROUGH*/
   case DSTATE_INHEADER:
     retcode = (*cinfo->inputctl->consume_input) (cinfo);
     if (retcode == JPEG_REACHED_SOS) { /* Found SOS, prepare to decompress */

--- a/jdapimin.c
+++ b/jdapimin.c
@@ -308,7 +308,7 @@ jpeg_consume_input(j_decompress_ptr cinfo)
     /* Initialize application's data source module */
     (*cinfo->src->init_source) (cinfo);
     cinfo->global_state = DSTATE_INHEADER;
-    /*FALLTHROUGH*/
+    FALLTHROUGH;
   case DSTATE_INHEADER:
     retcode = (*cinfo->inputctl->consume_input) (cinfo);
     if (retcode == JPEG_REACHED_SOS) { /* Found SOS, prepare to decompress */

--- a/jdmainct.c
+++ b/jdmainct.c
@@ -360,7 +360,7 @@ process_data_context_main(j_decompress_ptr cinfo, JSAMPARRAY output_buf,
     main_ptr->context_state = CTX_PREPARE_FOR_IMCU;
     if (*out_row_ctr >= out_rows_avail)
       return;                   /* Postprocessor exactly filled output buf */
-    /*FALLTHROUGH*/
+    FALLTHROUGH;
   case CTX_PREPARE_FOR_IMCU:
     /* Prepare to process first M-1 row groups of this iMCU row */
     main_ptr->rowgroup_ctr = 0;
@@ -371,7 +371,7 @@ process_data_context_main(j_decompress_ptr cinfo, JSAMPARRAY output_buf,
     if (main_ptr->iMCU_row_ctr == cinfo->total_iMCU_rows)
       set_bottom_pointers(cinfo);
     main_ptr->context_state = CTX_PROCESS_IMCU;
-    /*FALLTHROUGH*/
+    FALLTHROUGH;
   case CTX_PROCESS_IMCU:
     /* Call postprocessor using previously set pointers */
     (*cinfo->post->post_process_data) (cinfo,

--- a/jdmainct.c
+++ b/jdmainct.c
@@ -18,6 +18,7 @@
 
 #include "jinclude.h"
 #include "jdmainct.h"
+#include "jconfigint.h"
 
 
 /*
@@ -360,7 +361,7 @@ process_data_context_main(j_decompress_ptr cinfo, JSAMPARRAY output_buf,
     main_ptr->context_state = CTX_PREPARE_FOR_IMCU;
     if (*out_row_ctr >= out_rows_avail)
       return;                   /* Postprocessor exactly filled output buf */
-    FALLTHROUGH;
+    FALLTHROUGH;                /*FALLTHROUGH*/
   case CTX_PREPARE_FOR_IMCU:
     /* Prepare to process first M-1 row groups of this iMCU row */
     main_ptr->rowgroup_ctr = 0;
@@ -371,7 +372,7 @@ process_data_context_main(j_decompress_ptr cinfo, JSAMPARRAY output_buf,
     if (main_ptr->iMCU_row_ctr == cinfo->total_iMCU_rows)
       set_bottom_pointers(cinfo);
     main_ptr->context_state = CTX_PROCESS_IMCU;
-    FALLTHROUGH;
+    FALLTHROUGH;                /*FALLTHROUGH*/
   case CTX_PROCESS_IMCU:
     /* Call postprocessor using previously set pointers */
     (*cinfo->post->post_process_data) (cinfo,

--- a/jinclude.h
+++ b/jinclude.h
@@ -86,3 +86,18 @@
   ((size_t)fread((void *)(buf), (size_t)1, (size_t)(sizeofbuf), (file)))
 #define JFWRITE(file, buf, sizeofbuf) \
   ((size_t)fwrite((const void *)(buf), (size_t)1, (size_t)(sizeofbuf), (file)))
+
+/* Attribute to annotate explicit fallthrough. As noted on
+ * https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005fattribute.html ,
+ * combining the two tests in one conditional would not be portable.
+ */
+
+#if defined __has_attribute
+#if __has_attribute(fallthrough)
+#define FALLTHROUGH __attribute__((fallthrough))
+#else
+#define FALLTHROUGH
+#endif
+#else
+#define FALLTHROUGH
+#endif

--- a/jinclude.h
+++ b/jinclude.h
@@ -86,18 +86,3 @@
   ((size_t)fread((void *)(buf), (size_t)1, (size_t)(sizeofbuf), (file)))
 #define JFWRITE(file, buf, sizeofbuf) \
   ((size_t)fwrite((const void *)(buf), (size_t)1, (size_t)(sizeofbuf), (file)))
-
-/* Attribute to annotate explicit fallthrough. As noted on
- * https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005fattribute.html ,
- * combining the two tests in one conditional would not be portable.
- */
-
-#if defined __has_attribute
-#if __has_attribute(fallthrough)
-#define FALLTHROUGH __attribute__((fallthrough))
-#else
-#define FALLTHROUGH
-#endif
-#else
-#define FALLTHROUGH
-#endif


### PR DESCRIPTION
The existing /*FALLTHROUGH*/ annotations worked for gcc, but not clang.
Change to a macro that uses an attribute on supported compilers.

Bug: chromium:995993