### PR TITLE
Build: Set CMP0065 NEW (respect ENABLE_EXPORTS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 2.8.12)
 
+if(POLICY CMP0065)
+  cmake_policy(SET CMP0065 NEW)
+endif()
+
 if(CMAKE_EXECUTABLE_SUFFIX)
   set(CMAKE_EXECUTABLE_SUFFIX_TMP ${CMAKE_EXECUTABLE_SUFFIX})
 endif()


### PR DESCRIPTION
This was apparently inadvertently enabled in the cmake transition, since
-rdynamic/-export-dynamic is not used by the autoconf system. It
shouldn't be needed for libjpeg-turbo because it doesn't have any plugin
system or even use dlopen.

On my machine, this reduces jpegtran-static size by 8192 bytes and
tjexample by 4096 bytes, with other binaries unchanged. The exact amount
will vary depending on machine architecture and optimization flags.