### PR TITLE
Remove early-return for pre-existing Huffman tables

### DIFF
--- a/jstdhuff.c
+++ b/jstdhuff.c
@@ -25,8 +25,6 @@ add_huff_table(j_common_ptr cinfo, JHUFF_TBL **htblptr, const UINT8 *bits,
 
   if (*htblptr == NULL)
     *htblptr = jpeg_alloc_huff_table(cinfo);
-  else
-    return;
 
   /* Copy the number-of-symbols-of-each-code-length counts */
   memcpy((*htblptr)->bits, bits, sizeof((*htblptr)->bits));


### PR DESCRIPTION
This optimization step prevents an already existing Huffman table to
be re-initialized, which is exactly what one would want when the
encoding changes from custom tables to the default ones (while
re-using the same encoder).