### PR TITLE
WITH_CALLOC mode to resolve SIMD related valgrind warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,7 @@ boolean_number(WITH_SIMD)
 option(WITH_TURBOJPEG
   "Include the TurboJPEG API library and associated test programs" TRUE)
 boolean_number(WITH_TURBOJPEG)
+option(WITH_CALLOC "Use calloc" TRUE)
 option(WITH_FUZZ "Build fuzz targets" FALSE)
 
 macro(report_option var desc)
@@ -624,6 +625,10 @@ if(WITH_SIMD)
   endif()
 else()
   message(STATUS "SIMD extensions: None (WITH_SIMD = ${WITH_SIMD})")
+endif()
+
+if (WITH_CALLOC)
+    add_definitions(-DWITH_CALLOC)
 endif()
 
 # We have to generate these here, because if the build system tries and fails

--- a/jmemnobs.c
+++ b/jmemnobs.c
@@ -31,7 +31,11 @@
 GLOBAL(void *)
 jpeg_get_small(j_common_ptr cinfo, size_t sizeofobject)
 {
+#ifdef WITH_CALLOC
+  return (void *)calloc(1, sizeofobject);
+#else
   return (void *)malloc(sizeofobject);
+#endif
 }
 
 GLOBAL(void)
@@ -48,7 +52,11 @@ jpeg_free_small(j_common_ptr cinfo, void *object, size_t sizeofobject)
 GLOBAL(void *)
 jpeg_get_large(j_common_ptr cinfo, size_t sizeofobject)
 {
+#ifdef WITH_CALLOC
+  return (void *)calloc(1, sizeofobject);
+#else
   return (void *)malloc(sizeofobject);
+#endif
 }
 
 GLOBAL(void)


### PR DESCRIPTION
In relation to the discussion in Issue #619 

I've been chasing some instablity in some OpenCV-based C++.
One of the more mysterious valgrind messages concerned RGB loaded from JPEG.
`Conditional jump or move depends on uninitialised value(s)`

