### PR TITLE
cjpeg.1: Reflect cjpeg with pgm behavior in man page.

### DIFF
--- a/cjpeg.1
+++ b/cjpeg.1
@@ -41,9 +41,9 @@ Scale quantization tables to adjust image quality.  Quality is 0 (worst) to
 .TP
 .B \-grayscale
 Create monochrome JPEG file from color input.  Be sure to use this switch when
-compressing a grayscale BMP or GIF file, because
+compressing a grayscale PGM, BMP or GIF file, because
 .B cjpeg
-isn't bright enough to notice whether a BMP or GIF file uses only shades of
+isn't bright enough to notice whether a PGM, BMP or GIF file uses only shades of
 gray.  By saying
 .BR \-grayscale,
 you'll get a smaller JPEG file that takes less time to process.


### PR DESCRIPTION
Since commit aa7459050 the behavior of cjpeg has changed. Make sure to
document that `-grayscale` is now required for compressing of grayscale
PGM input file ('P5' header).