### PR TITLE
Add AltiVec detection on FreeBSD

### DIFF
--- a/simd/powerpc/jsimd.c
+++ b/simd/powerpc/jsimd.c
@@ -35,6 +35,9 @@
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #include <machine/cpu.h>
+#elif defined(__FreeBSD__)
+#include <machine/cpu.h>
+#include <sys/auxv.h>
 #endif
 
 static unsigned int simd_support = ~0;
@@ -122,6 +125,8 @@ init_simd(void)
   int mib[2] = { CTL_MACHDEP, CPU_ALTIVEC };
   int altivec;
   size_t len = sizeof(altivec);
+#elif defined(__FreeBSD__)
+  unsigned long cpufeatures = 0;
 #endif
 
   if (simd_support != ~0U)
@@ -143,6 +148,10 @@ init_simd(void)
     simd_support |= JSIMD_ALTIVEC;
 #elif defined(__OpenBSD__)
   if (sysctl(mib, 2, &altivec, &len, NULL, 0) == 0 && altivec != 0)
+    simd_support |= JSIMD_ALTIVEC;
+#elif defined(__FreeBSD__)
+  elf_aux_info(AT_HWCAP, &cpufeatures, sizeof(cpufeatures));
+  if(cpufeatures & PPC_FEATURE_HAS_ALTIVEC)
     simd_support |= JSIMD_ALTIVEC;
 #endif
 


### PR DESCRIPTION
After all, there's no such MIB on FreeBSD. PPC_FEATURE_HAS_ALTIVEC is used for elf aux vector querying. cpu_features is provided in a header.