I was also able to reproduce a similar issue with djpeg:
```
$ valgrind  "--tool=memcheck" "--leak-check=full" "--num-callers=25" "--errors-for-leak-kinds=definite" "--show-leak-kinds=definite" --track-origins=yes --expensive-definedness-checks=yes -- build/install/bin/djpeg -verbose -outfile test.ppm input.jpg
==1159678== Memcheck, a memory error detector
==1159678== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1159678== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==1159678== Command: build/install/bin/djpeg -verbose -outfile test.ppm input.jpg
==1159678==
libjpeg-turbo version 3.0.2 (build 20240807)
Copyright (C) 2009-2024 D. R. Commander
Copyright (C) 2015, 2020 Google, Inc.
Copyright (C) 2019-2020 Arm Limited
Copyright (C) 2015-2016, 2018 Matthieu Darbois
Copyright (C) 2011-2016 Siarhei Siamashka
Copyright (C) 2015 Intel Corporation
Copyright (C) 2013-2014 Linaro Limited
Copyright (C) 2013-2014 MIPS Technologies, Inc.
Copyright (C) 2009, 2012 Pierre Ossman for Cendio AB
Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies)
Copyright (C) 1999-2006 MIYASAKA Masaru
Copyright (C) 1999 Ken Murchison
Copyright (C) 1991-2020 Thomas G. Lane, Guido Vollbeding

Emulating The Independent JPEG Group's software, version 6b  27-Mar-1998

Start of Image
JFIF APP0 marker: version 1.01, density 1x1  0
Define Quantization Table 0  precision 0
Define Quantization Table 1  precision 0
Start Of Frame 0xc0: width=3407, height=1916, components=3
    Component 1: 2hx2v q=0
    Component 2: 1hx1v q=1
    Component 3: 1hx1v q=1
Define Huffman Table 0x00
Define Huffman Table 0x10
Define Huffman Table 0x01
Define Huffman Table 0x11
Start Of Scan: 3 components
    Component 1: dc=0 ac=0
    Component 2: dc=1 ac=1
    Component 3: dc=1 ac=1
  Ss=0, Se=63, Ah=0, Al=0
==1159678== Syscall param write(buf) points to uninitialised byte(s)
==1159678==    at 0x4974297: write (write.c:26)
==1159678==    by 0x48F4E8C: _IO_file_write@@GLIBC_2.2.5 (fileops.c:1181)
==1159678==    by 0x48F6950: new_do_write (fileops.c:449)
==1159678==    by 0x48F6950: _IO_new_do_write (fileops.c:426)
==1159678==    by 0x48F6950: _IO_do_write@@GLIBC_2.2.5 (fileops.c:423)
==1159678==    by 0x48F56B4: _IO_new_file_xsputn (fileops.c:1244)
==1159678==    by 0x48F56B4: _IO_file_xsputn@@GLIBC_2.2.5 (fileops.c:1197)
==1159678==    by 0x48E93C0: fwrite (iofwrite.c:39)
==1159678==    by 0x1105CA: put_pixel_rows (wrppm.c:96)
==1159678==    by 0x10C79F: main (djpeg.c:874)
==1159678==  Address 0x4a81c21 is 17 bytes inside a block of size 4,096 alloc'd
==1159678==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==1159678==    by 0x48E7D03: _IO_file_doallocate (filedoalloc.c:101)
==1159678==    by 0x48F7ECF: _IO_doallocbuf (genops.c:347)
==1159678==    by 0x48F6F2F: _IO_file_overflow@@GLIBC_2.2.5 (fileops.c:745)
==1159678==    by 0x48F56B4: _IO_new_file_xsputn (fileops.c:1244)
==1159678==    by 0x48F56B4: _IO_file_xsputn@@GLIBC_2.2.5 (fileops.c:1197)
==1159678==    by 0x48DC971: __vfprintf_internal (vfprintf-internal.c:1373)
==1159678==    by 0x48C7C69: fprintf (fprintf.c:32)
==1159678==    by 0x110C2A: start_output_ppm (wrppm.c:263)
==1159678==    by 0x10C65B: main (djpeg.c:849)
==1159678==
==1159678== Syscall param write(buf) points to uninitialised byte(s)
==1159678==    at 0x4974297: write (write.c:26)
==1159678==    by 0x48F4E8C: _IO_file_write@@GLIBC_2.2.5 (fileops.c:1181)
==1159678==    by 0x48F57A7: new_do_write (fileops.c:449)
==1159678==    by 0x48F57A7: _IO_new_file_xsputn (fileops.c:1255)
==1159678==    by 0x48F57A7: _IO_file_xsputn@@GLIBC_2.2.5 (fileops.c:1197)
==1159678==    by 0x48E93C0: fwrite (iofwrite.c:39)
==1159678==    by 0x1105CA: put_pixel_rows (wrppm.c:96)
==1159678==    by 0x10C79F: main (djpeg.c:874)
==1159678==  Address 0x4a5ffcf is 4,543 bytes inside a block of size 16,343 alloc'd
==1159678==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==1159678==    by 0x123BEF: jpeg_get_small (jmemnobs.c:34)
==1159678==    by 0x121EBD: alloc_small (jmemmgr.c:317)
==1159678==    by 0x11A89E: get_sof (jdmarker.c:282)
==1159678==    by 0x11D899: read_markers (jdmarker.c:997)
==1159678==    by 0x11A04E: consume_markers (jdinput.c:334)
==1159678==    by 0x118962: jpeg_consume_input (jdapimin.c:323)
==1159678==    by 0x11885E: jpeg_read_header (jdapimin.c:271)
==1159678==    by 0x10BBBD: main (djpeg.c:649)
==1159678==
==1159678== Syscall param write(buf) points to uninitialised byte(s)
==1159678==    at 0x4974297: write (write.c:26)
==1159678==    by 0x48F4E8C: _IO_file_write@@GLIBC_2.2.5 (fileops.c:1181)
==1159678==    by 0x48F6950: new_do_write (fileops.c:449)
==1159678==    by 0x48F6950: _IO_new_do_write (fileops.c:426)
==1159678==    by 0x48F6950: _IO_do_write@@GLIBC_2.2.5 (fileops.c:423)
==1159678==    by 0x48F4477: _IO_file_sync@@GLIBC_2.2.5 (fileops.c:799)
==1159678==    by 0x48E83C5: fflush (iofflush.c:40)
==1159678==    by 0x110C75: finish_output_ppm (wrppm.c:280)
==1159678==    by 0x10C94F: main (djpeg.c:912)
==1159678==  Address 0x4a81c10 is 0 bytes inside a block of size 4,096 alloc'd
==1159678==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==1159678==    by 0x48E7D03: _IO_file_doallocate (filedoalloc.c:101)
==1159678==    by 0x48F7ECF: _IO_doallocbuf (genops.c:347)
==1159678==    by 0x48F6F2F: _IO_file_overflow@@GLIBC_2.2.5 (fileops.c:745)
==1159678==    by 0x48F56B4: _IO_new_file_xsputn (fileops.c:1244)
==1159678==    by 0x48F56B4: _IO_file_xsputn@@GLIBC_2.2.5 (fileops.c:1197)
==1159678==    by 0x48DC971: __vfprintf_internal (vfprintf-internal.c:1373)
==1159678==    by 0x48C7C69: fprintf (fprintf.c:32)
==1159678==    by 0x110C2A: start_output_ppm (wrppm.c:263)
==1159678==    by 0x10C65B: main (djpeg.c:849)
==1159678==
End Of Image
==1159678==
==1159678== HEAP SUMMARY:
==1159678==     in use at exit: 0 bytes in 0 blocks
==1159678==   total heap usage: 16 allocs, 16 frees, 161,693 bytes allocated
==1159678==
==1159678== All heap blocks were freed -- no leaks are possible
==1159678==
==1159678== For lists of detected and suppressed errors, rerun with: -s
==1159678== ERROR SUMMARY: 3833 errors from 3 contexts (suppressed: 0 from 0)
```

I found that disabling SIMD makes valgrind happy.
But the other solution is to use calloc rather than malloc.

As formulated here, a build-time opt-in: `-DWITH_CALLOC=Y`
