### PR TITLE
all: Optimization using data alignment for 64-bit platforms

### DIFF
--- a/src/jquant1.c
+++ b/src/jquant1.c
@@ -145,25 +145,24 @@ typedef struct {
   struct jpeg_color_quantizer pub; /* public fields */
 
   /* Initially allocated colormap is saved here */
-  _JSAMPARRAY sv_colormap;      /* The color map as a 2-D pixel array */
-  int sv_actual;                /* number of entries in use */
-
   _JSAMPARRAY colorindex;       /* Precomputed mapping for speed */
   /* colorindex[i][j] = index of color closest to pixel value j in component i,
    * premultiplied as described above.  Since colormap indexes must fit into
    * _JSAMPLEs, the entries of this array will too.
    */
+  _JSAMPARRAY sv_colormap;      /* The color map as a 2-D pixel array */
+  int sv_actual;                /* number of entries in use */
   boolean is_padded;            /* is the colorindex padded for odither? */
 
   int Ncolors[MAX_Q_COMPS];     /* # of values allocated to each component */
 
   /* Variables for ordered dithering */
-  int row_index;                /* cur row's vertical index in dither matrix */
   ODITHER_MATRIX_PTR odither[MAX_Q_COMPS]; /* one dither array per component */
+  int row_index;                /* cur row's vertical index in dither matrix */
 
   /* Variables for Floyd-Steinberg dithering */
-  FSERRPTR fserrors[MAX_Q_COMPS]; /* accumulated errors */
   boolean on_odd_row;           /* flag to remember which row we are on */
+  FSERRPTR fserrors[MAX_Q_COMPS]; /* accumulated errors */
 } my_cquantizer;
 
 typedef my_cquantizer *my_cquantize_ptr;

--- a/src/jquant2.c
+++ b/src/jquant2.c
@@ -177,15 +177,15 @@ typedef struct {
   _JSAMPARRAY sv_colormap;      /* colormap allocated at init time */
   int desired;                  /* desired # of colors = size of colormap */
 
+  boolean needs_zeroed;         /* TRUE if next pass must zero histogram */
+
   /* Variables for accumulating image statistics */
   hist3d histogram;             /* pointer to the histogram */
 
-  boolean needs_zeroed;         /* TRUE if next pass must zero histogram */
-
   /* Variables for Floyd-Steinberg dithering */
   FSERRPTR fserrors;            /* accumulated errors */
-  boolean on_odd_row;           /* flag to remember which row we are on */
   int *error_limiter;           /* table for clamping the applied error */
+  boolean on_odd_row;           /* flag to remember which row we are on */
 } my_cquantizer;
 
 typedef my_cquantizer *my_cquantize_ptr;

