### PR TITLE
Cast pointer arguments to PAD() to uintptr_t instead of size_t

### DIFF
--- a/jcphuff.c
+++ b/jcphuff.c
@@ -680,7 +680,7 @@ encode_mcu_AC_first(j_compress_ptr cinfo, JBLOCKROW *MCU_data)
       emit_restart(entropy, entropy->next_restart_num);
 
 #ifdef WITH_SIMD
-  cvalue = values = (JCOEF *)PAD((size_t)values_unaligned, 16);
+  cvalue = values = (JCOEF *)PAD((JUINTPTR)values_unaligned, 16);
 #else
   /* Not using SIMD, so alignment is not needed */
   cvalue = values = values_unaligned;
@@ -945,7 +945,7 @@ encode_mcu_AC_refine(j_compress_ptr cinfo, JBLOCKROW *MCU_data)
       emit_restart(entropy, entropy->next_restart_num);
 
 #ifdef WITH_SIMD
-  cabsvalue = absvalues = (JCOEF *)PAD((size_t)absvalues_unaligned, 16);
+  cabsvalue = absvalues = (JCOEF *)PAD((JUINTPTR)absvalues_unaligned, 16);
 #else
   /* Not using SIMD, so alignment is not needed */
   cabsvalue = absvalues = absvalues_unaligned;

--- a/jpegint.h
+++ b/jpegint.h
@@ -47,6 +47,19 @@ typedef enum {            /* Operating modes for buffer controllers */
 /* JLONG must hold at least signed 32-bit values. */
 typedef long JLONG;
 
+/*
+ * JUINTPTR must be able hold pointer values. Once C99 is required this can
+ * be replaced with uintptr_t from ≤stdint.h>.
+ */
+#ifdef __UINTPTR_TYPE__
+/*
+ * GCC 4.6 and Clang 3.0 provide __UINTPTR_TYPE__ that can be used to avoid
+ * a dependency on C99's stdint.h.
+ */
+typedef __UINTPTR_TYPE__ JUINTPTR;
+#else
+typedef size_t JUINTPTR;
+#endif
 
 /*
  * Left shift macro that handles a negative operand without causing any

--- a/turbojpeg.c
+++ b/turbojpeg.c
@@ -845,7 +845,7 @@ DLLEXPORT int tjEncodeYUVPlanes(tjhandle handle, const unsigned char *srcBuf,
       THROW("tjEncodeYUVPlanes(): Memory allocation failure");
     for (row = 0; row < cinfo->max_v_samp_factor; row++) {
       unsigned char *_tmpbuf_aligned =
-        (unsigned char *)PAD((size_t)_tmpbuf[i], 32);
+        (unsigned char *)PAD((JUINTPTR)_tmpbuf[i], 32);
 
       tmpbuf[i][row] = &_tmpbuf_aligned[
         PAD((compptr->width_in_blocks * cinfo->max_h_samp_factor * DCTSIZE) /
@@ -861,7 +861,7 @@ DLLEXPORT int tjEncodeYUVPlanes(tjhandle handle, const unsigned char *srcBuf,
       THROW("tjEncodeYUVPlanes(): Memory allocation failure");
     for (row = 0; row < compptr->v_samp_factor; row++) {
       unsigned char *_tmpbuf2_aligned =
-        (unsigned char *)PAD((size_t)_tmpbuf2[i], 32);
+        (unsigned char *)PAD((JUINTPTR)_tmpbuf2[i], 32);
 
       tmpbuf2[i][row] =
         &_tmpbuf2_aligned[PAD(compptr->width_in_blocks * DCTSIZE, 32) * row];
@@ -1524,7 +1524,7 @@ DLLEXPORT int tjDecodeYUVPlanes(tjhandle handle,
       THROW("tjDecodeYUVPlanes(): Memory allocation failure");
     for (row = 0; row < compptr->v_samp_factor; row++) {
       unsigned char *_tmpbuf_aligned =
-        (unsigned char *)PAD((size_t)_tmpbuf[i], 32);
+        (unsigned char *)PAD((JUINTPTR)_tmpbuf[i], 32);
 
       tmpbuf[i][row] =
         &_tmpbuf_aligned[PAD(compptr->width_in_blocks * DCTSIZE, 32) * row];


### PR DESCRIPTION
The C standard does not guarantee that size_t is large enough to hold a
pointer value (e.g. 32-bit size_t and 64-bit pointers), so this cast can
strip parts of the pointer value. Casting to uintptr_t avoids this problem
since (u)intptr_t is defined as the integer type that can hold a pointer.

This change allows libjpeg-turbo to be compiled for CHERI-enabled
architectures (e.g. CHERI-RISC-V or Arm's Morello), since pointers are
twice the size of size_t (128 bits for Morello and RV64) and this cast
via size_t creates a non-dereferenceable pointer.
This is flagged by the following compiler warning:
```
warning: cast from provenance-free integer type to pointer type will give pointer that can not be dereferenced [-Werror,-Wcheri-capability-misuse]
  cvalue = values = (JCOEF *)PAD((size_t)values_unaligned, 16);
```
Not fixing this warning will result in a run-time crash since on CHERI
casting a pointer to a non-uintptr_t integer and back will result in
a pointer without the validity bit set. On dereference this then results
in a trap. With this patch I am able to successfully run the test suite
on CHERI-RISC-V without any failures.

Since C89 is still supported this patch introduces a JUINTPTR typedef
that can be used to avoid the C99 <stdint.h>.