### PR TITLE
Support architectures with alignof(void*)>alignof(double)

### DIFF
--- a/jmemmgr.c
+++ b/jmemmgr.c
@@ -68,10 +68,13 @@ round_up_pow2(size_t a, size_t b)
  * There isn't any really portable way to determine the worst-case alignment
  * requirement.  This module assumes that the alignment requirement is
  * multiples of ALIGN_SIZE.
- * By default, we define ALIGN_SIZE as sizeof(double).  This is necessary on
- * some workstations (where doubles really do need 8-byte alignment) and will
- * work fine on nearly everything.  If your machine has lesser alignment needs,
- * you can save a few bytes by making ALIGN_SIZE smaller.
+ * By default, we define ALIGN_SIZE as the maximum of sizeof(double) and
+ * sizeof(void *). This is necessary on some workstations (where doubles really
+ * do need 8-byte alignment) and will work fine on nearly everything. We use the
+ * maximum here since sizeof(double) may not sufficient e.g. on CHERI-enabled
+ * platforms where pointers can be 16 bytes and also require that alignment.
+ * If your machine has lesser alignment needs, you can save a few bytes by
+ * making ALIGN_SIZE smaller.
  * The only place I know of where this will NOT work is certain Macintosh
  * 680x0 compilers that define double as a 10-byte IEEE extended float.
  * Doing 10-byte alignment is counterproductive because longwords won't be
@@ -81,7 +84,7 @@ round_up_pow2(size_t a, size_t b)
 
 #ifndef ALIGN_SIZE              /* so can override from jconfig.h */
 #ifndef WITH_SIMD
-#define ALIGN_SIZE  sizeof(double)
+#define ALIGN_SIZE  MAX(sizeof(void *), sizeof(double))
 #else
 #define ALIGN_SIZE  32 /* Most of the SIMD instructions we support require
                           16-byte (128-bit) alignment, but AVX2 requires


### PR DESCRIPTION
When building with SIMD disabled, the memory allocations will align to
`sizeof(double)` right now. However, this may not be sufficient to load
or store pointers on architectures such as Arm Morello or 64-bit
CHERI-RISC-V where pointers require 16-byte alignment rather than 8.
This patch uses `MAX(sizeof(void*), sizeof(double))` to obtain the required
alignment, but with C11 we could instead use `alignof(max_align_t)`.