### PR TITLE
Cast diff bits before shift to avoid UB.

### DIFF
--- a/simd/arm/aarch64/jchuff-neon.c
+++ b/simd/arm/aarch64/jchuff-neon.c
@@ -250,7 +250,7 @@ JOCTET *jsimd_huff_encode_one_block_neon(void *state, JOCTET *buffer,
 #endif
   unsigned int nbits = 32 - lz;
   /* Emit Huffman-coded symbol and additional diff bits. */
-  unsigned int diff = (unsigned int)(vgetq_lane_u16(row0_diff, 0) << lz) >> lz;
+  unsigned int diff = ((unsigned int)vgetq_lane_u16(row0_diff, 0) << lz) >> lz;
   PUT_CODE(dctbl->ehufco[nbits], dctbl->ehufsi[nbits], diff)
 
   /* Encode AC coefficients. */


### PR DESCRIPTION
This avoids UndefinedBehavior Sanitizer reports such as

libjpeg-turbo/simd/arm/aarch64/jchuff-neon.c:253:67: runtime error:
left shift of 64511 by 21 places cannot be represented in type 'int'

since signed shift overflow is undefined. By C 6.5.7 3 both sides of a
bitwise shift operator are promoted and the type is that of the left
operand. In this case the left operand is uint16_t which, by C 6.3.1.1
is promoted to signed int. The shift then happened on the signed int and
the result later cast to unsigned int. Correct this by casting the
uint16_t to unsigned int first.