### PR TITLE
Do not redefine strcasecmp/strncasecmp

### DIFF
--- a/tjutil.h
+++ b/tjutil.h
@@ -27,8 +27,12 @@
  */
 
 #ifdef _WIN32
+#ifndef strcasecmp
 #define strcasecmp  stricmp
+#endif
+#ifndef strncasecmp
 #define strncasecmp  strnicmp
+#endif
 #endif
 
 #ifdef _MSC_VER


### PR DESCRIPTION
mingw defines strcasecmp and strncasecmp in string.h. Check this to prevent a redefinition warning.