### PR TITLE
MSVC: Generate a resource script to embed version information in DLL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
 
 message(STATUS "VERSION = ${VERSION}, BUILD = ${BUILD}")
 
+include(cmakescripts/PackageInfo.cmake)
+
 # Detect CPU type and whether we're building 64-bit or 32-bit code
 math(EXPR BITS "${CMAKE_SIZEOF_VOID_P} * 8")
 string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} CMAKE_SYSTEM_PROCESSOR_LC)

--- a/cmakescripts/BuildPackages.cmake
+++ b/cmakescripts/BuildPackages.cmake
@@ -1,18 +1,6 @@
 # This file is included from the top-level CMakeLists.txt.  We just store it
 # here to avoid cluttering up that file.
 
-set(PKGNAME ${CMAKE_PROJECT_NAME} CACHE STRING
-  "Distribution package name (default: ${CMAKE_PROJECT_NAME})")
-set(PKGVENDOR "The ${CMAKE_PROJECT_NAME} Project" CACHE STRING
-  "Vendor name to be included in distribution package descriptions (default: The ${CMAKE_PROJECT_NAME} Project)")
-set(PKGURL "http://www.${CMAKE_PROJECT_NAME}.org" CACHE STRING
-  "URL of project web site to be included in distribution package descriptions (default: http://www.${CMAKE_PROJECT_NAME}.org)")
-set(PKGEMAIL "information@${CMAKE_PROJECT_NAME}.org" CACHE STRING
-  "E-mail of project maintainer to be included in distribution package descriptions (default: information@${CMAKE_PROJECT_NAME}.org")
-set(PKGID "com.${CMAKE_PROJECT_NAME}.${PKGNAME}" CACHE STRING
-  "Globally unique package identifier (reverse DNS notation) (default: com.${CMAKE_PROJECT_NAME}.${PKGNAME})")
-
-
 ###############################################################################
 # Linux RPM and DEB
 ###############################################################################

--- a/cmakescripts/PackageInfo.cmake
+++ b/cmakescripts/PackageInfo.cmake
@@ -1,0 +1,14 @@
+# This file is included from the top-level CMakeLists.txt.  We just store it
+# here to avoid cluttering up that file.
+
+set(PKGNAME ${CMAKE_PROJECT_NAME} CACHE STRING
+  "Distribution package name (default: ${CMAKE_PROJECT_NAME})")
+set(PKGVENDOR "The ${CMAKE_PROJECT_NAME} Project" CACHE STRING
+  "Vendor name to be included in distribution package descriptions (default: The ${CMAKE_PROJECT_NAME} Project)")
+set(PKGURL "http://www.${CMAKE_PROJECT_NAME}.org" CACHE STRING
+  "URL of project web site to be included in distribution package descriptions (default: http://www.${CMAKE_PROJECT_NAME}.org)")
+set(PKGEMAIL "information@${CMAKE_PROJECT_NAME}.org" CACHE STRING
+  "E-mail of project maintainer to be included in distribution package descriptions (default: information@${CMAKE_PROJECT_NAME}.org")
+set(PKGID "com.${CMAKE_PROJECT_NAME}.${PKGNAME}" CACHE STRING
+  "Globally unique package identifier (reverse DNS notation) (default: com.${CMAKE_PROJECT_NAME}.${PKGNAME})")
+  

--- a/sharedlib/CMakeLists.txt
+++ b/sharedlib/CMakeLists.txt
@@ -17,6 +17,22 @@ if(MSVC)
       string(REGEX REPLACE "/MT" "/MD" ${var} "${${var}}")
     endif()
   endforeach()
+  
+  # Create a resource script to embed version information in the DLL
+  if(JPEG_LIB_VERSION STREQUAL "62")
+    set(LIBJPEG_ABI_VERSION_STRING "6b")
+  else()
+    set(LIBJPEG_ABI_VERSION_STRING ${SO_MAJOR_VERSION})
+  endif()
+  set(DEFAULT_VERSIONINFO_COMPANY ${PKGVENDOR})
+  set(VERSIONINFO_COMPANY ${DEFAULT_VERSIONINFO_COMPANY} CACHE STRING
+  "Company that produced the libjpeg DLL (default: ${DEFAULT_VERSIONINFO_COMPANY})")
+  set(VERSIONINFO_COPYRIGHTS "Copyright (C) 1991-2020, Thomas G. Lane, Guido Vollbeding\nCopyright (C)2009-2022 D. R. Commander. All Rights Reserved.\nCopyright (C)2015 Viktor Szathmáry. All Rights Reserved.")
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/version.rc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+    @ONLY)
+  set(DLL_VERSIONINFO_RESOURCE_SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
 endif()
 
 foreach(src ${JPEG_SOURCES})
@@ -36,7 +52,7 @@ if(WIN32)
   endif()
 endif()
 add_library(jpeg SHARED ${JPEG_SRCS} ${DEFFILE} $<TARGET_OBJECTS:simd>
-  ${SIMD_OBJS})
+  ${SIMD_OBJS} ${DLL_VERSIONINFO_RESOURCE_SCRIPT})
 
 set_target_properties(jpeg PROPERTIES SOVERSION ${SO_MAJOR_VERSION}
   VERSION ${SO_MAJOR_VERSION}.${SO_AGE}.${SO_MINOR_VERSION})

--- a/sharedlib/version.rc.in
+++ b/sharedlib/version.rc.in
@@ -1,0 +1,35 @@
+#include "Winver.h"
+#include "winres.h"
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION @SO_MAJOR_VERSION@,@SO_MINOR_VERSION@,0,0
+ PRODUCTVERSION @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_REVISION@,0
+ FILEFLAGSMASK 0x17L
+#ifndef NDEBUG
+ FILEFLAGS VS_FF_DEBUG
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS VOS_NT_WINDOWS32
+ FILETYPE VFT_DLL
+ FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "@VERSIONINFO_COMPANY@"
+            VALUE "FileDescription", "libjpeg-turbo emulating libjpeg API/ABI v@LIBJPEG_ABI_VERSION_STRING@"
+            VALUE "FileVersion", "@JPEG_LIB_VERSION@"
+            VALUE "ProductVersion", "@VERSION@"
+            VALUE "ProductName", "@PKGNAME@"
+            VALUE "InternalName", "jpeg"
+            VALUE "LegalCopyright", "@VERSIONINFO_COPYRIGHTS@"
+            VALUE "OriginalFilename", "jpeg@SO_MAJOR_VERSION@.dll"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END


### PR DESCRIPTION
## Preamble

I am aware that `libjpeg-turbo` does not often take pull requests, but this is more of a build configuration enhancement rather than a library enhancement.

## Overview

 - Only affects `jpeg` shared library when built with `MSVC`
 - Makes it so that when you right-click the DLL and navigate to the Details tab, you find information about the `libjpeg-turbo` version that was used to create the emulated `libjpeg` library

#### Extra CMake Configuration

 1 new `CACHED` parameter is added so that the user can set their own `CompanyName` value, since that field is traditionally used to describe the company that actually built the file (as opposed to the company that wrote the source). 

The value defaults to the value of `PKGVENDOR`.

#### Why do this?

This information gives security auditors a better idea of the provenance of the turbo `libjpeg` library when it has been distributed in binary form on the Windows platform.