--- a/src/rdtarga.c
+++ b/src/rdtarga.c
@@ -50,11 +50,11 @@ typedef struct _tga_source_struct {
   jvirt_sarray_ptr whole_image; /* Needed if funny input row order */
   JDIMENSION current_row;       /* Current logical row number to read */
 
-  /* Pointer to routine to extract next Targa pixel from input file */
-  void (*read_pixel) (tga_source_ptr sinfo);
-
   /* Result of read_pixel is delivered here: */
   U_CHAR tga_pixel[4];
+
+  /* Pointer to routine to extract next Targa pixel from input file */
+  void (*read_pixel) (tga_source_ptr sinfo);
 
   int pixel_size;               /* Bytes per Targa pixel (1 to 4) */
   int cmap_length;              /* colormap length */

--- a/src/wrbmp.c
+++ b/src/wrbmp.c
@@ -52,12 +52,6 @@ typedef struct {
 
   boolean is_os2;               /* saves the OS2 format request flag */
 
-  jvirt_sarray_ptr whole_image; /* needed to reverse row order */
-  JDIMENSION data_width;        /* JSAMPLEs per row */
-  JDIMENSION row_width;         /* physical width of one row in the BMP file */
-  int pad_bytes;                /* number of padding bytes needed per row */
-  JDIMENSION cur_output_row;    /* next row# to write to virtual array */
-
   boolean use_inversion_array;  /* TRUE = buffer the whole image, which is
                                    stored to disk in bottom-up order, and
                                    receive rows from the calling program in
@@ -66,6 +60,12 @@ typedef struct {
                                    FALSE = the calling program will maintain
                                    its own image buffer and write the rows in
                                    bottom-up order */
+
+  jvirt_sarray_ptr whole_image; /* needed to reverse row order */
+  JDIMENSION data_width;        /* JSAMPLEs per row */
+  JDIMENSION row_width;         /* physical width of one row in the BMP file */
+  int pad_bytes;                /* number of padding bytes needed per row */
+  JDIMENSION cur_output_row;    /* next row# to write to virtual array */
 
   JSAMPLE *iobuffer;            /* I/O buffer (used to buffer a single row to
                                    disk if use_inversion_array == FALSE) */


### PR DESCRIPTION
@dcommander,
I decided to do this by looking at the organization of memory in the processor cache lines in `libjpeg-turbo`, and I noticed that `libjpeg-turbo` really uses large structures. It is desirable that the structures are no more than `64 bytes` or a multiple of 64 bytes (division without remainder), so it will be easier for `C/C++/C#` compiler to process them. Since it is very difficult to recycle structures, I solved the problem easier.

Out of habit, I aligned him.

This PR will decrease costs copying, moving, and creating object-structures only for common 64bit processors due to the 8-byte data alignment.
Smaller size structure or class, higher chance putting into CPU cache. Most processors are already 64 bit, so the change won't make it any worse.

If you know how to use pahole (https://linux.die.net/man/1/pahole), then you can view the object files in release, debug, non-optimized debug, and so on. By default, C/C++ compilers do not change the size of structures until the programmer himself specifies the packing or alignment attribute (keyword).

## Changed structs:

- jpeg_decompress_struct 632 -> 608 **(saved 24 bytes)**
- jpeg_compress_struct 520 -> 504 **(saved 1 CPU cacheline!!! and saved 16 bytes)**
- _tga_source_struct 136 -> 128 **(saved 1 CPU cacheline!!! and saved 8 bytes)**
- bmp_dest_struct 120 -> 112 (saved 8 bytes)
- jquant2/my_cquantizer 96 -> 88 (saved 8 bytes)
- jquant1/my_cquantizer 160 -> 152 (saved 8 bytes)

## Example pahole log for struct jpeg_compress_struct

- Comment `/* XXX {n} bytes hole, try to pack */` shows where optimization is possible by rearranging the order of fields structures and classes

```c
$ ~/GIT/dwarves/build/pahole -S --class_name=jpeg_compress_struct -j8 */*/*.o
struct jpeg_compress_struct {
        struct jpeg_error_mgr *    err;                  /*     0     8 */
        struct jpeg_memory_mgr *   mem;                  /*     8     8 */
        struct jpeg_progress_mgr * progress;             /*    16     8 */
        void *                     client_data;          /*    24     8 */
        boolean                    is_decompressor;      /*    32     4 */
        int                        global_state;         /*    36     4 */
        struct jpeg_destination_mgr * dest;              /*    40     8 */
        JDIMENSION                 image_width;          /*    48     4 */
        JDIMENSION                 image_height;         /*    52     4 */
        int                        input_components;     /*    56     4 */
        J_COLOR_SPACE              in_color_space;       /*    60     4 */
        /* --- cacheline 1 boundary (64 bytes) --- */
        double                     input_gamma;          /*    64     8 */
        int                        data_precision;       /*    72     4 */
        int                        num_components;       /*    76     4 */
        J_COLOR_SPACE              jpeg_color_space;     /*    80     4 */

        /* XXX 4 bytes hole, try to pack */

        jpeg_component_info *      comp_info;            /*    88     8 */
        JQUANT_TBL *               quant_tbl_ptrs[4];    /*    96    32 */
        /* --- cacheline 2 boundary (128 bytes) --- */
        JHUFF_TBL *                dc_huff_tbl_ptrs[4];  /*   128    32 */
        JHUFF_TBL *                ac_huff_tbl_ptrs[4];  /*   160    32 */
        /* --- cacheline 3 boundary (192 bytes) --- */
        UINT8                      arith_dc_L[16];       /*   192    16 */
        UINT8                      arith_dc_U[16];       /*   208    16 */
        UINT8                      arith_ac_K[16];       /*   224    16 */
        int                        num_scans;            /*   240     4 */

        /* XXX 4 bytes hole, try to pack */

        const jpeg_scan_info  *    scan_info;            /*   248     8 */
        /* --- cacheline 4 boundary (256 bytes) --- */
        boolean                    raw_data_in;          /*   256     4 */
        boolean                    arith_code;           /*   260     4 */
        boolean                    optimize_coding;      /*   264     4 */
        boolean                    CCIR601_sampling;     /*   268     4 */
        int                        smoothing_factor;     /*   272     4 */
        J_DCT_METHOD               dct_method;           /*   276     4 */
        unsigned int               restart_interval;     /*   280     4 */
        int                        restart_in_rows;      /*   284     4 */
        boolean                    write_JFIF_header;    /*   288     4 */
        UINT8                      JFIF_major_version;   /*   292     1 */
        UINT8                      JFIF_minor_version;   /*   293     1 */
        UINT8                      density_unit;         /*   294     1 */

        /* XXX 1 byte hole, try to pack */

        UINT16                     X_density;            /*   296     2 */
        UINT16                     Y_density;            /*   298     2 */
        boolean                    write_Adobe_marker;   /*   300     4 */
        JDIMENSION                 next_scanline;        /*   304     4 */
        boolean                    progressive_mode;     /*   308     4 */
        int                        max_h_samp_factor;    /*   312     4 */
        int                        max_v_samp_factor;    /*   316     4 */
        /* --- cacheline 5 boundary (320 bytes) --- */
        JDIMENSION                 total_iMCU_rows;      /*   320     4 */
        int                        comps_in_scan;        /*   324     4 */
        jpeg_component_info *      cur_comp_info[4];     /*   328    32 */
        JDIMENSION                 MCUs_per_row;         /*   360     4 */
        JDIMENSION                 MCU_rows_in_scan;     /*   364     4 */
        int                        blocks_in_MCU;        /*   368     4 */
        int                        MCU_membership[10];   /*   372    40 */
        /* --- cacheline 6 boundary (384 bytes) was 28 bytes ago --- */
        int                        Ss;                   /*   412     4 */
        int                        Se;                   /*   416     4 */
        int                        Ah;                   /*   420     4 */
        int                        Al;                   /*   424     4 */

        /* XXX 4 bytes hole, try to pack */

        struct jpeg_comp_master *  master;               /*   432     8 */
        struct jpeg_c_main_controller * main;            /*   440     8 */
        /* --- cacheline 7 boundary (448 bytes) --- */
        struct jpeg_c_prep_controller * prep;            /*   448     8 */
        struct jpeg_c_coef_controller * coef;            /*   456     8 */
        struct jpeg_marker_writer * marker;              /*   464     8 */
        struct jpeg_color_converter * cconvert;          /*   472     8 */
        struct jpeg_downsampler *  downsample;           /*   480     8 */
        struct jpeg_forward_dct *  fdct;                 /*   488     8 */
        struct jpeg_entropy_encoder * entropy;           /*   496     8 */
        jpeg_scan_info *           script_space;         /*   504     8 */
        /* --- cacheline 8 boundary (512 bytes) --- */
        int                        script_space_size;    /*   512     4 */

        /* size: 520, cachelines: 9, members: 65 */
        /* sum members: 503, holes: 4, sum holes: 13 */
        /* padding: 4 */
        /* last cacheline: 8 bytes */
};
```

## References:

https://hpc.rz.rptu.de/Tutorials/AVX/alignment.shtml

https://wr.informatik.uni-hamburg.de/_media/teaching/wintersemester_2013_2014/epc-14-haase-svenhendrik-alignmentinc-presentation.pdf

https://en.wikipedia.org/wiki/Data_structure_alignment

https://stackoverflow.com/a/20882083

https://zijishi.xyz/post/optimization-technique/learning-to-use-data-alignment/