### PR TITLE
Explicitly pass ASM Compiler Target via CMake flags

### DIFF
--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -329,7 +329,7 @@ option(NEON_INTRINSICS
 if(NOT NEON_INTRINSICS)
   enable_language(ASM)
 
-  set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_ASM_FLAGS}")
+  set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_ASM_FLAGS} --target=${CMAKE_ASM_COMPILER_TARGET}")
 
   # Test whether gas-preprocessor.pl would be needed to build the GAS
   # implementation of the Neon SIMD extensions.  If so, then automatically


### PR DESCRIPTION
Without it some builds seem to fail to correctly detect the Assembler
during the Configure-phase, which leads to a loss of performance for the
resulting binaries.