### PR TITLE
Fast ac tables

### DIFF
--- a/jcmaster.c
+++ b/jcmaster.c
@@ -16,6 +16,8 @@
  */
 
 #define JPEG_INTERNALS
+
+#include <jconfigint.h>
 #include "jinclude.h"
 #include "jpeglib.h"
 #include "jpegcomp.h"
@@ -493,7 +495,7 @@ prepare_for_pass(j_compress_ptr cinfo)
     master->pass_type = output_pass;
     master->pass_number++;
 #endif
-    FALLTHROUGH                 /*FALLTHROUGH*/
+    FALLTHROUGH;                 /*FALLTHROUGH*/
   case output_pass:
     /* Do a data-output pass. */
     /* We need not repeat per-scan setup if prior optimization pass did it. */

--- a/jdapimin.c
+++ b/jdapimin.c
@@ -20,6 +20,8 @@
  */
 
 #define JPEG_INTERNALS
+
+#include <jconfigint.h>
 #include "jinclude.h"
 #include "jpeglib.h"
 #include "jdmaster.h"

--- a/jdhuff.c
+++ b/jdhuff.c
@@ -22,6 +22,7 @@
  */
 
 #define JPEG_INTERNALS
+
 #include "jinclude.h"
 #include "jpeglib.h"
 #include "jdhuff.h"             /* Declarations shared with jdphuff.c */
@@ -37,96 +38,100 @@
  */
 
 typedef struct {
-  int last_dc_val[MAX_COMPS_IN_SCAN]; /* last DC coef for each component */
+    int last_dc_val[MAX_COMPS_IN_SCAN]; /* last DC coef for each component */
 } savable_state;
 
 typedef struct {
-  struct jpeg_entropy_decoder pub; /* public fields */
+    struct jpeg_entropy_decoder pub; /* public fields */
 
-  /* These fields are loaded into local variables at start of each MCU.
-   * In case of suspension, we exit WITHOUT updating them.
-   */
-  bitread_perm_state bitstate;  /* Bit buffer at start of MCU */
-  savable_state saved;          /* Other state at start of MCU */
+    /* These fields are loaded into local variables at start of each MCU.
+     * In case of suspension, we exit WITHOUT updating them.
+     */
+    bitread_perm_state bitstate;  /* Bit buffer at start of MCU */
+    savable_state saved;          /* Other state at start of MCU */
 
-  /* These fields are NOT loaded into local working state. */
-  unsigned int restarts_to_go;  /* MCUs left in this restart interval */
+    /* These fields are NOT loaded into local working state. */
+    unsigned int restarts_to_go;  /* MCUs left in this restart interval */
 
-  /* Pointers to derived tables (these workspaces have image lifespan) */
-  d_derived_tbl *dc_derived_tbls[NUM_HUFF_TBLS];
-  d_derived_tbl *ac_derived_tbls[NUM_HUFF_TBLS];
+    /* Pointers to derived tables (these workspaces have image lifespan) */
+    d_derived_tbl *dc_derived_tbls[NUM_HUFF_TBLS];
+    d_derived_tbl *ac_derived_tbls[NUM_HUFF_TBLS];
 
-  /* Precalculated info set up by start_pass for use in decode_mcu: */
+    /* Precalculated info set up by start_pass for use in decode_mcu: */
 
-  /* Pointers to derived tables to be used for each block within an MCU */
-  d_derived_tbl *dc_cur_tbls[D_MAX_BLOCKS_IN_MCU];
-  d_derived_tbl *ac_cur_tbls[D_MAX_BLOCKS_IN_MCU];
-  /* Whether we care about the DC and AC coefficient values for each block */
-  boolean dc_needed[D_MAX_BLOCKS_IN_MCU];
-  boolean ac_needed[D_MAX_BLOCKS_IN_MCU];
+    /* Pointers to derived tables to be used for each block within an MCU */
+    d_derived_tbl *dc_cur_tbls[D_MAX_BLOCKS_IN_MCU];
+    d_derived_tbl *ac_cur_tbls[D_MAX_BLOCKS_IN_MCU];
+    /* Whether we care about the DC and AC coefficient values for each block */
+    boolean dc_needed[D_MAX_BLOCKS_IN_MCU];
+    boolean ac_needed[D_MAX_BLOCKS_IN_MCU];
+    /*Fast AC Huffman tables that do a decode and a receive extend*/
+    int fast_ac_tables[NUM_HUFF_TBLS][1 << HUFF_LOOKAHEAD]
+
 } huff_entropy_decoder;
 
 typedef huff_entropy_decoder *huff_entropy_ptr;
 
 
+LOCAL(void) jpeg_make_fast_ac_tables(j_decompress_ptr cinfo, huff_entropy_ptr entropy, int tblno);
 /*
  * Initialize for a Huffman-compressed scan.
  */
 
 METHODDEF(void)
