### PR TITLE
Use ASCII (C) symbol in resource files

### DIFF
--- a/win/jpeg.rc.in
+++ b/win/jpeg.rc.in
@@ -24,7 +24,7 @@ BEGIN
             VALUE "ProductVersion", "@VERSION@"
             VALUE "ProductName", "@CMAKE_PROJECT_NAME@"
             VALUE "InternalName", "jpeg@SO_MAJOR_VERSION@"
-            VALUE "LegalCopyright", "Copyright \xA9 @COPYRIGHT_YEAR@ The libjpeg-turbo Project and many others"
+            VALUE "LegalCopyright", "Copyright (C) @COPYRIGHT_YEAR@ The libjpeg-turbo Project and many others"
             VALUE "OriginalFilename", "jpeg@SO_MAJOR_VERSION@.dll"
         END
     END

--- a/win/turbojpeg.rc.in
+++ b/win/turbojpeg.rc.in
@@ -24,7 +24,7 @@ BEGIN
             VALUE "ProductVersion", "@VERSION@"
             VALUE "ProductName", "@CMAKE_PROJECT_NAME@"
             VALUE "InternalName", "turbojpeg"
-            VALUE "LegalCopyright", "Copyright \xA9 @COPYRIGHT_YEAR@ The libjpeg-turbo Project and many others"
+            VALUE "LegalCopyright", "Copyright (C) @COPYRIGHT_YEAR@ The libjpeg-turbo Project and many others"
             VALUE "OriginalFilename", "turbojpeg.dll"
         END
     END


### PR DESCRIPTION
Prior to this patch, compiling libjpeg-turbo using LLVM on Windows can fail depending on the current codepage:
```
llvm-rc: Error in VERSIONINFO statement (ID 1):
Non-ASCII 8-bit codepoint (169) can't occur in a non-Unicode string
```
The same issue may arise with MSVC's rc.exe.

It could probably also be fixed by making the `LegalCopyright` string a wide-string, but this avoids the issue altogether.