### PR TITLE
Fix accidental control line in jpegtran.1

### DIFF
--- a/jpegtran.1
+++ b/jpegtran.1
@@ -167,7 +167,7 @@ on an iMCU boundary.  If it doesn't, then it is silently moved up and/or left
 to the nearest iMCU boundary (the lower right corner is unchanged.)  Thus, the
 output image covers at least the requested region, but it may cover more.  The
 adjustment of the region dimensions may be optionally disabled by attaching an
-'f' character ("force") to the width or height number.
+\&'f' character ("force") to the width or height number.
 
 The image can be losslessly cropped by giving the switch:
 .TP


### PR DESCRIPTION
Apologies, I didn't go through the checklist, but I think this is pretty straightforward. Before this change, a paragraph gets truncated in "man jpegtran" output.