### PR TITLE
Decode Lossless JPEG images with valid values of BitsPerSample

### DIFF
--- a/jdapistd.c
+++ b/jdapistd.c
@@ -313,7 +313,7 @@ _jpeg_read_scanlines(j_decompress_ptr cinfo, _JSAMPARRAY scanlines,
 #if BITS_IN_JSAMPLE != 16 || defined(D_LOSSLESS_SUPPORTED)
   JDIMENSION row_ctr;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
+  if (cinfo->data_precision > BITS_IN_JSAMPLE)
     ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   if (cinfo->global_state != DSTATE_SCANNING)

--- a/jdcolor.c
+++ b/jdcolor.c
@@ -759,7 +759,7 @@ _jinit_color_deconverter(j_decompress_ptr cinfo)
   my_cconvert_ptr cconvert;
   int ci;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
+  if (cinfo->data_precision > BITS_IN_JSAMPLE)
     ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   cconvert = (my_cconvert_ptr)

--- a/jdinput.c
+++ b/jdinput.c
@@ -58,8 +58,7 @@ initial_setup(j_decompress_ptr cinfo)
 
   /* For now, precision must match compiled-in value... */
 #ifdef D_LOSSLESS_SUPPORTED
-  if (cinfo->data_precision != 8 && cinfo->data_precision != 12 &&
-      cinfo->data_precision != 16)
+  if (!(2 <= cinfo->data_precision && cinfo->data_precision <= 16))
 #else
   if (cinfo->data_precision != 8 && cinfo->data_precision != 12)
 #endif

--- a/jdmainct.c
+++ b/jdmainct.c
@@ -431,7 +431,7 @@ _jinit_d_main_controller(j_decompress_ptr cinfo, boolean need_full_buffer)
   int ci, rgroup, ngroups;
   jpeg_component_info *compptr;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
+  if (cinfo->data_precision > BITS_IN_JSAMPLE)
     ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   main_ptr = (my_main_ptr)

--- a/jdmaster.c
+++ b/jdmaster.c
@@ -422,7 +422,7 @@ prepare_range_limit_table(j_decompress_ptr cinfo)
 #endif
   int i;
 
-  if (cinfo->data_precision == 16) {
+  if (12 < cinfo->data_precision && cinfo->data_precision <= 16) {
 #ifdef D_LOSSLESS_SUPPORTED
     table16 = (J16SAMPLE *)
       (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
@@ -615,7 +615,7 @@ master_selection(j_decompress_ptr cinfo)
       ERREXIT(cinfo, JERR_NOT_COMPILED);
 #endif
     } else {
-      if (cinfo->data_precision == 16) {
+      if (12 < cinfo->data_precision && cinfo->data_precision <= 16) {
 #ifdef D_LOSSLESS_SUPPORTED
         j16init_color_deconverter(cinfo);
         j16init_upsampler(cinfo);
@@ -630,7 +630,7 @@ master_selection(j_decompress_ptr cinfo)
         jinit_upsampler(cinfo);
       }
     }
-    if (cinfo->data_precision == 16)
+    if (12 < cinfo->data_precision && cinfo->data_precision <= 16)
 #ifdef D_LOSSLESS_SUPPORTED
       j16init_d_post_controller(cinfo, cinfo->enable_2pass_quant);
 #else
@@ -647,7 +647,7 @@ master_selection(j_decompress_ptr cinfo)
     /* Prediction, sample undifferencing, point transform, and sample size
      * scaling
      */
-    if (cinfo->data_precision == 16)
+    if (12 < cinfo->data_precision && cinfo->data_precision <= 16)
       j16init_lossless_decompressor(cinfo);
     else if (cinfo->data_precision == 12)
       j12init_lossless_decompressor(cinfo);
@@ -663,7 +663,7 @@ master_selection(j_decompress_ptr cinfo)
     /* Initialize principal buffer controllers. */
     use_c_buffer = cinfo->inputctl->has_multiple_scans ||
                    cinfo->buffered_image;
-    if (cinfo->data_precision == 16)
+    if (12 < cinfo->data_precision && cinfo->data_precision <= 16)
       j16init_d_diff_controller(cinfo, use_c_buffer);
     else if (cinfo->data_precision == 12)
       j12init_d_diff_controller(cinfo, use_c_buffer);
@@ -708,7 +708,7 @@ master_selection(j_decompress_ptr cinfo)
   }
 
   if (!cinfo->raw_data_out) {
-    if (cinfo->data_precision == 16)
+    if (12 < cinfo->data_precision && cinfo->data_precision <= 16)
 #ifdef D_LOSSLESS_SUPPORTED
       j16init_d_main_controller(cinfo,
                                 FALSE /* never need full buffer here */);

--- a/jdpostct.c
+++ b/jdpostct.c
@@ -267,7 +267,7 @@ _jinit_d_post_controller(j_decompress_ptr cinfo, boolean need_full_buffer)
 {
   my_post_ptr post;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
+  if (cinfo->data_precision > BITS_IN_JSAMPLE)
     ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   post = (my_post_ptr)

--- a/jdsample.c
+++ b/jdsample.c
@@ -421,7 +421,7 @@ _jinit_upsampler(j_decompress_ptr cinfo)
   boolean need_buffer, do_fancy;
   int h_in_group, v_in_group, h_out_group, v_out_group;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
+  if (cinfo->data_precision > BITS_IN_JSAMPLE)
     ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   if (!cinfo->master->jinit_upsampler_no_alloc) {

--- a/jmemmgr.c
+++ b/jmemmgr.c
@@ -449,7 +449,7 @@ alloc_sarray(j_common_ptr cinfo, int pool_id, JDIMENSION samplesperrow,
   int data_precision = cinfo->is_decompressor ?
                         ((j_decompress_ptr)cinfo)->data_precision :
                         ((j_compress_ptr)cinfo)->data_precision;
-  size_t sample_size = data_precision == 16 ?
+  size_t sample_size = (12 < data_precision && data_precision <= 16) ?
                        sizeof(J16SAMPLE) : (data_precision == 12 ?
                                             sizeof(J12SAMPLE) :
                                             sizeof(JSAMPLE));
@@ -477,7 +477,7 @@ alloc_sarray(j_common_ptr cinfo, int pool_id, JDIMENSION samplesperrow,
     rowsperchunk = numrows;
   mem->last_rowsperchunk = rowsperchunk;
 
-  if (data_precision == 16) {
+  if (12 < data_precision && data_precision <= 16) {
 #if defined(C_LOSSLESS_SUPPORTED) || defined(D_LOSSLESS_SUPPORTED)
     /* Get space for row pointers (small object) */
     result16 = (J16SAMPARRAY)alloc_small(cinfo, pool_id,
@@ -703,7 +703,7 @@ realize_virt_arrays(j_common_ptr cinfo)
   int data_precision = cinfo->is_decompressor ?
                         ((j_decompress_ptr)cinfo)->data_precision :
                         ((j_compress_ptr)cinfo)->data_precision;
-  size_t sample_size = data_precision == 16 ?
+  size_t sample_size = (12 < data_precision && data_precision <= 16) ?
                        sizeof(J16SAMPLE) : (data_precision == 12 ?
                                             sizeof(J12SAMPLE) :
                                             sizeof(JSAMPLE));
@@ -821,7 +821,7 @@ do_sarray_io(j_common_ptr cinfo, jvirt_sarray_ptr ptr, boolean writing)
   int data_precision = cinfo->is_decompressor ?
                         ((j_decompress_ptr)cinfo)->data_precision :
                         ((j_compress_ptr)cinfo)->data_precision;
-  size_t sample_size = data_precision == 16 ?
+  size_t sample_size = (12 < data_precision && data_precision <= 16) ?
                        sizeof(J16SAMPLE) : (data_precision == 12 ?
                                             sizeof(J12SAMPLE) :
                                             sizeof(JSAMPLE));
@@ -840,7 +840,7 @@ do_sarray_io(j_common_ptr cinfo, jvirt_sarray_ptr ptr, boolean writing)
     if (rows <= 0)              /* this chunk might be past end of file! */
       break;
     byte_count = rows * bytesperrow;
-    if (data_precision == 16) {
+    if (12 < data_precision && data_precision <= 16) {
 #if defined(C_LOSSLESS_SUPPORTED) || defined(D_LOSSLESS_SUPPORTED)
       J16SAMPARRAY mem_buffer16 = (J16SAMPARRAY)ptr->mem_buffer;
 
@@ -926,7 +926,7 @@ access_virt_sarray(j_common_ptr cinfo, jvirt_sarray_ptr ptr,
   int data_precision = cinfo->is_decompressor ?
                         ((j_decompress_ptr)cinfo)->data_precision :
                         ((j_compress_ptr)cinfo)->data_precision;
-  size_t sample_size = data_precision == 16 ?
+  size_t sample_size = (12 < data_precision && data_precision <= 16) ?
                        sizeof(J16SAMPLE) : (data_precision == 12 ?
                                             sizeof(J12SAMPLE) :
                                             sizeof(JSAMPLE));


### PR DESCRIPTION
**Complete description of the bug fix or feature that this pull request implements**
This is the minimum change required to make the library usable for decoding Lossless JPEG images encoded with any valid values of BitsPerSample other than 8, 12, or 16.

Fixes: #768

**Checklist before submitting the pull request, to maximize the chances that the pull request will be accepted**

- [x] Read CONTRIBUTING.md, a link to which appears under "Helpful resources" below.  That document discusses general guidelines for contributing to libjpeg-turbo, as well as the types of contributions that will not be accepted or are unlikely to be accepted.
- [x] Search the existing issues and pull requests (both open and closed) to ensure that a similar request has not already been submitted and rejected.
- [x] Discuss the proposed bug fix or feature in a GitHub issue, through direct e-mail with the project maintainer, or on the libjpeg-turbo-devel mailing list.
