### PR TITLE
turbojpeg-mp.c: fix discards const from pointer target

### DIFF
--- a/src/turbojpeg-mp.c
+++ b/src/turbojpeg-mp.c
@@ -499,7 +499,7 @@ DLLEXPORT int GET_NAME(tj3SaveImage, BITS_IN_JSAMPLE)
   j_decompress_ptr dinfo = NULL;
   djpeg_dest_ptr dst;
   FILE *file = NULL;
-  char *ptr = NULL;
+  const char *ptr = NULL;
   boolean invert;
 
   GET_TJINSTANCE(handle, -1)


### PR DESCRIPTION
**Complete description of the bug fix or feature that this pull request implements**

- fixes #868 

Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html

**Checklist before submitting the pull request, to maximize the chances that the pull request will be accepted**

- [X] Read CONTRIBUTING.md, a link to which appears under "Helpful resources" below.  That document discusses general guidelines for contributing to libjpeg-turbo, as well as the types of contributions that will not be accepted or are unlikely to be accepted.
- [X] Search the existing issues and pull requests (both open and closed) to ensure that a similar request has not already been submitted and rejected.
- [X] Discuss the proposed bug fix or feature in a GitHub issue, through direct e-mail with the project maintainer, or on the libjpeg-turbo-devel mailing list.
