### PR TITLE
ChangeLog.md: List CVE ID fixed by ccaba5d

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -415,7 +415,7 @@ transform a specially-crafted malformed JPEG image.
 
 1. Fixed a regression introduced by 2.1 beta1[6(b)] whereby attempting to
 decompress certain progressive JPEG images with one or more component planes of
-width 8 or less caused a buffer overrun.
+width 8 or less caused a buffer overrun (CVE-2021-29390).
 
 2. Fixed a regression introduced by 2.1 beta1[6(b)] whereby attempting to
 decompress a specially-crafted malformed progressive JPEG image caused the


### PR DESCRIPTION
**Complete description of the bug fix or feature that this pull request implements**
https://nvd.nist.gov/vuln/detail/CVE-2021-29390 has been made public a couple weeks ago.
Using the POC from https://bugzilla.redhat.com/show_bug.cgi?id=1943797, I bisected the correction to ccaba5d (it was not the same POC than the one from oss-fuzz).

The PR adds a reference to the CVE ID in the change log.

Please do note that [SNYK](https://security.snyk.io/vuln/SNYK-UNMANAGED-LIBJPEGTURBO-5880501) is listing another commit (https://github.com/libjpeg-turbo/libjpeg-turbo/commit/c7ca521bc85b57d41d3ad4963c13fc0100481084) as fix for this CVE.

**Checklist before submitting the pull request, to maximize the chances that the pull request will be accepted**

- [x] Read CONTRIBUTING.md, a link to which appears under "Helpful resources" below.  That document discusses general guidelines for contributing to libjpeg-turbo, as well as the types of contributions that will not be accepted or are unlikely to be accepted.
- [x] Search the existing issues and pull requests (both open and closed) to ensure that a similar request has not already been submitted and rejected.
- [ ] Discuss the proposed bug fix or feature in a GitHub issue, through direct e-mail with the project maintainer, or on the libjpeg-turbo-devel mailing list.
