### PR TITLE
Fix allocator mismatch: use tj3Free() for buffers allocated with tj3Alloc()

### DIFF
--- a/fuzz/compress_yuv.cc
+++ b/fuzz/compress_yuv.cc
@@ -105,8 +105,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         sum += dstBuf[i];
     }
 
-    free(dstBuf);
+    /* dstBuf was allocated with tj3Alloc(), so release it with tj3Free(). */
+    tj3Free(dstBuf);
     dstBuf = NULL;
+
     free(yuvBuf);
     yuvBuf = NULL;
     tj3Free(srcBuf);
@@ -119,7 +121,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   }
 
 bailout:
-  free(dstBuf);
+  /* Free TurboJPEG-managed allocations with tj3Free(), not free(). */
+  tj3Free(dstBuf);
   free(yuvBuf);
   tj3Free(srcBuf);
   if (fd >= 0) {

--- a/fuzz/decompress.cc
+++ b/fuzz/decompress.cc
@@ -126,7 +126,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         goto bailout;
     }
 
-    free(dstBuf);
+    /* Free TurboJPEG-managed allocations with tj3Free(), not free(). */
+    tj3Free(dstBuf);
     dstBuf = NULL;
 
     /* Prevent the code above from being optimized out.  This test should never
@@ -136,7 +137,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   }
 
 bailout:
-  free(dstBuf);
+  /* Free TurboJPEG-managed allocations with tj3Free(), not free(). */
+  tj3Free(dstBuf);
   tj3Destroy(handle);
   return 0;
 }

--- a/fuzz/decompress_yuv.cc
+++ b/fuzz/decompress_yuv.cc
@@ -99,9 +99,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     } else
       goto bailout;
 
-    free(dstBuf);
+    /* Free TurboJPEG-managed allocations with tj3Free(), not free(). */
+    tj3Free(dstBuf);
     dstBuf = NULL;
-    free(yuvBuf);
+    tj3Free(yuvBuf);
     yuvBuf = NULL;
 
     /* Prevent the code above from being optimized out.  This test should never
@@ -111,8 +112,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   }
 
 bailout:
-  free(dstBuf);
-  free(yuvBuf);
+  /* Free TurboJPEG-managed allocations with tj3Free(), not free(). */
+  tj3Free(dstBuf);
+  tj3Free(yuvBuf);
   tj3Destroy(handle);
   return 0;
 }


### PR DESCRIPTION
## Summary

This pull request fixes an allocator mismatch in several TurboJPEG fuzz targets.
Buffers allocated using `tj3Alloc()` were previously deallocated using `free()`, which is unsafe unless `tj3Alloc()` is guaranteed to be `malloc()`-compatible.

## Details

The following fuzz targets allocated output buffers via `tj3Alloc()` but released them using `free()`:

* `fuzz/decompress.cc`
* `fuzz/decompress_yuv.cc`
* `fuzz/compress_yuv.cc`

If `tj3Alloc()` uses a custom or wrapped allocator (for example, for alignment), freeing such memory with `free()` results in undefined behavior and can lead to heap corruption.

## Fix

All buffers allocated with `tj3Alloc()` are now consistently released using `tj3Free()` on both normal and error/bailout paths.

This restores correct allocator pairing and makes the code safe regardless of the internal implementation of `tj3Alloc()`.

## Impact

* Eliminates potential heap corruption in fuzz-exposed code paths
* Improves memory-safety and correctness
* Makes fuzz targets safe to reuse as reference code

## Testing

* Fuzz targets build successfully
* Verified under ASan/UBSan with no allocator-mismatch warnings

No functional behavior changes outside of memory management.
