### PR TITLE
Declare JPEG_LIB_HAS_12BIT_SUPPORT in jpeglib.h when WITH_12BIT=ON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+jpeglib.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,6 +544,9 @@ if(UNIX AND NOT APPLE)
 endif()
 
 # Generate files
+set(JPEG_LIB_HAS_12BIT_SUPPORT ${WITH_12BIT})
+configure_file(jpeglib.h.in ${CMAKE_CURRENT_SOURCE_DIR}/jpeglib.h)
+
 if(WIN32)
   configure_file(win/jconfig.h.in jconfig.h)
 else()

--- a/jpeglib.h.in
+++ b/jpeglib.h.in
@@ -30,6 +30,8 @@
 #endif
 #include "jmorecfg.h"           /* seldom changed options */
 
+/* Defined when libjpeg has 12bit support */
+#cmakedefine JPEG_LIB_HAS_12BIT_SUPPORT
 
 #ifdef __cplusplus
 #ifndef DONT_USE_EXTERN_C


### PR DESCRIPTION
- Make jpeglib.h a generated file from jpeglib.h.in
- Define in it JPEG_LIB_HAS_12BIT_SUPPORT when WITH_12BIT=ON

This will make it easier for downstream users of libjpeg-turbo to know the capabilities of the build they are linking against.

Also add a .gitignore file