### PR TITLE
Change gastest output file location into build directory

### DIFF
--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -366,6 +366,7 @@ if(NOT NEON_INTRINSICS)
   separate_arguments(CMAKE_ASM_FLAGS_SEP UNIX_COMMAND "${CMAKE_ASM_FLAGS}")
   execute_process(COMMAND ${CMAKE_ASM_COMPILER} ${CMAKE_ASM_FLAGS_SEP}
       -x assembler-with-cpp -c ${CMAKE_CURRENT_BINARY_DIR}/gastest.S
+      -o ${CMAKE_CURRENT_BINARY_DIR}/gastest.o
     RESULT_VARIABLE RESULT OUTPUT_VARIABLE OUTPUT ERROR_VARIABLE ERROR)
   if(NOT RESULT EQUAL 0)
     message(WARNING "GAS appears to be broken.  Using the full Neon SIMD intrinsics implementation.")


### PR DESCRIPTION
Hi
While I was trying to build the project, I noticed an artifact appearing on project root dir named gastest.o.
I found this inconviniat and thought it would be nicer if this file placed in build directory.