### PR TITLE
Install the required header file jpegint.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1769,7 +1769,7 @@ install(EXPORT ${CMAKE_PROJECT_NAME}Targets
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/jconfig.h
   ${CMAKE_CURRENT_SOURCE_DIR}/jerror.h ${CMAKE_CURRENT_SOURCE_DIR}/jmorecfg.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/jpeglib.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/jpeglib.h ${CMAKE_CURRENT_SOURCE_DIR}/jpegint.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 include(cmakescripts/BuildPackages.cmake)


### PR DESCRIPTION
**Complete description of the bug fix or feature that this pull request implements**
libjpeg-turbo current port install the `jpeglib.h` header. In some case (advanced users) we want to use the entire API. In particular:

```
$ head -n 1122 ./vcpkg_installed/x64-windows-static/include/jpeglib.h | tail -1
#include "jpegint.h"            /* fetch private declarations */
```
Would you be able to also install `jpegint.h` next to `jpeglib.h`.

For details, see: https://github.com/microsoft/vcpkg/issues/31913. I will temporarily install jpegint.h in vcpkg as a patch, and remove it after your next release.

**Checklist before submitting the pull request, to maximize the chances that the pull request will be accepted**

- [x] Read CONTRIBUTING.md, a link to which appears under "Helpful resources" below.  That document discusses general guidelines for contributing to libjpeg-turbo, as well as the types of contributions that will not be accepted or are unlikely to be accepted.
- [x] Search the existing issues and pull requests (both open and closed) to ensure that a similar request has not already been submitted and rejected.
- [x] Discuss the proposed bug fix or feature in a GitHub issue, through direct e-mail with the project maintainer, or on the libjpeg-turbo-devel mailing list.
