### PR TITLE
Initialize msg_parm fields in jpeg_std_error.

### DIFF
--- a/jerror.c
+++ b/jerror.c
@@ -235,9 +235,15 @@ jpeg_std_error(struct jpeg_error_mgr *err)
   err->format_message = format_message;
   err->reset_error_mgr = reset_error_mgr;
 
+  err->msg_code = 0;            /* may be useful as a flag for "no error" */
+
+  err->msg_parm.i[0] = err->msg_parm.i[1] =
+  err->msg_parm.i[2] = err->msg_parm.i[3] =
+  err->msg_parm.i[4] = err->msg_parm.i[5] =
+  err->msg_parm.i[6] = err->msg_parm.i[7] = 0;  /* initialize before use */
+
   err->trace_level = 0;         /* default = no tracing */
   err->num_warnings = 0;        /* no warnings emitted yet */
-  err->msg_code = 0;            /* may be useful as a flag for "no error" */
 
   /* Initialize message table pointers */
   err->jpeg_message_table = jpeg_std_message_table;


### PR DESCRIPTION
When libjpeg-turbo reports an error, it calls SNPRINTF, and passes in all eight values from jpeg_error_mgr::msg_parm.i[0] through i[7], regardless of the contents of the format string. (See https://github.com/libjpeg-turbo/libjpeg-turbo/blob/main/jerror.c#L194-L198 ) However, if the format string doesn't actually reference any values, those fields are never initialized anywhere, so uninitialized data is passed.

Whether or not these values are actually used to assemble the final error message, MSAN doesn't like that we are passing uninitialized values into SNPRINTF, and emits a use-of-uninitialized-value report.

This PR explicitly zeros out the msg_parm fields inside jpeg_std_error, to ensure that uninitialized values are never passed into SNPRINTF.