### PR TITLE
Build: Improve detetction of Loongson MMI

### DIFF
--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -449,6 +449,9 @@ elseif(CPU_TYPE STREQUAL "loongson" OR CPU_TYPE MATCHES "^mips64")
 set(CMAKE_REQUIRED_FLAGS -Wa,-mloongson-mmi,-mloongson-ext)
 
 check_c_source_compiles("
+  #if !(defined(__mips__) && __mips_isa_rev < 6)
+  #error Loongson MMI can't work with MIPS Release 6+
+  #endif
   int main(void) {
     int c = 0, a = 0, b = 0;
     asm (


### PR DESCRIPTION
MIPS R6 had removed some instructions and Loongson MMI
can't be built with MIPS R6+ toolchain.
Detect this in build system.

Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>