### PR TITLE
Use __builtin_align_up for PAD() if available

### DIFF
--- a/jcphuff.c
+++ b/jcphuff.c
@@ -149,8 +149,6 @@ typedef phuff_entropy_encoder *phuff_entropy_ptr;
 #define IRIGHT_SHIFT(x, shft)   ((x) >> (shft))
 #endif
 
-#define PAD(v, p)  ((v + (p) - 1) & (~((p) - 1)))
-
 /* Forward declarations */
 METHODDEF(boolean) encode_mcu_DC_first(j_compress_ptr cinfo,
                                        JBLOCKROW *MCU_data);

--- a/jpegint.h
+++ b/jpegint.h
@@ -303,6 +303,7 @@ struct jpeg_color_quantizer {
 #define RIGHT_SHIFT(x, shft)    ((x) >> (shft))
 #endif
 
+#define PAD(v, p) (((v) + (p) - 1) & (~((p) - 1)))
 
 /* Compression module initialization routines */
 EXTERN(void) jinit_compress_master(j_compress_ptr cinfo);

--- a/jpegint.h
+++ b/jpegint.h
@@ -303,7 +303,15 @@ struct jpeg_color_quantizer {
 #define RIGHT_SHIFT(x, shft)    ((x) >> (shft))
 #endif
 
+#if !defined(__has_builtin)
+#define __has_builtin(...) 0
+#endif
+#if __has_builtin(__builtin_align_up)
+#define PAD(v, p) __builtin_align_up(v, p)
+#else
 #define PAD(v, p) (((v) + (p) - 1) & (~((p) - 1)))
+#endif
+
 
 /* Compression module initialization routines */
 EXTERN(void) jinit_compress_master(j_compress_ptr cinfo);

--- a/tjunittest.c
+++ b/tjunittest.c
@@ -268,8 +268,6 @@ bailout:
 }
 
 
-#define PAD(v, p)  ((v + (p) - 1) & (~((p) - 1)))
-
 static int checkBufYUV(unsigned char *buf, int w, int h, int subsamp,
                        tjscalingfactor sf)
 {

--- a/turbojpeg.c
+++ b/turbojpeg.c
@@ -50,7 +50,6 @@ extern void jpeg_mem_dest_tj(j_compress_ptr, unsigned char **, unsigned long *,
 extern void jpeg_mem_src_tj(j_decompress_ptr, const unsigned char *,
                             unsigned long);
 
-#define PAD(v, p)  ((v + (p) - 1) & (~((p) - 1)))
 #define IS_POW2(x)  (((x) & (x - 1)) == 0)
 
 


### PR DESCRIPTION
Clang 10+ includes builtins for checking and adjusting alignment without
casting from pointer to integer:
https://clang.llvm.org/docs/LanguageExtensions.html#alignment-builtins

These builtins provide better argument checking (for example they check if
the second argument is a power-of-two) and they are type-preserving.
Additionally, they are defined to work for pointer arguments so we could
remove pointer-to-integer casts that adversely affect the compiler's
analysis passes.