### PR TITLE
Fix CMake error when targetting Windows with empty CMAKE_INSTALL_PREFIX

### DIFF
--- a/cmakescripts/BuildPackages.cmake
+++ b/cmakescripts/BuildPackages.cmake
@@ -105,7 +105,7 @@ else()
   set(INST_DEFS ${INST_DEFS} "-DBUILDDIR=")
 endif()
 
-string(REGEX REPLACE "/" "\\\\" INST_DIR ${CMAKE_INSTALL_PREFIX})
+string(REGEX REPLACE "/" "\\\\" INST_DIR "${CMAKE_INSTALL_PREFIX}")
 
 configure_file(release/installer.nsi.in installer.nsi @ONLY)
 # TODO: It would be nice to eventually switch to CPack and eliminate this mess,


### PR DESCRIPTION
Missing quotes caused the following error:
```
CMake Error at cmakescripts/BuildPackages.cmake:108 (string):
  string sub-command REGEX, mode REPLACE needs at least 6 arguments total to
  command.
```

Ran into this when cross compiling from Linux to Windows. I'm setting CMAKE_STAGING_PREFIX but leaving CMAKE_INSTALL_PREFIX empty. Unsure if this is the correct approach, but setting CMAKE_INSTALL_PREFIX to a Windows path runs into other errors (related to configure_package_config_file).