### PR TITLE
Fix tjexample.c to work with VC++

### DIFF
--- a/tjexample.c
+++ b/tjexample.c
@@ -46,6 +46,8 @@
 #ifdef _WIN32
 #define strcasecmp  stricmp
 #define strncasecmp  strnicmp
+#define strnicmp _strnicmp
+#define stricmp _stricmp
 #endif
 
 #define THROW(action, message) { \
@@ -269,7 +271,7 @@ int main(int argc, char **argv)
     if (size == 0)
       THROW("determining input file size", "Input file contains no data");
     jpegSize = size;
-    if ((jpegBuf = tj3Alloc(jpegSize)) == NULL)
+    if ((jpegBuf = (unsigned char*)tj3Alloc(jpegSize)) == NULL)
       THROW_UNIX("allocating JPEG buffer");
     if (fread(jpegBuf, jpegSize, 1, jpegFile) < 1)
       THROW_UNIX("reading input file");


### PR DESCRIPTION
In order to compile as C++ with VC++ tjexample.c needs two more #defines and one more cast.

This pull request makes these changes, allowing tjexample.c to compile as a VC++ source file.

**Checklist before submitting the pull request, to maximize the chances that the pull request will be accepted**

- [X] Read CONTRIBUTING.md, a link to which appears under "Helpful resources" below.  That document discusses general guidelines for contributing to libjpeg-turbo, as well as the types of contributions that will not be accepted or are unlikely to be accepted.
- [X] Search the existing issues and pull requests (both open and closed) to ensure that a similar request has not already been submitted and rejected.
- [X] Discuss the proposed bug fix or feature in a GitHub issue, through direct e-mail with the project maintainer, or on the libjpeg-turbo-devel mailing list.

I created an issue and want to create this pull request to make the issue more concrete.
