### PR TITLE
build: use CMAKE_CURRENT_SOURCE_DIR in case library is included in other project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,7 +624,7 @@ if(WITH_TURBOJPEG)
       set(TJMAPFILE ${CMAKE_CURRENT_SOURCE_DIR}/turbojpeg-mapfile.jni)
     endif()
     if(MSVC)
-      configure_file(${CMAKE_SOURCE_DIR}/win/turbojpeg.rc.in
+      configure_file(${CMAKE_CURRENT_SOURCE_DIR}/win/turbojpeg.rc.in
         ${CMAKE_BINARY_DIR}/win/turbojpeg.rc)
       set(TURBOJPEG_SOURCES ${TURBOJPEG_SOURCES}
         ${CMAKE_BINARY_DIR}/win/turbojpeg.rc)

--- a/sharedlib/CMakeLists.txt
+++ b/sharedlib/CMakeLists.txt
@@ -32,7 +32,7 @@ if(WIN32)
   set(DEFFILE ../win/jpeg${SO_MAJOR_VERSION}.def)
 endif()
 if(MSVC)
-  configure_file(${CMAKE_SOURCE_DIR}/win/jpeg.rc.in
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../win/jpeg.rc.in
     ${CMAKE_BINARY_DIR}/win/jpeg.rc)
   set(JPEG_SRCS ${JPEG_SRCS} ${CMAKE_BINARY_DIR}/win/jpeg.rc)
 endif()


### PR DESCRIPTION
Otherwise, the parent project source directory is used, which breaks the build.