### PR TITLE
Neon: Do not put functions into .rodata section

### DIFF
--- a/simd/arm/aarch64/jsimd_neon.S
+++ b/simd/arm/aarch64/jsimd_neon.S
@@ -185,6 +185,8 @@ Ljsimd_huff_encode_one_block_neon_consts:
 
 /*****************************************************************************/
 
+.text
+
 /* Supplementary macro for setting function attributes */
 .macro asm_function fname
 #ifdef __APPLE__


### PR DESCRIPTION
jsimd_neon.S contains `.section .rodata` directive at the beginning
of the file but didn't have `.text` before function definitions.
As a result, executable code in this file was written to .rodata,
which makes the entire .rodata section in libjpeg.so executable.
This is bad from a security standpoint.