-start_pass_huff_decoder(j_decompress_ptr cinfo)
-{
-  huff_entropy_ptr entropy = (huff_entropy_ptr)cinfo->entropy;
-  int ci, blkn, dctbl, actbl;
-  d_derived_tbl **pdtbl;
-  jpeg_component_info *compptr;
+start_pass_huff_decoder(j_decompress_ptr cinfo) {
+    huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
+    int ci, blkn, dctbl, actbl;
+    d_derived_tbl **pdtbl;
+    jpeg_component_info *compptr;
 
-  /* Check that the scan parameters Ss, Se, Ah/Al are OK for sequential JPEG.
-   * This ought to be an error condition, but we make it a warning because
-   * there are some baseline files out there with all zeroes in these bytes.
-   */
-  if (cinfo->Ss != 0 || cinfo->Se != DCTSIZE2 - 1 ||
-      cinfo->Ah != 0 || cinfo->Al != 0)
-    WARNMS(cinfo, JWRN_NOT_SEQUENTIAL);
+    /* Check that the scan parameters Ss, Se, Ah/Al are OK for sequential JPEG.
+     * This ought to be an error condition, but we make it a warning because
+     * there are some baseline files out there with all zeroes in these bytes.
+     */
+    if (cinfo->Ss != 0 || cinfo->Se != DCTSIZE2 - 1 ||
+        cinfo->Ah != 0 || cinfo->Al != 0)
+        WARNMS(cinfo, JWRN_NOT_SEQUENTIAL);
 
-  for (ci = 0; ci < cinfo->comps_in_scan; ci++) {
-    compptr = cinfo->cur_comp_info[ci];
-    dctbl = compptr->dc_tbl_no;
-    actbl = compptr->ac_tbl_no;
-    /* Compute derived values for Huffman tables */
-    /* We may do this more than once for a table, but it's not expensive */
-    pdtbl = (d_derived_tbl **)(entropy->dc_derived_tbls) + dctbl;
-    jpeg_make_d_derived_tbl(cinfo, TRUE, dctbl, pdtbl);
-    pdtbl = (d_derived_tbl **)(entropy->ac_derived_tbls) + actbl;
-    jpeg_make_d_derived_tbl(cinfo, FALSE, actbl, pdtbl);
-    /* Initialize DC predictions to 0 */
-    entropy->saved.last_dc_val[ci] = 0;
-  }
-
-  /* Precalculate decoding info for each block in an MCU of this scan */
-  for (blkn = 0; blkn < cinfo->blocks_in_MCU; blkn++) {
-    ci = cinfo->MCU_membership[blkn];
-    compptr = cinfo->cur_comp_info[ci];
-    /* Precalculate which table to use for each block */
-    entropy->dc_cur_tbls[blkn] = entropy->dc_derived_tbls[compptr->dc_tbl_no];
-    entropy->ac_cur_tbls[blkn] = entropy->ac_derived_tbls[compptr->ac_tbl_no];
-    /* Decide whether we really care about the coefficient values */
-    if (compptr->component_needed) {
-      entropy->dc_needed[blkn] = TRUE;
-      /* we don't need the ACs if producing a 1/8th-size image */
-      entropy->ac_needed[blkn] = (compptr->_DCT_scaled_size > 1);
-    } else {
-      entropy->dc_needed[blkn] = entropy->ac_needed[blkn] = FALSE;
+    for (ci = 0; ci < cinfo->comps_in_scan; ci++) {
+        compptr = cinfo->cur_comp_info[ci];
+        dctbl = compptr->dc_tbl_no;
+        actbl = compptr->ac_tbl_no;
+        /* Compute derived values for Huffman tables */
+        /* We may do this more than once for a table, but it's not expensive */
+        pdtbl = (d_derived_tbl **) (entropy->dc_derived_tbls) + dctbl;
+        jpeg_make_d_derived_tbl(cinfo, TRUE, dctbl, pdtbl);
+        pdtbl = (d_derived_tbl **) (entropy->ac_derived_tbls) + actbl;
+        jpeg_make_d_derived_tbl(cinfo, FALSE, actbl, pdtbl);
+        jpeg_make_fast_ac_tables(cinfo, entropy, actbl);
+        /* Initialize DC predictions to 0 */
+        entropy->saved.last_dc_val[ci] = 0;
     }
-  }
 
-  /* Initialize bitread state variables */
-  entropy->bitstate.bits_left = 0;
-  entropy->bitstate.get_buffer = 0; /* unnecessary, but keeps Purify quiet */
-  entropy->pub.insufficient_data = FALSE;
+    /* Precalculate decoding info for each block in an MCU of this scan */
+    for (blkn = 0; blkn < cinfo->blocks_in_MCU; blkn++) {
+        ci = cinfo->MCU_membership[blkn];
+        compptr = cinfo->cur_comp_info[ci];
+        /* Precalculate which table to use for each block */
+        entropy->dc_cur_tbls[blkn] = entropy->dc_derived_tbls[compptr->dc_tbl_no];
+        entropy->ac_cur_tbls[blkn] = entropy->ac_derived_tbls[compptr->ac_tbl_no];
+        /* Decide whether we really care about the coefficient values */
+        if (compptr->component_needed) {
+            entropy->dc_needed[blkn] = TRUE;
+            /* we don't need the ACs if producing a 1/8th-size image */
+            entropy->ac_needed[blkn] = (compptr->_DCT_scaled_size > 1);
+        } else {
+            entropy->dc_needed[blkn] = entropy->ac_needed[blkn] = FALSE;
+        }
+    }
 
-  /* Initialize restart counter */
-  entropy->restarts_to_go = cinfo->restart_interval;
+    /* Initialize bitread state variables */
+    entropy->bitstate.bits_left = 0;
+    entropy->bitstate.get_buffer = 0; /* unnecessary, but keeps Purify quiet */
+    entropy->pub.insufficient_data = FALSE;
+
+    /* Initialize restart counter */
+    entropy->restarts_to_go = cinfo->restart_interval;
 }
 
 
@@ -139,125 +144,226 @@ start_pass_huff_decoder(j_decompress_ptr cinfo)
 
 GLOBAL(void)
 jpeg_make_d_derived_tbl(j_decompress_ptr cinfo, boolean isDC, int tblno,
-                        d_derived_tbl **pdtbl)
-{
-  JHUFF_TBL *htbl;
-  d_derived_tbl *dtbl;
-  int p, i, l, si, numsymbols;
-  int lookbits, ctr;
-  char huffsize[257];
-  unsigned int huffcode[257];
-  unsigned int code;
+                        d_derived_tbl **pdtbl) {
+    JHUFF_TBL *htbl;
+    d_derived_tbl *dtbl;
+    int p, i, l, si, numsymbols;
+    int lookbits, ctr;
+    char huffsize[257];
+    unsigned int huffcode[257];
+    unsigned int code;
 
-  /* Note that huffsize[] and huffcode[] are filled in code-length order,
-   * paralleling the order of the symbols themselves in htbl->huffval[].
-   */
-
-  /* Find the input Huffman table */
-  if (tblno < 0 || tblno >= NUM_HUFF_TBLS)
-    ERREXIT1(cinfo, JERR_NO_HUFF_TABLE, tblno);
-  htbl =
-    isDC ? cinfo->dc_huff_tbl_ptrs[tblno] : cinfo->ac_huff_tbl_ptrs[tblno];
-  if (htbl == NULL)
-    ERREXIT1(cinfo, JERR_NO_HUFF_TABLE, tblno);
-
-  /* Allocate a workspace if we haven't already done so. */
-  if (*pdtbl == NULL)
-    *pdtbl = (d_derived_tbl *)
-      (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
-                                  sizeof(d_derived_tbl));
-  dtbl = *pdtbl;
-  dtbl->pub = htbl;             /* fill in back link */
-
-  /* Figure C.1: make table of Huffman code length for each symbol */
-
-  p = 0;
-  for (l = 1; l <= 16; l++) {
-    i = (int)htbl->bits[l];
-    if (i < 0 || p + i > 256)   /* protect against table overrun */
-      ERREXIT(cinfo, JERR_BAD_HUFF_TABLE);
-    while (i--)
-      huffsize[p++] = (char)l;
-  }
-  huffsize[p] = 0;
-  numsymbols = p;
-
-  /* Figure C.2: generate the codes themselves */
-  /* We also validate that the counts represent a legal Huffman code tree. */
-
-  code = 0;
-  si = huffsize[0];
-  p = 0;
-  while (huffsize[p]) {
-    while (((int)huffsize[p]) == si) {
-      huffcode[p++] = code;
-      code++;
-    }
-    /* code is now 1 more than the last code used for codelength si; but
-     * it must still fit in si bits, since no code is allowed to be all ones.
+    /* Note that huffsize[] and huffcode[] are filled in code-length order,
+     * paralleling the order of the symbols themselves in htbl->huffval[].
      */
-    if (((JLONG)code) >= (((JLONG)1) << si))
-      ERREXIT(cinfo, JERR_BAD_HUFF_TABLE);
-    code <<= 1;
-    si++;
-  }
 
-  /* Figure F.15: generate decoding tables for bit-sequential decoding */
+    /* Find the input Huffman table */
+    if (tblno < 0 || tblno >= NUM_HUFF_TBLS)
+        ERREXIT1(cinfo, JERR_NO_HUFF_TABLE, tblno);
+    htbl =
+            isDC ? cinfo->dc_huff_tbl_ptrs[tblno] : cinfo->ac_huff_tbl_ptrs[tblno];
+    if (htbl == NULL)
+        ERREXIT1(cinfo, JERR_NO_HUFF_TABLE, tblno);
 
-  p = 0;
-  for (l = 1; l <= 16; l++) {
-    if (htbl->bits[l]) {
-      /* valoffset[l] = huffval[] index of 1st symbol of code length l,
-       * minus the minimum code of length l
-       */
-      dtbl->valoffset[l] = (JLONG)p - (JLONG)huffcode[p];
-      p += htbl->bits[l];
-      dtbl->maxcode[l] = huffcode[p - 1]; /* maximum code of length l */
-    } else {
-      dtbl->maxcode[l] = -1;    /* -1 if no codes of this length */
+    /* Allocate a workspace if we haven't already done so. */
+    if (*pdtbl == NULL)
+        *pdtbl = (d_derived_tbl *)
+                (*cinfo->mem->alloc_small)((j_common_ptr) cinfo, JPOOL_IMAGE,
+                                           sizeof(d_derived_tbl));
+    dtbl = *pdtbl;
+    dtbl->pub = htbl;             /* fill in back link */
+
+    /* Figure C.1: make table of Huffman code length for each symbol */
+
+    p = 0;
+    for (l = 1; l <= 16; l++) {
+        i = (int) htbl->bits[l];
+        if (i < 0 || p + i > 256)   /* protect against table overrun */
+            ERREXIT(cinfo, JERR_BAD_HUFF_TABLE);
+        while (i--)
+            huffsize[p++] = (char) l;
     }
-  }
-  dtbl->valoffset[17] = 0;
-  dtbl->maxcode[17] = 0xFFFFFL; /* ensures jpeg_huff_decode terminates */
+    huffsize[p] = 0;
+    numsymbols = p;
 
-  /* Compute lookahead tables to speed up decoding.
-   * First we set all the table entries to 0, indicating "too long";
-   * then we iterate through the Huffman codes that are short enough and
-   * fill in all the entries that correspond to bit sequences starting
-   * with that code.
-   */
+    /* Figure C.2: generate the codes themselves */
+    /* We also validate that the counts represent a legal Huffman code tree. */
 
-  for (i = 0; i < (1 << HUFF_LOOKAHEAD); i++)
-    dtbl->lookup[i] = (HUFF_LOOKAHEAD + 1) << HUFF_LOOKAHEAD;
-
-  p = 0;
-  for (l = 1; l <= HUFF_LOOKAHEAD; l++) {
-    for (i = 1; i <= (int)htbl->bits[l]; i++, p++) {
-      /* l = current code's length, p = its index in huffcode[] & huffval[]. */
-      /* Generate left-justified code followed by all possible bit sequences */
-      lookbits = huffcode[p] << (HUFF_LOOKAHEAD - l);
-      for (ctr = 1 << (HUFF_LOOKAHEAD - l); ctr > 0; ctr--) {
-        dtbl->lookup[lookbits] = (l << HUFF_LOOKAHEAD) | htbl->huffval[p];
-        lookbits++;
-      }
+    code = 0;
+    si = huffsize[0];
+    p = 0;
+    while (huffsize[p]) {
+        while (((int) huffsize[p]) == si) {
+            huffcode[p++] = code;
+            code++;
+        }
+        /* code is now 1 more than the last code used for codelength si; but
+         * it must still fit in si bits, since no code is allowed to be all ones.
+         */
+        if (((JLONG) code) >= (((JLONG) 1) << si))
+            ERREXIT(cinfo, JERR_BAD_HUFF_TABLE);
+        code <<= 1;
+        si++;
     }
-  }
 
-  /* Validate symbols as being reasonable.
-   * For AC tables, we make no check, but accept all byte values 0..255.
-   * For DC tables, we require the symbols to be in range 0..15.
-   * (Tighter bounds could be applied depending on the data depth and mode,
-   * but this is sufficient to ensure safe decoding.)
-   */
-  if (isDC) {
-    for (i = 0; i < numsymbols; i++) {
-      int sym = htbl->huffval[i];
-      if (sym < 0 || sym > 15)
-        ERREXIT(cinfo, JERR_BAD_HUFF_TABLE);
+    /* Figure F.15: generate decoding tables for bit-sequential decoding */
+
+    p = 0;
+    for (l = 1; l <= 16; l++) {
+        if (htbl->bits[l]) {
+            /* valoffset[l] = huffval[] index of 1st symbol of code length l,
+             * minus the minimum code of length l
+             */
+            dtbl->valoffset[l] = (JLONG) p - (JLONG) huffcode[p];
+            p += htbl->bits[l];
+            dtbl->maxcode[l] = huffcode[p - 1]; /* maximum code of length l */
+        } else {
+            dtbl->maxcode[l] = -1;    /* -1 if no codes of this length */
+        }
     }
-  }
+    dtbl->valoffset[17] = 0;
+    dtbl->maxcode[17] = 0xFFFFFL; /* ensures jpeg_huff_decode terminates */
+
+    /* Compute lookahead tables to speed up decoding.
+     * First we set all the table entries to 0, indicating "too long";
+     * then we iterate through the Huffman codes that are short enough and
+     * fill in all the entries that correspond to bit sequences starting
+     * with that code.
+     */
+
+    for (i = 0; i < (1 << HUFF_LOOKAHEAD); i++)
+        dtbl->lookup[i] = (HUFF_LOOKAHEAD + 1) << HUFF_LOOKAHEAD;
+
+    p = 0;
+    for (l = 1; l <= HUFF_LOOKAHEAD; l++) {
+        for (i = 1; i <= (int) htbl->bits[l]; i++, p++) {
+            /* l = current code's length, p = its index in huffcode[] & huffval[]. */
+            /* Generate left-justified code followed by all possible bit sequences */
+            lookbits = huffcode[p] << (HUFF_LOOKAHEAD - l);
+            for (ctr = 1 << (HUFF_LOOKAHEAD - l); ctr > 0; ctr--) {
+                dtbl->lookup[lookbits] = (l << HUFF_LOOKAHEAD) | htbl->huffval[p];
+                lookbits++;
+            }
+        }
+    }
+    /**/
+    /* Validate symbols as being reasonable.
+     * For AC tables, we make no check, but accept all byte values 0..255.
+     * For DC tables, we require the symbols to be in range 0..15.
+     * (Tighter bounds could be applied depending on the data depth and mode,
+     * but this is sufficient to ensure safe decoding.)
+     */
+    if (isDC) {
+        for (i = 0; i < numsymbols; i++) {
+            int sym = htbl->huffval[i];
+            if (sym < 0 || sym > 15)
+                ERREXIT(cinfo, JERR_BAD_HUFF_TABLE);
+        }
+    }
 }
 
+/*
+ * Generate fast ac tables that do the equivalent of decode and receive extend in one go
+ * */
+LOCAL(void) jpeg_make_fast_ac_tables(j_decompress_ptr cinfo, huff_entropy_ptr entropy, int tblno) {
+    /*
+     *Basically repeat the major things in jpeg_make_d_derived_tbl because
+     * we can't extend that function(it's public), therefore we do what it does to get information
+     * then we create fast ac tables.
+     * */
+    JHUFF_TBL *htbl;
+    int num_symbols, p, i, l, si;
+    char huff_size[257];
+    unsigned int huff_code[257];
+    unsigned int code;
+    /* non-spec acceleration table */
+    unsigned char fast[1 << HUFF_LOOKAHEAD];
+    /*Fast AC table*/
+    int *fast_ac = entropy->fast_ac_tables[tblno];
+
+    /* Get current AC tables*/
+    htbl = cinfo->ac_huff_tbl_ptrs[tblno];
+
+    num_symbols = 0;
+    p = 0;
+    /* make table of Huffman code length for each symbol*/
+    for (l = 0; l < 16; l++) {
+        i = htbl->bits[l];
+        while (i != 0) {
+
+            huff_size[p++] = (char) l;
+
+            i--;
+        }
+    }
+    huff_size[p] = 0;
+
+    num_symbols = p;
+    /*Generate  codes themselves*/
+    code = 0;
+
+    si = (int) huff_size[0];
+
+    p = 0;
+    while (huff_size[p] != 0) {
+        while (huff_size[p] == si) {
+            huff_code[p++] = code++;
+        }
+        /*Don't check for errors, we already did in make d_derived_tbl*/
+        code <<= 1;
+        si++;
+    }
+    p = 0;
+    /*Compute non-spec acceleration table*/
+    /*For the non-spec acceleration table; 255 is flag for not accelerated*/
+    memset(fast, 255, (1 << HUFF_LOOKAHEAD));
+
+    for (i = 0; i < num_symbols; i++) {
+        /* Get code size */
+        char s = huff_size[i];
+
+        if (s <= HUFF_LOOKAHEAD) {
+            /* Symbol is less than table, create its value */
+            int c = (signed int) huff_code[i] << (HUFF_LOOKAHEAD - s);
+
+            int m = 1 << (HUFF_LOOKAHEAD - s);
+            for (int j = 0; j < m; j++) {
+                fast[c + j] = i;
+            }
+        }
+    }
+
+    for (i = 0; i < (1 << HUFF_LOOKAHEAD); i++) {
+        int fast_v = fast[i];
+        fast_ac[i] = 0;
+        if (fast_v < 255) {
+            /* symbol */
+            int rs = htbl->huffval[fast_v];
+            /* Run length */
+            int run = (rs >> 4) & 15;
+            /* Magnitude */
+            int mag_bits = rs & 15;
+
+            /* Bits consumed */
+            int len = (int) huff_size[fast_v];
+            if (len == 1 && mag_bits == 0) {
+                /* End of block case*/
+                fast_ac[i] = (63 << 4) + 1;
+            } else if (mag_bits != 0 && (len + mag_bits) << HUFF_LOOKAHEAD) {
+                int k = (i << len) & ((1 << HUFF_LOOKAHEAD) - 1) >> (HUFF_LOOKAHEAD - mag_bits);
+
+                int m = 1 << (mag_bits - 1);
+
+                if (k < m) k += (~0 << mag_bits) + 1;
+
+                /*If result is small enough, fit into fast ac table*/
+                if (k >= -128 && k <= 127) {
+                    fast_ac[i] = (k << 10) + (run << 4) + (len + mag_bits);
+                }
+            }
+        }
+    }
+}
 
 /*
  * Out-of-line code for bit fetching (shared with jdphuff.c).
@@ -287,98 +393,98 @@ jpeg_fill_bit_buffer(bitread_working_state *state,
                      int nbits)
 /* Load up the bit buffer to a depth of at least nbits */
 {
-  /* Copy heavily used state fields into locals (hopefully registers) */
-  register const JOCTET *next_input_byte = state->next_input_byte;
-  register size_t bytes_in_buffer = state->bytes_in_buffer;
-  j_decompress_ptr cinfo = state->cinfo;
+    /* Copy heavily used state fields into locals (hopefully registers) */
+    register const JOCTET *next_input_byte = state->next_input_byte;
+    register size_t bytes_in_buffer = state->bytes_in_buffer;
+    j_decompress_ptr cinfo = state->cinfo;
 
-  /* Attempt to load at least MIN_GET_BITS bits into get_buffer. */
-  /* (It is assumed that no request will be for more than that many bits.) */
-  /* We fail to do so only if we hit a marker or are forced to suspend. */
+    /* Attempt to load at least MIN_GET_BITS bits into get_buffer. */
+    /* (It is assumed that no request will be for more than that many bits.) */
+    /* We fail to do so only if we hit a marker or are forced to suspend. */
 
-  if (cinfo->unread_marker == 0) {      /* cannot advance past a marker */
-    while (bits_left < MIN_GET_BITS) {
-      register int c;
+    if (cinfo->unread_marker == 0) {      /* cannot advance past a marker */
+        while (bits_left < MIN_GET_BITS) {
+            register int c;
 
-      /* Attempt to read a byte */
-      if (bytes_in_buffer == 0) {
-        if (!(*cinfo->src->fill_input_buffer) (cinfo))
-          return FALSE;
-        next_input_byte = cinfo->src->next_input_byte;
-        bytes_in_buffer = cinfo->src->bytes_in_buffer;
-      }
-      bytes_in_buffer--;
-      c = *next_input_byte++;
+            /* Attempt to read a byte */
+            if (bytes_in_buffer == 0) {
+                if (!(*cinfo->src->fill_input_buffer)(cinfo))
+                    return FALSE;
+                next_input_byte = cinfo->src->next_input_byte;
+                bytes_in_buffer = cinfo->src->bytes_in_buffer;
+            }
+            bytes_in_buffer--;
+            c = *next_input_byte++;
 
-      /* If it's 0xFF, check and discard stuffed zero byte */
-      if (c == 0xFF) {
-        /* Loop here to discard any padding FF's on terminating marker,
-         * so that we can save a valid unread_marker value.  NOTE: we will
-         * accept multiple FF's followed by a 0 as meaning a single FF data
-         * byte.  This data pattern is not valid according to the standard.
+            /* If it's 0xFF, check and discard stuffed zero byte */
+            if (c == 0xFF) {
+                /* Loop here to discard any padding FF's on terminating marker,
+                 * so that we can save a valid unread_marker value.  NOTE: we will
+                 * accept multiple FF's followed by a 0 as meaning a single FF data
+                 * byte.  This data pattern is not valid according to the standard.
+                 */
+                do {
+                    if (bytes_in_buffer == 0) {
+                        if (!(*cinfo->src->fill_input_buffer)(cinfo))
+                            return FALSE;
+                        next_input_byte = cinfo->src->next_input_byte;
+                        bytes_in_buffer = cinfo->src->bytes_in_buffer;
+                    }
+                    bytes_in_buffer--;
+                    c = *next_input_byte++;
+                } while (c == 0xFF);
+
+                if (c == 0) {
+                    /* Found FF/00, which represents an FF data byte */
+                    c = 0xFF;
+                } else {
+                    /* Oops, it's actually a marker indicating end of compressed data.
+                     * Save the marker code for later use.
+                     * Fine point: it might appear that we should save the marker into
+                     * bitread working state, not straight into permanent state.  But
+                     * once we have hit a marker, we cannot need to suspend within the
+                     * current MCU, because we will read no more bytes from the data
+                     * source.  So it is OK to update permanent state right away.
+                     */
+                    cinfo->unread_marker = c;
+                    /* See if we need to insert some fake zero bits. */
+                    goto no_more_bytes;
+                }
+            }
+
+            /* OK, load c into get_buffer */
+            get_buffer = (get_buffer << 8) | c;
+            bits_left += 8;
+        } /* end while */
+    } else {
+        no_more_bytes:
+        /* We get here if we've read the marker that terminates the compressed
+         * data segment.  There should be enough bits in the buffer register
+         * to satisfy the request; if so, no problem.
          */
-        do {
-          if (bytes_in_buffer == 0) {
-            if (!(*cinfo->src->fill_input_buffer) (cinfo))
-              return FALSE;
-            next_input_byte = cinfo->src->next_input_byte;
-            bytes_in_buffer = cinfo->src->bytes_in_buffer;
-          }
-          bytes_in_buffer--;
-          c = *next_input_byte++;
-        } while (c == 0xFF);
-
-        if (c == 0) {
-          /* Found FF/00, which represents an FF data byte */
-          c = 0xFF;
-        } else {
-          /* Oops, it's actually a marker indicating end of compressed data.
-           * Save the marker code for later use.
-           * Fine point: it might appear that we should save the marker into
-           * bitread working state, not straight into permanent state.  But
-           * once we have hit a marker, we cannot need to suspend within the
-           * current MCU, because we will read no more bytes from the data
-           * source.  So it is OK to update permanent state right away.
-           */
-          cinfo->unread_marker = c;
-          /* See if we need to insert some fake zero bits. */
-          goto no_more_bytes;
+        if (nbits > bits_left) {
+            /* Uh-oh.  Report corrupted data to user and stuff zeroes into
+             * the data stream, so that we can produce some kind of image.
+             * We use a nonvolatile flag to ensure that only one warning message
+             * appears per data segment.
+             */
+            if (!cinfo->entropy->insufficient_data) {
+                WARNMS(cinfo, JWRN_HIT_MARKER);
+                cinfo->entropy->insufficient_data = TRUE;
+            }
+            /* Fill the buffer with zero bits */
+            get_buffer <<= MIN_GET_BITS - bits_left;
+            bits_left = MIN_GET_BITS;
         }
-      }
-
-      /* OK, load c into get_buffer */
-      get_buffer = (get_buffer << 8) | c;
-      bits_left += 8;
-    } /* end while */
-  } else {
-no_more_bytes:
-    /* We get here if we've read the marker that terminates the compressed
-     * data segment.  There should be enough bits in the buffer register
-     * to satisfy the request; if so, no problem.
-     */
-    if (nbits > bits_left) {
-      /* Uh-oh.  Report corrupted data to user and stuff zeroes into
-       * the data stream, so that we can produce some kind of image.
-       * We use a nonvolatile flag to ensure that only one warning message
-       * appears per data segment.
-       */
-      if (!cinfo->entropy->insufficient_data) {
-        WARNMS(cinfo, JWRN_HIT_MARKER);
-        cinfo->entropy->insufficient_data = TRUE;
-      }
-      /* Fill the buffer with zero bits */
-      get_buffer <<= MIN_GET_BITS - bits_left;
-      bits_left = MIN_GET_BITS;
     }
-  }
 
-  /* Unload the local registers */
-  state->next_input_byte = next_input_byte;
-  state->bytes_in_buffer = bytes_in_buffer;
-  state->get_buffer = get_buffer;
-  state->bits_left = bits_left;
+    /* Unload the local registers */
+    state->next_input_byte = next_input_byte;
+    state->bytes_in_buffer = bytes_in_buffer;
+    state->get_buffer = get_buffer;
+    state->bits_left = bits_left;
 
-  return TRUE;
+    return TRUE;
 }
 
 
@@ -433,39 +539,38 @@ no_more_bytes:
 GLOBAL(int)
 jpeg_huff_decode(bitread_working_state *state,
                  register bit_buf_type get_buffer, register int bits_left,
-                 d_derived_tbl *htbl, int min_bits)
-{
-  register int l = min_bits;
-  register JLONG code;
+                 d_derived_tbl *htbl, int min_bits) {
+    register int l = min_bits;
+    register JLONG code;
 
-  /* HUFF_DECODE has determined that the code is at least min_bits */
-  /* bits long, so fetch that many bits in one swoop. */
+    /* HUFF_DECODE has determined that the code is at least min_bits */
+    /* bits long, so fetch that many bits in one swoop. */
 
-  CHECK_BIT_BUFFER(*state, l, return -1);
-  code = GET_BITS(l);
+    CHECK_BIT_BUFFER(*state, l, return -1);
+    code = GET_BITS(l);
 
-  /* Collect the rest of the Huffman code one bit at a time. */
-  /* This is per Figure F.16. */
+    /* Collect the rest of the Huffman code one bit at a time. */
+    /* This is per Figure F.16. */
 
-  while (code > htbl->maxcode[l]) {
-    code <<= 1;
-    CHECK_BIT_BUFFER(*state, 1, return -1);
-    code |= GET_BITS(1);
-    l++;
-  }
+    while (code > htbl->maxcode[l]) {
+        code <<= 1;
+        CHECK_BIT_BUFFER(*state, 1, return -1);
+        code |= GET_BITS(1);
+        l++;
+    }
 
-  /* Unload the local registers */
-  state->get_buffer = get_buffer;
-  state->bits_left = bits_left;
+    /* Unload the local registers */
+    state->get_buffer = get_buffer;
+    state->bits_left = bits_left;
 
-  /* With garbage input we may reach the sentinel value l = 17. */
+    /* With garbage input we may reach the sentinel value l = 17. */
 
-  if (l > 16) {
-    WARNMS(state->cinfo, JWRN_HUFF_BAD_CODE);
-    return 0;                   /* fake a zero as the safest result */
-  }
+    if (l > 16) {
+        WARNMS(state->cinfo, JWRN_HUFF_BAD_CODE);
+        return 0;                   /* fake a zero as the safest result */
+    }
 
-  return htbl->pub->huffval[(int)(code + htbl->valoffset[l])];
+    return htbl->pub->huffval[(int) (code + htbl->valoffset[l])];
 }
 
 
@@ -507,36 +612,35 @@ static const int extend_offset[16] = { /* entry n is (-1 << n) + 1 */
  */
 
 LOCAL(boolean)
-process_restart(j_decompress_ptr cinfo)
-{
-  huff_entropy_ptr entropy = (huff_entropy_ptr)cinfo->entropy;
-  int ci;
+process_restart(j_decompress_ptr cinfo) {
+    huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
+    int ci;
 
-  /* Throw away any unused bits remaining in bit buffer; */
-  /* include any full bytes in next_marker's count of discarded bytes */
-  cinfo->marker->discarded_bytes += entropy->bitstate.bits_left / 8;
-  entropy->bitstate.bits_left = 0;
+    /* Throw away any unused bits remaining in bit buffer; */
+    /* include any full bytes in next_marker's count of discarded bytes */
+    cinfo->marker->discarded_bytes += entropy->bitstate.bits_left / 8;
+    entropy->bitstate.bits_left = 0;
 
-  /* Advance past the RSTn marker */
-  if (!(*cinfo->marker->read_restart_marker) (cinfo))
-    return FALSE;
+    /* Advance past the RSTn marker */
+    if (!(*cinfo->marker->read_restart_marker)(cinfo))
+        return FALSE;
 
-  /* Re-initialize DC predictions to 0 */
-  for (ci = 0; ci < cinfo->comps_in_scan; ci++)
-    entropy->saved.last_dc_val[ci] = 0;
+    /* Re-initialize DC predictions to 0 */
+    for (ci = 0; ci < cinfo->comps_in_scan; ci++)
+        entropy->saved.last_dc_val[ci] = 0;
 
-  /* Reset restart counter */
-  entropy->restarts_to_go = cinfo->restart_interval;
+    /* Reset restart counter */
+    entropy->restarts_to_go = cinfo->restart_interval;
 
-  /* Reset out-of-data flag, unless read_restart_marker left us smack up
-   * against a marker.  In that case we will end up treating the next data
-   * segment as empty, and we can avoid producing bogus output pixels by
-   * leaving the flag set.
-   */
-  if (cinfo->unread_marker == 0)
-    entropy->pub.insufficient_data = FALSE;
+    /* Reset out-of-data flag, unless read_restart_marker left us smack up
+     * against a marker.  In that case we will end up treating the next data
+     * segment as empty, and we can avoid producing bogus output pixels by
+     * leaving the flag set.
+     */
+    if (cinfo->unread_marker == 0)
+        entropy->pub.insufficient_data = FALSE;
 
-  return TRUE;
+    return TRUE;
 }
 
 
@@ -546,108 +650,108 @@ __attribute__((no_sanitize("signed-integer-overflow"),
                no_sanitize("unsigned-integer-overflow")))
 #endif
 #endif
+
 LOCAL(boolean)
-decode_mcu_slow(j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
-{
-  huff_entropy_ptr entropy = (huff_entropy_ptr)cinfo->entropy;
-  BITREAD_STATE_VARS;
-  int blkn;
-  savable_state state;
-  /* Outer loop handles each block in the MCU */
+decode_mcu_slow(j_decompress_ptr cinfo, JBLOCKROW *MCU_data) {
+    huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
+    BITREAD_STATE_VARS;
+    int blkn;
+    savable_state state;
+    /* Outer loop handles each block in the MCU */
 
-  /* Load up working state */
-  BITREAD_LOAD_STATE(cinfo, entropy->bitstate);
-  state = entropy->saved;
+    /* Load up working state */
+    BITREAD_LOAD_STATE(cinfo, entropy->bitstate);
+    state = entropy->saved;
 
-  for (blkn = 0; blkn < cinfo->blocks_in_MCU; blkn++) {
-    JBLOCKROW block = MCU_data ? MCU_data[blkn] : NULL;
-    d_derived_tbl *dctbl = entropy->dc_cur_tbls[blkn];
-    d_derived_tbl *actbl = entropy->ac_cur_tbls[blkn];
-    register int s, k, r;
+    for (blkn = 0; blkn < cinfo->blocks_in_MCU; blkn++) {
+        JBLOCKROW block = MCU_data ? MCU_data[blkn] : NULL;
+        d_derived_tbl *dctbl = entropy->dc_cur_tbls[blkn];
+        d_derived_tbl *actbl = entropy->ac_cur_tbls[blkn];
+        register int s, k, r;
 
-    /* Decode a single block's worth of coefficients */
+        /* Decode a single block's worth of coefficients */
 
-    /* Section F.2.2.1: decode the DC coefficient difference */
-    HUFF_DECODE(s, br_state, dctbl, return FALSE, label1);
-    if (s) {
-      CHECK_BIT_BUFFER(br_state, s, return FALSE);
-      r = GET_BITS(s);
-      s = HUFF_EXTEND(r, s);
-    }
-
-    if (entropy->dc_needed[blkn]) {
-      /* Convert DC difference to actual value, update last_dc_val */
-      int ci = cinfo->MCU_membership[blkn];
-      /* Certain malformed JPEG images produce repeated DC coefficient
-       * differences of 2047 or -2047, which causes state.last_dc_val[ci] to
-       * grow until it overflows or underflows a 32-bit signed integer.  This
-       * behavior is, to the best of our understanding, innocuous, and it is
-       * unclear how to work around it without potentially affecting
-       * performance.  Thus, we (hopefully temporarily) suppress UBSan integer
-       * overflow errors for this function and decode_mcu_fast().
-       */
-      s += state.last_dc_val[ci];
-      state.last_dc_val[ci] = s;
-      if (block) {
-        /* Output the DC coefficient (assumes jpeg_natural_order[0] = 0) */
-        (*block)[0] = (JCOEF)s;
-      }
-    }
-
-    if (entropy->ac_needed[blkn] && block) {
-
-      /* Section F.2.2.2: decode the AC coefficients */
-      /* Since zeroes are skipped, output area must be cleared beforehand */
-      for (k = 1; k < DCTSIZE2; k++) {
-        HUFF_DECODE(s, br_state, actbl, return FALSE, label2);
-
-        r = s >> 4;
-        s &= 15;
-
+        /* Section F.2.2.1: decode the DC coefficient difference */
+        HUFF_DECODE(s, br_state, dctbl, return FALSE, label1);
         if (s) {
-          k += r;
-          CHECK_BIT_BUFFER(br_state, s, return FALSE);
-          r = GET_BITS(s);
-          s = HUFF_EXTEND(r, s);
-          /* Output coefficient in natural (dezigzagged) order.
-           * Note: the extra entries in jpeg_natural_order[] will save us
-           * if k >= DCTSIZE2, which could happen if the data is corrupted.
-           */
-          (*block)[jpeg_natural_order[k]] = (JCOEF)s;
-        } else {
-          if (r != 15)
-            break;
-          k += 15;
+            CHECK_BIT_BUFFER(br_state, s, return FALSE);
+            r = GET_BITS(s);
+            s = HUFF_EXTEND(r, s);
         }
-      }
 
-    } else {
-
-      /* Section F.2.2.2: decode the AC coefficients */
-      /* In this path we just discard the values */
-      for (k = 1; k < DCTSIZE2; k++) {
-        HUFF_DECODE(s, br_state, actbl, return FALSE, label3);
-
-        r = s >> 4;
-        s &= 15;
-
-        if (s) {
-          k += r;
-          CHECK_BIT_BUFFER(br_state, s, return FALSE);
-          DROP_BITS(s);
-        } else {
-          if (r != 15)
-            break;
-          k += 15;
+        if (entropy->dc_needed[blkn]) {
+            /* Convert DC difference to actual value, update last_dc_val */
+            int ci = cinfo->MCU_membership[blkn];
+            /* Certain malformed JPEG images produce repeated DC coefficient
+             * differences of 2047 or -2047, which causes state.last_dc_val[ci] to
+             * grow until it overflows or underflows a 32-bit signed integer.  This
+             * behavior is, to the best of our understanding, innocuous, and it is
+             * unclear how to work around it without potentially affecting
+             * performance.  Thus, we (hopefully temporarily) suppress UBSan integer
+             * overflow errors for this function and decode_mcu_fast().
+             */
+            s += state.last_dc_val[ci];
+            state.last_dc_val[ci] = s;
+            if (block) {
+                /* Output the DC coefficient (assumes jpeg_natural_order[0] = 0) */
+                (*block)[0] = (JCOEF) s;
+            }
         }
-      }
+
+        if (entropy->ac_needed[blkn] && block) {
+
+            /* Section F.2.2.2: decode the AC coefficients */
+            /* Since zeroes are skipped, output area must be cleared beforehand */
+            for (k = 1; k < DCTSIZE2; k++) {
+                HUFF_DECODE(s, br_state, actbl, return FALSE, label2);
+
+                r = s >> 4;
+                s &= 15;
+
+                if (s) {
+                    k += r;
+                    CHECK_BIT_BUFFER(br_state, s, return FALSE);
+                    r = GET_BITS(s);
+                    s = HUFF_EXTEND(r, s);
+                    /* Output coefficient in natural (dezigzagged) order.
+                     * Note: the extra entries in jpeg_natural_order[] will save us
+                     * if k >= DCTSIZE2, which could happen if the data is corrupted.
+                     */
+                    (*block)[jpeg_natural_order[k]] = (JCOEF) s;
+                } else {
+                    if (r != 15)
+                        break;
+                    k += 15;
+                }
+            }
+
+        } else {
+
+            /* Section F.2.2.2: decode the AC coefficients */
+            /* In this path we just discard the values */
+            for (k = 1; k < DCTSIZE2; k++) {
+                HUFF_DECODE(s, br_state, actbl, return FALSE, label3);
+
+                r = s >> 4;
+                s &= 15;
+
+                if (s) {
+                    k += r;
+                    CHECK_BIT_BUFFER(br_state, s, return FALSE);
+                    DROP_BITS(s);
+                } else {
+                    if (r != 15)
+                        break;
+                    k += 15;
+                }
+            }
+        }
     }
-  }
 
-  /* Completed MCU, so update state */
-  BITREAD_SAVE_STATE(cinfo, entropy->bitstate);
-  entropy->saved = state;
-  return TRUE;
+    /* Completed MCU, so update state */
+    BITREAD_SAVE_STATE(cinfo, entropy->bitstate);
+    entropy->saved = state;
+    return TRUE;
 }
 
 
@@ -657,93 +761,113 @@ __attribute__((no_sanitize("signed-integer-overflow"),
                no_sanitize("unsigned-integer-overflow")))
 #endif
 #endif
+
 LOCAL(boolean)
-decode_mcu_fast(j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
-{
-  huff_entropy_ptr entropy = (huff_entropy_ptr)cinfo->entropy;
-  BITREAD_STATE_VARS;
-  JOCTET *buffer;
-  int blkn;
-  savable_state state;
-  /* Outer loop handles each block in the MCU */
+decode_mcu_fast(j_decompress_ptr cinfo, JBLOCKROW *MCU_data) {
+    huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
+    BITREAD_STATE_VARS;
+    JOCTET *buffer;
+    int blkn;
+    savable_state state;
+    /* Outer loop handles each block in the MCU */
 
-  /* Load up working state */
-  BITREAD_LOAD_STATE(cinfo, entropy->bitstate);
-  buffer = (JOCTET *)br_state.next_input_byte;
-  state = entropy->saved;
+    /* Load up working state */
+    BITREAD_LOAD_STATE(cinfo, entropy->bitstate);
+    buffer = (JOCTET *) br_state.next_input_byte;
+    state = entropy->saved;
 
-  for (blkn = 0; blkn < cinfo->blocks_in_MCU; blkn++) {
-    JBLOCKROW block = MCU_data ? MCU_data[blkn] : NULL;
-    d_derived_tbl *dctbl = entropy->dc_cur_tbls[blkn];
-    d_derived_tbl *actbl = entropy->ac_cur_tbls[blkn];
-    register int s, k, r, l;
-
-    HUFF_DECODE_FAST(s, l, dctbl);
-    if (s) {
-      FILL_BIT_BUFFER_FAST
-      r = GET_BITS(s);
-      s = HUFF_EXTEND(r, s);
-    }
-
-    if (entropy->dc_needed[blkn]) {
-      int ci = cinfo->MCU_membership[blkn];
-      /* Refer to the comment in decode_mcu_slow() regarding the supression of
-       * a UBSan integer overflow error in this line of code.
-       */
-      s += state.last_dc_val[ci];
-      state.last_dc_val[ci] = s;
-      if (block)
-        (*block)[0] = (JCOEF)s;
-    }
-
-    if (entropy->ac_needed[blkn] && block) {
-
-      for (k = 1; k < DCTSIZE2; k++) {
-        HUFF_DECODE_FAST(s, l, actbl);
-        r = s >> 4;
-        s &= 15;
-
-        if (s) {
-          k += r;
-          FILL_BIT_BUFFER_FAST
-          r = GET_BITS(s);
-          s = HUFF_EXTEND(r, s);
-          (*block)[jpeg_natural_order[k]] = (JCOEF)s;
-        } else {
-          if (r != 15) break;
-          k += 15;
+    for (blkn = 0; blkn < cinfo->blocks_in_MCU; blkn++) {
+        JBLOCKROW block = MCU_data ? MCU_data[blkn] : NULL;
+        for (int i = 0; i < DCTSIZE2; i++) {
+            *block[i] = 0;
         }
-      }
+        d_derived_tbl *dctbl = entropy->dc_cur_tbls[blkn];
+        d_derived_tbl *actbl = entropy->ac_cur_tbls[blkn];
+        register int s, k, r, l;
 
-    } else {
-
-      for (k = 1; k < DCTSIZE2; k++) {
-        HUFF_DECODE_FAST(s, l, actbl);
-        r = s >> 4;
-        s &= 15;
-
+        HUFF_DECODE_FAST(s, l, dctbl);
         if (s) {
-          k += r;
-          FILL_BIT_BUFFER_FAST
-          DROP_BITS(s);
-        } else {
-          if (r != 15) break;
-          k += 15;
+            FILL_BIT_BUFFER_FAST
+            r = GET_BITS(s);
+            s = HUFF_EXTEND(r, s);
         }
-      }
+
+        if (entropy->dc_needed[blkn]) {
+            int ci = cinfo->MCU_membership[blkn];
+            /* Refer to the comment in decode_mcu_slow() regarding the supression of
+             * a UBSan integer overflow error in this line of code.
+             */
+            s += state.last_dc_val[ci];
+            state.last_dc_val[ci] = s;
+            if (block)
+                (*block)[0] = (JCOEF) s;
+        }
+
+        if (entropy->ac_needed[blkn] && block) {
+
+            for (k = 1; k < DCTSIZE2; k++) {
+                FILL_BIT_BUFFER_FAST;
+                s = PEEK_BITS(HUFF_LOOKAHEAD);
+                int fast_ac = entropy->fast_ac_tables[blkn][s];
+
+                if (fast_ac != 0) {
+                    // run
+                    k += ((fast_ac >> 4) & 63);
+
+                    int pos = k < 63 ? k : 63;
+
+                    /* value */
+                    (*block[jpeg_natural_order[pos]]) = (JCOEF) (fast_ac >> 10);
+
+                    DROP_BITS(fast_ac & 15);
+                } else {
+                    HUFF_DECODE_FAST(s, l, actbl);
+                    r = s >> 4;
+                    s &= 15;
+
+                    if (s) {
+                        k += r;
+                        FILL_BIT_BUFFER_FAST
+                        r = GET_BITS(s);
+                        s = HUFF_EXTEND(r, s);
+                        (*block)[jpeg_natural_order[k]] = (JCOEF) s;
+                    } else {
+                        if (r != 15) break;
+                        k += 15;
+                    }
+                }
+            }
+
+        } else {
+
+            for (k = 1; k < DCTSIZE2; k++) {
+
+                    HUFF_DECODE_FAST(s, l, actbl);
+                    r = s >> 4;
+                    s &= 15;
+
+                    if (s) {
+                        k += r;
+                        FILL_BIT_BUFFER_FAST
+                        DROP_BITS(s);
+                    } else {
+                        if (r != 15) break;
+                        k += 15;
+                    }
+                }
+        }
     }
-  }
 
-  if (cinfo->unread_marker != 0) {
-    cinfo->unread_marker = 0;
-    return FALSE;
-  }
+    if (cinfo->unread_marker != 0) {
+        cinfo->unread_marker = 0;
+        return FALSE;
+    }
 
-  br_state.bytes_in_buffer -= (buffer - br_state.next_input_byte);
-  br_state.next_input_byte = buffer;
-  BITREAD_SAVE_STATE(cinfo, entropy->bitstate);
-  entropy->saved = state;
-  return TRUE;
+    br_state.bytes_in_buffer -= (buffer - br_state.next_input_byte);
+    br_state.next_input_byte = buffer;
+    BITREAD_SAVE_STATE(cinfo, entropy->bitstate);
+    entropy->saved = state;
+    return TRUE;
 }
 
 
@@ -765,42 +889,42 @@ decode_mcu_fast(j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
 #define BUFSIZE  (DCTSIZE2 * 8)
 
 METHODDEF(boolean)
-decode_mcu(j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
-{
-  huff_entropy_ptr entropy = (huff_entropy_ptr)cinfo->entropy;
-  int usefast = 1;
+decode_mcu(j_decompress_ptr cinfo, JBLOCKROW *MCU_data) {
+    huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
+    int usefast = 1;
 
-  /* Process restart marker if needed; may have to suspend */
-  if (cinfo->restart_interval) {
-    if (entropy->restarts_to_go == 0)
-      if (!process_restart(cinfo))
-        return FALSE;
-    usefast = 0;
-  }
-
-  if (cinfo->src->bytes_in_buffer < BUFSIZE * (size_t)cinfo->blocks_in_MCU ||
-      cinfo->unread_marker != 0)
-    usefast = 0;
-
-  /* If we've run out of data, just leave the MCU set to zeroes.
-   * This way, we return uniform gray for the remainder of the segment.
-   */
-  if (!entropy->pub.insufficient_data) {
-
-    if (usefast) {
-      if (!decode_mcu_fast(cinfo, MCU_data)) goto use_slow;
-    } else {
-use_slow:
-      if (!decode_mcu_slow(cinfo, MCU_data)) return FALSE;
+    /* Process restart marker if needed; may have to suspend */
+    if (cinfo->restart_interval) {
+        if (entropy->restarts_to_go == 0)
+            if (!process_restart(cinfo))
+                return FALSE;
+        usefast = 0;
     }
 
-  }
+    if (cinfo->src->bytes_in_buffer < BUFSIZE * (size_t) cinfo->blocks_in_MCU ||
+        cinfo->unread_marker != 0)
+        usefast = 0;
 
-  /* Account for restart interval (no-op if not using restarts) */
-  if (cinfo->restart_interval)
-    entropy->restarts_to_go--;
+    /* If we've run out of data, just leave the MCU set to zeroes.
+     * This way, we return uniform gray for the remainder of the segment.
+     */
+    usefast=1;
+    if (!entropy->pub.insufficient_data) {
 
-  return TRUE;
+        if (usefast) {
+            if (!decode_mcu_fast(cinfo, MCU_data)) goto use_slow;
+        } else {
+            use_slow:
+            if (!decode_mcu_slow(cinfo, MCU_data)) return FALSE;
+        }
+
+    }
+
+    /* Account for restart interval (no-op if not using restarts) */
+    if (cinfo->restart_interval)
+        entropy->restarts_to_go--;
+
+    return TRUE;
 }
 
 
@@ -809,26 +933,25 @@ use_slow:
  */
 
 GLOBAL(void)
-jinit_huff_decoder(j_decompress_ptr cinfo)
-{
-  huff_entropy_ptr entropy;
-  int i;
+jinit_huff_decoder(j_decompress_ptr cinfo) {
+    huff_entropy_ptr entropy;
+    int i;
 
-  /* Motion JPEG frames typically do not include the Huffman tables if they
-     are the default tables.  Thus, if the tables are not set by the time
-     the Huffman decoder is initialized (usually within the body of
-     jpeg_start_decompress()), we set them to default values. */
-  std_huff_tables((j_common_ptr)cinfo);
+    /* Motion JPEG frames typically do not include the Huffman tables if they
+       are the default tables.  Thus, if the tables are not set by the time
+       the Huffman decoder is initialized (usually within the body of
+       jpeg_start_decompress()), we set them to default values. */
+    std_huff_tables((j_common_ptr) cinfo);
 
-  entropy = (huff_entropy_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
-                                sizeof(huff_entropy_decoder));
-  cinfo->entropy = (struct jpeg_entropy_decoder *)entropy;
-  entropy->pub.start_pass = start_pass_huff_decoder;
-  entropy->pub.decode_mcu = decode_mcu;
+    entropy = (huff_entropy_ptr)
+            (*cinfo->mem->alloc_small)((j_common_ptr) cinfo, JPOOL_IMAGE,
+                                       sizeof(huff_entropy_decoder));
+    cinfo->entropy = (struct jpeg_entropy_decoder *) entropy;
+    entropy->pub.start_pass = start_pass_huff_decoder;
+    entropy->pub.decode_mcu = decode_mcu;
 
-  /* Mark tables unallocated */
-  for (i = 0; i < NUM_HUFF_TBLS; i++) {
-    entropy->dc_derived_tbls[i] = entropy->ac_derived_tbls[i] = NULL;
-  }
+    /* Mark tables unallocated */
+    for (i = 0; i < NUM_HUFF_TBLS; i++) {
+        entropy->dc_derived_tbls[i] = entropy->ac_derived_tbls[i] = NULL;
+    }
 }

--- a/jdhuff.c
+++ b/jdhuff.c
@@ -714,7 +714,9 @@ decode_mcu_slow(j_decompress_ptr cinfo, JBLOCKROW *MCU_data) {
             /* Section F.2.2.2: decode the AC coefficients */
             /* Since zeroes are skipped, output area must be cleared beforehand */
             for (k = 1; k < DCTSIZE2; k++) {
-                if (!jpeg_fill_bit_buffer(&br_state, get_buffer, bits_left, 0))return FALSE;
+                if (!jpeg_fill_bit_buffer(&br_state, get_buffer, bits_left,0))return FALSE;
+                get_buffer = br_state.get_buffer;
+                bits_left = br_state.bits_left;
                 s = PEEK_BITS(HUFF_LOOKAHEAD);
                 int fast_ac = entropy->fast_ac_tables[cinfo->MCU_membership[blkn]][s];
 
@@ -723,7 +725,6 @@ decode_mcu_slow(j_decompress_ptr cinfo, JBLOCKROW *MCU_data) {
                     k += ((fast_ac >> 4) & 63);
 
                     int pos = k < 63 ? k : 63;
-
                     /* value */
                     (*block[jpeg_natural_order[pos]]) = (JCOEF) (fast_ac >> 10);
 
@@ -731,7 +732,6 @@ decode_mcu_slow(j_decompress_ptr cinfo, JBLOCKROW *MCU_data) {
 
                 } else {
                     HUFF_DECODE(s, br_state, actbl, return FALSE, label2);
-
                     r = s >> 4;
                     s &= 15;
 
@@ -936,7 +936,6 @@ decode_mcu(j_decompress_ptr cinfo, JBLOCKROW *MCU_data) {
      */
 
     if (!entropy->pub.insufficient_data) {
-
         if (usefast) {
             if (!decode_mcu_fast(cinfo, MCU_data)) goto use_slow;
         } else {

--- a/jdmainct.c
+++ b/jdmainct.c
@@ -16,6 +16,7 @@
  * supplies the equivalent of the main buffer in that case.
  */
 
+#include <jconfigint.h>
 #include "jinclude.h"
 #include "jdmainct.h"
 #include "jconfigint.h"

--- a/jdmaster.c
+++ b/jdmaster.c
@@ -259,6 +259,7 @@ GLOBAL(void)
 jpeg_calc_output_dimensions(j_decompress_ptr cinfo)
 /* Do computations that are needed before master selection phase */
 {
+
 #ifdef IDCT_SCALING_SUPPORTED
   int ci;
   jpeg_component_info *compptr;

--- a/jdsample.c
+++ b/jdsample.c
@@ -324,6 +324,7 @@ h1v2_fancy_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
   int inrow, outrow, v;
 
   inrow = outrow = 0;
+
   while (outrow < cinfo->max_v_samp_factor) {
     for (v = 0; v < 2; v++) {
       /* inptr0 points to nearest input row, inptr1 points to next nearest */


### PR DESCRIPTION
First Pull request for fast AC tables.

This adds code that implements table lookup decoding of short AC coefficients(less than HUFF_LOOKAHEAD).
It also handles EOB runs using the same lookup table.

Should partially resolve https://github.com/libjpeg-turbo/libjpeg-turbo/issues/525 (what's remaining is the same support for progressive images).

Other files except `jdhuff.c` were modified because the code didn't compile because gcc 11.1.0 couldn't find definition of `FALLTHROUGH` macro

## Modifications to jdhuff.c
1. `huff_entropy_decoder` has a new field, `fast_ac_tables` where the tables are stored.
2. The loop in `start_pass_huff_decoder` calls an additional function `jpeg_make_fast_ac_tables` which contains code that creates the fast tables.
3. function `jpeg_make_fast_ac_tables` has to redo some work done by `jpeg_make_d_derived_tbl` to get the needed coefficients for computing the fast AC tables.
4. fast ac tables are used in both in `decode_mcu_slow` and `decode_mcu_fast`
5. In handling EOB case, the fast ac table will return an entry that says the routine should skip forward 63 positions. This will force the loop to terminate.  But because we need to do a write(the EOB case should be transparent to all other cases). We check if k is greater than 63 and if it is, we clamp it to 63.


6. The rest were my IDE's formatter using four spaces instead of two, sorry  