### PR TITLE
PowerPC: Detect AltiVec support at run-time on OS X

### DIFF
--- a/simd/powerpc/jsimd.c
+++ b/simd/powerpc/jsimd.c
@@ -29,7 +29,10 @@
 
 #include <ctype.h>
 
-#if defined(__OpenBSD__)
+#if defined(__APPLE__)
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#elif defined(__OpenBSD__)
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #include <machine/cpu.h>
@@ -119,6 +122,10 @@ init_simd(void)
   int bufsize = 1024; /* an initial guess for the line buffer size limit */
 #elif defined(__amigaos4__)
   uint32 altivec = 0;
+#elif defined(__APPLE__)
+  int mib[2] = { CTL_HW, HW_VECTORUNIT };
+  int altivec;
+  size_t len = sizeof(altivec);
 #elif defined(__OpenBSD__)
   int mib[2] = { CTL_MACHDEP, CPU_ALTIVEC };
   int altivec;
@@ -132,7 +139,7 @@ init_simd(void)
 
   simd_support = 0;
 
-#if defined(__ALTIVEC__) || defined(__APPLE__)
+#if defined(__ALTIVEC__)
   simd_support |= JSIMD_ALTIVEC;
 #elif defined(__linux__) || defined(ANDROID) || defined(__ANDROID__)
   while (!parse_proc_cpuinfo(bufsize)) {
@@ -144,7 +151,7 @@ init_simd(void)
   IExec->GetCPUInfoTags(GCIT_VectorUnit, &altivec, TAG_DONE);
   if (altivec == VECTORTYPE_ALTIVEC)
     simd_support |= JSIMD_ALTIVEC;
-#elif defined(__OpenBSD__)
+#elif defined(__APPLE__) || defined(__OpenBSD__)
   if (sysctl(mib, 2, &altivec, &len, NULL, 0) == 0 && altivec != 0)
     simd_support |= JSIMD_ALTIVEC;
 #elif defined(__FreeBSD__)


### PR DESCRIPTION
On OS X PowerPC, the code currently does this:

```c
#if defined(__ALTIVEC__) || defined(__APPLE__)
  simd_support |= JSIMD_ALTIVEC;
```

i.e. AltiVec is enabled by default on this target (unless you compile it without SIMD or use `JSIMD_FORCENONE`). But OS X 10.4 can also run on G3 processors, which have no AltiVec support, so it would trigger illegal instructions there.

The following PR does a run-time check with `sysctl()`, instead, as done by SDL1.2 and FFmpeg, for example.

Attached are `make test` logs on a machine with AltiVec and a second one without it. Tests are OK on both side, except for the `djpeg-*-3x2-float-prog-cmp` tests which fail for some reason on this platform?

**Note:** I actually don't have a real G3 running OSX; instead I'm booting OS X Tiger on a G4 with `novmx=1` so that the OS disables AltiVec support. This makes `sysctl hw.vectorunit` go from 1 to 0.

[libjpeg_turbo_tests_altivec_on.txt](https://github.com/libjpeg-turbo/libjpeg-turbo/files/9063243/libjpeg_turbo_tests_altivec_on.txt)
[libjpeg_turbo_tests_altivec_off.txt](https://github.com/libjpeg-turbo/libjpeg-turbo/files/9063242/libjpeg_turbo_tests_altivec_off.txt)