### PR TITLE
Replace magic numbers

### DIFF
--- a/jmemmgr.c
+++ b/jmemmgr.c
@@ -1156,7 +1156,7 @@ jinit_memory_mgr(j_common_ptr cinfo)
    */
 #ifndef NO_GETENV
   {
-    static const int memenv_size = 30;
+    enum { memenv_size = 30 };
     char memenv[memenv_size] = { 0 };
 
     if (!GETENV_S(memenv, memenv_size, "JPEGMEM") && strlen(memenv) > 0) {

--- a/jmemmgr.c
+++ b/jmemmgr.c
@@ -1156,9 +1156,10 @@ jinit_memory_mgr(j_common_ptr cinfo)
    */
 #ifndef NO_GETENV
   {
-    char memenv[30] = { 0 };
+    static const int memenv_size = 30;
+    char memenv[memenv_size] = { 0 };
 
-    if (!GETENV_S(memenv, 30, "JPEGMEM") && strlen(memenv) > 0) {
+    if (!GETENV_S(memenv, memenv_size, "JPEGMEM") && strlen(memenv) > 0) {
       char ch = 'x';
 
 #ifdef _MSC_VER

--- a/simd/arm/aarch32/jsimd.c
+++ b/simd/arm/aarch32/jsimd.c
@@ -105,7 +105,7 @@ LOCAL(void)
 init_simd(void)
 {
 #ifndef NO_GETENV
-  static const int env_size = 2;
+  enum { env_size = 2 };
   char env[env_size] = { 0 };
 #endif
 #if !defined(__ARM_NEON__) && (defined(__linux__) || defined(ANDROID) || defined(__ANDROID__))

--- a/simd/arm/aarch32/jsimd.c
+++ b/simd/arm/aarch32/jsimd.c
@@ -105,7 +105,8 @@ LOCAL(void)
 init_simd(void)
 {
 #ifndef NO_GETENV
-  char env[2] = { 0 };
+  static const int env_size = 2;
+  char env[env_size] = { 0 };
 #endif
 #if !defined(__ARM_NEON__) && (defined(__linux__) || defined(ANDROID) || defined(__ANDROID__))
   int bufsize = 1024; /* an initial guess for the line buffer size limit */
@@ -131,11 +132,11 @@ init_simd(void)
 
 #ifndef NO_GETENV
   /* Force different settings through environment variables */
-  if (!GETENV_S(env, 2, "JSIMD_FORCENEON") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_FORCENEON") && !strcmp(env, "1"))
     simd_support = JSIMD_NEON;
-  if (!GETENV_S(env, 2, "JSIMD_FORCENONE") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_FORCENONE") && !strcmp(env, "1"))
     simd_support = 0;
-  if (!GETENV_S(env, 2, "JSIMD_NOHUFFENC") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_NOHUFFENC") && !strcmp(env, "1"))
     simd_huffman = 0;
 #endif
 }

--- a/simd/arm/aarch64/jsimd.c
+++ b/simd/arm/aarch64/jsimd.c
@@ -125,7 +125,8 @@ LOCAL(void)
 init_simd(void)
 {
 #ifndef NO_GETENV
-  char env[2] = { 0 };
+  static const int env_size = 2;
+  char env[env_size] = { 0 };
 #endif
 #if defined(__linux__) || defined(ANDROID) || defined(__ANDROID__)
   int bufsize = 1024; /* an initial guess for the line buffer size limit */
@@ -147,19 +148,19 @@ init_simd(void)
 
 #ifndef NO_GETENV
   /* Force different settings through environment variables */
-  if (!GETENV_S(env, 2, "JSIMD_FORCENEON") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_FORCENEON") && !strcmp(env, "1"))
     simd_support = JSIMD_NEON;
-  if (!GETENV_S(env, 2, "JSIMD_FORCENONE") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_FORCENONE") && !strcmp(env, "1"))
     simd_support = 0;
-  if (!GETENV_S(env, 2, "JSIMD_NOHUFFENC") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_NOHUFFENC") && !strcmp(env, "1"))
     simd_huffman = 0;
-  if (!GETENV_S(env, 2, "JSIMD_FASTLD3") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_FASTLD3") && !strcmp(env, "1"))
     simd_features |= JSIMD_FASTLD3;
-  if (!GETENV_S(env, 2, "JSIMD_FASTLD3") && !strcmp(env, "0"))
+  if (!GETENV_S(env, env_size, "JSIMD_FASTLD3") && !strcmp(env, "0"))
     simd_features &= ~JSIMD_FASTLD3;
-  if (!GETENV_S(env, 2, "JSIMD_FASTST3") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_FASTST3") && !strcmp(env, "1"))
     simd_features |= JSIMD_FASTST3;
-  if (!GETENV_S(env, 2, "JSIMD_FASTST3") && !strcmp(env, "0"))
+  if (!GETENV_S(env, env_size, "JSIMD_FASTST3") && !strcmp(env, "0"))
     simd_features &= ~JSIMD_FASTST3;
 #endif
 }

--- a/simd/arm/aarch64/jsimd.c
+++ b/simd/arm/aarch64/jsimd.c
@@ -125,7 +125,7 @@ LOCAL(void)
 init_simd(void)
 {
 #ifndef NO_GETENV
-  static const int env_size = 2;
+  enum { env_size = 2 };
   char env[env_size] = { 0 };
 #endif
 #if defined(__linux__) || defined(ANDROID) || defined(__ANDROID__)

--- a/simd/i386/jsimd.c
+++ b/simd/i386/jsimd.c
@@ -44,7 +44,7 @@ LOCAL(void)
 init_simd(void)
 {
 #ifndef NO_GETENV
-  static const int env_size = 2;
+  enum { env_size = 2 };
   char env[env_size] = { 0 };
 #endif
 

--- a/simd/i386/jsimd.c
+++ b/simd/i386/jsimd.c
@@ -44,7 +44,8 @@ LOCAL(void)
 init_simd(void)
 {
 #ifndef NO_GETENV
-  char env[2] = { 0 };
+  static const int env_size = 2;
+  char env[env_size] = { 0 };
 #endif
 
   if (simd_support != ~0U)
@@ -54,19 +55,19 @@ init_simd(void)
 
 #ifndef NO_GETENV
   /* Force different settings through environment variables */
-  if (!GETENV_S(env, 2, "JSIMD_FORCEMMX") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_FORCEMMX") && !strcmp(env, "1"))
     simd_support &= JSIMD_MMX;
-  if (!GETENV_S(env, 2, "JSIMD_FORCE3DNOW") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_FORCE3DNOW") && !strcmp(env, "1"))
     simd_support &= JSIMD_3DNOW | JSIMD_MMX;
-  if (!GETENV_S(env, 2, "JSIMD_FORCESSE") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_FORCESSE") && !strcmp(env, "1"))
     simd_support &= JSIMD_SSE | JSIMD_MMX;
-  if (!GETENV_S(env, 2, "JSIMD_FORCESSE2") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_FORCESSE2") && !strcmp(env, "1"))
     simd_support &= JSIMD_SSE2;
-  if (!GETENV_S(env, 2, "JSIMD_FORCEAVX2") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_FORCEAVX2") && !strcmp(env, "1"))
     simd_support &= JSIMD_AVX2;
-  if (!GETENV_S(env, 2, "JSIMD_FORCENONE") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_FORCENONE") && !strcmp(env, "1"))
     simd_support = 0;
-  if (!GETENV_S(env, 2, "JSIMD_NOHUFFENC") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_NOHUFFENC") && !strcmp(env, "1"))
     simd_huffman = 0;
 #endif
 }

--- a/simd/x86_64/jsimd.c
+++ b/simd/x86_64/jsimd.c
@@ -44,7 +44,8 @@ LOCAL(void)
 init_simd(void)
 {
 #ifndef NO_GETENV
-  char env[2] = { 0 };
+  static const int env_size = 2;
+  char env[env_size] = { 0 };
 #endif
 
   if (simd_support != ~0U)
@@ -54,13 +55,13 @@ init_simd(void)
 
 #ifndef NO_GETENV
   /* Force different settings through environment variables */
-  if (!GETENV_S(env, 2, "JSIMD_FORCESSE2") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_FORCESSE2") && !strcmp(env, "1"))
     simd_support &= JSIMD_SSE2;
-  if (!GETENV_S(env, 2, "JSIMD_FORCEAVX2") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_FORCEAVX2") && !strcmp(env, "1"))
     simd_support &= JSIMD_AVX2;
-  if (!GETENV_S(env, 2, "JSIMD_FORCENONE") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_FORCENONE") && !strcmp(env, "1"))
     simd_support = 0;
-  if (!GETENV_S(env, 2, "JSIMD_NOHUFFENC") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "JSIMD_NOHUFFENC") && !strcmp(env, "1"))
     simd_huffman = 0;
 #endif
 }

--- a/simd/x86_64/jsimd.c
+++ b/simd/x86_64/jsimd.c
@@ -44,7 +44,7 @@ LOCAL(void)
 init_simd(void)
 {
 #ifndef NO_GETENV
-  static const int env_size = 2;
+  enum { env_size = 2 };
   char env[env_size] = { 0 };
 #endif
 

--- a/strtest.c
+++ b/strtest.c
@@ -55,7 +55,7 @@ void invalid_parameter_handler(const wchar_t *expression,
 int main(int argc, char **argv)
 {
   int err;
-  static const char env_size = 3;
+  enum { env_size = 3 };
   char env[env_size];
 
 #ifdef _MSC_VER

--- a/strtest.c
+++ b/strtest.c
@@ -55,7 +55,8 @@ void invalid_parameter_handler(const wchar_t *expression,
 int main(int argc, char **argv)
 {
   int err;
-  char env[3];
+  static const char env_size = 3;
+  char env[env_size];
 
 #ifdef _MSC_VER
   _set_invalid_parameter_handler(invalid_parameter_handler);
@@ -93,7 +94,7 @@ int main(int argc, char **argv)
   env[0] = 1;
   env[1] = 2;
   env[2] = 3;
-  err = GETENV_S(env, 3, NULL);
+  err = GETENV_S(env, env_size, NULL);
   CHECK_ERRNO(err, 0);
   CHECK_VALUE(env[0], 0, "env[0]");
   CHECK_VALUE(env[1], 2, "env[1]");
@@ -103,14 +104,14 @@ int main(int argc, char **argv)
   env[0] = 1;
   env[1] = 2;
   env[2] = 3;
-  err = GETENV_S(env, 3, "TESTENV2");
+  err = GETENV_S(env, env_size, "TESTENV2");
   CHECK_ERRNO(err, 0);
   CHECK_VALUE(env[0], 0, "env[0]");
   CHECK_VALUE(env[1], 2, "env[1]");
   CHECK_VALUE(env[2], 3, "env[2]");
 
   errno = 0;
-  err = GETENV_S(NULL, 3, "TESTENV");
+  err = GETENV_S(NULL, env_size, "TESTENV");
   CHECK_ERRNO(err, EINVAL);
 
   errno = 0;

--- a/turbojpeg.c
+++ b/turbojpeg.c
@@ -198,7 +198,7 @@ static int cs2pf[JPEG_NUMCS] = {
 }
 #ifdef _MSC_VER
 #define THROW_UNIX(m) { \
-  enum { strerrorBuf_size = 80 };
+  enum { strerrorBuf_size = 80 }; \
   char strerrorBuf[strerrorBuf_size] = { 0 }; \
   strerror_s(strerrorBuf, strerrorBuf_size, errno); \
   snprintf(errStr, JMSG_LENGTH_MAX, "%s\n%s", m, strerrorBuf); \

--- a/turbojpeg.c
+++ b/turbojpeg.c
@@ -198,7 +198,7 @@ static int cs2pf[JPEG_NUMCS] = {
 }
 #ifdef _MSC_VER
 #define THROW_UNIX(m) { \
-  static const int strerrorBuf_size = 80;
+  enum { strerrorBuf_size = 80 };
   char strerrorBuf[strerrorBuf_size] = { 0 }; \
   strerror_s(strerrorBuf, strerrorBuf_size, errno); \
   snprintf(errStr, JMSG_LENGTH_MAX, "%s\n%s", m, strerrorBuf); \
@@ -281,7 +281,7 @@ static void setCompDefaults(struct jpeg_compress_struct *cinfo,
                             int flags)
 {
 #ifndef NO_GETENV
-  static const int env_size = 7;
+  enum { env_size = 7 };
   char env[env_size] = { 0 };
 #endif
 

--- a/turbojpeg.c
+++ b/turbojpeg.c
@@ -198,8 +198,9 @@ static int cs2pf[JPEG_NUMCS] = {
 }
 #ifdef _MSC_VER
 #define THROW_UNIX(m) { \
-  char strerrorBuf[80] = { 0 }; \
-  strerror_s(strerrorBuf, 80, errno); \
+  static const int strerrorBuf_size = 80;
+  char strerrorBuf[strerrorBuf_size] = { 0 }; \
+  strerror_s(strerrorBuf, strerrorBuf_size, errno); \
   snprintf(errStr, JMSG_LENGTH_MAX, "%s\n%s", m, strerrorBuf); \
   retval = -1;  goto bailout; \
 }
@@ -280,7 +281,8 @@ static void setCompDefaults(struct jpeg_compress_struct *cinfo,
                             int flags)
 {
 #ifndef NO_GETENV
-  char env[7] = { 0 };
+  static const int env_size = 7;
+  char env[env_size] = { 0 };
 #endif
 
   cinfo->in_color_space = pf2cs[pixelFormat];
@@ -288,11 +290,11 @@ static void setCompDefaults(struct jpeg_compress_struct *cinfo,
   jpeg_set_defaults(cinfo);
 
 #ifndef NO_GETENV
-  if (!GETENV_S(env, 7, "TJ_OPTIMIZE") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "TJ_OPTIMIZE") && !strcmp(env, "1"))
     cinfo->optimize_coding = TRUE;
-  if (!GETENV_S(env, 7, "TJ_ARITHMETIC") && !strcmp(env, "1"))
+  if (!GETENV_S(env, env_size, "TJ_ARITHMETIC") && !strcmp(env, "1"))
     cinfo->arith_code = TRUE;
-  if (!GETENV_S(env, 7, "TJ_RESTART") && strlen(env) > 0) {
+  if (!GETENV_S(env, env_size, "TJ_RESTART") && strlen(env) > 0) {
     int temp = -1;
     char tempc = 0;
 
@@ -329,7 +331,7 @@ static void setCompDefaults(struct jpeg_compress_struct *cinfo,
   if (flags & TJFLAG_PROGRESSIVE)
     jpeg_simple_progression(cinfo);
 #ifndef NO_GETENV
-  else if (!GETENV_S(env, 7, "TJ_PROGRESSIVE") && !strcmp(env, "1"))
+  else if (!GETENV_S(env, env_size, "TJ_PROGRESSIVE") && !strcmp(env, "1"))
     jpeg_simple_progression(cinfo);
 #endif
 


### PR DESCRIPTION
In commit 607b668 several magic numbers were introduced.

This commit replaces those magic numbers with named constants.