### PR TITLE
Implement -roll option in jpegtran (#870)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,7 +32,16 @@ image.  The new default behavior is useful, in combination with the `-drop`
 option, for reversibly combining multiple JPEG source images into a single
 composite JPEG image.
 
-5. The MIPS DSPr2 SIMD extensions have been removed.  Justifications:
+5. Added a new `-roll +X+Y` option to jpegtran that performs a lossless roll
+(shift with wrap-around) transformation.  The image is shifted right by X
+and down by Y pixels, with pixels wrapping around the edges.  X and Y may be
+negative; a negative X shifts the image left, and a negative Y shifts the
+image up.  For a perfect transformation, the absolute values of X and Y
+should be multiples of the iMCU width and height, respectively.  When
+`-perfect` is specified, the transformation will fail if the offsets are not
+MCU-aligned.
+
+6. The MIPS DSPr2 SIMD extensions have been removed.  Justifications:
 
      - MIPS Technologies deprecated the MIPS architecture in favor of RISC-V in
 2021.
@@ -54,7 +63,7 @@ could benefit from the DSPr2 SIMD extensions to near zero.  The DSPr2 SIMD
 extensions will continue to be maintained in the 3.1.x branch on a break/fix
 basis.
 
-6. Added RISC-V Vector (RVV) SIMD implementations of the colorspace conversion,
+7. Added RISC-V Vector (RVV) SIMD implementations of the colorspace conversion,
 chroma downsampling and upsampling, integer quantization and sample conversion,
 and integer DCT/IDCT algorithms.  When using the accurate integer DCT/IDCT
 algorithms, RGB-to-baseline JPEG compression is approximately 131-221% (avg.

--- a/doc/jpegtran.1
+++ b/doc/jpegtran.1
@@ -97,6 +97,19 @@ Rotate image 180 degrees.
 .B \-rotate 270
 Rotate image 270 degrees clockwise (or 90 ccw).
 .TP
+.B \-roll +X+Y
+Roll (shift with wrap-around) the image horizontally by X pixels and vertically
+by Y pixels.  X and Y may be negative: a negative X shifts the image left,
+and a negative Y shifts the image up.  For a perfect transformation, the
+absolute values of X and Y should be multiples of the iMCU width and height,
+respectively.  If the offsets are not multiples of the iMCU dimensions, the
+transformation will not be perfect unless
+.B \-trim
+is also specified.  When used with
+.BR \-perfect ,
+the transformation will fail if the absolute value of X or Y is not a multiple
+of the corresponding iMCU dimension.
+.TP
 .B \-transpose
 Transpose image (across UL-to-LR axis).
 .TP

--- a/src/jpegtran.c
+++ b/src/jpegtran.c
@@ -5,6 +5,7 @@
  * Copyright (C) 1995-2019, Thomas G. Lane, Guido Vollbeding.
  * libjpeg-turbo Modifications:
  * Copyright (C) 2010, 2014, 2017, 2019-2022, 2024, D. R. Commander.
+ * Copyright (C) 2026, Ricardo M. Ferreira.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -73,6 +74,7 @@ usage(void)
   fprintf(stderr, "  -flip [horizontal|vertical]  Mirror image (left-right or top-bottom)\n");
   fprintf(stderr, "  -grayscale     Reduce to grayscale (omit color data)\n");
   fprintf(stderr, "  -perfect       Fail if there is non-transformable edge blocks\n");
+  fprintf(stderr, "  -roll +X+Y     Roll (shift with wrap) image horizontally and vertically\n");
   fprintf(stderr, "  -rotate [90|180|270]         Rotate image (degrees clockwise)\n");
 #endif
 #if TRANSFORMS_SUPPORTED
@@ -350,6 +352,18 @@ parse_switches(j_compress_ptr cinfo, int argc, char **argv,
       } else {
         cinfo->restart_in_rows = (int)lval;
         /* restart_interval will be computed during startup */
+      }
+    } else if (keymatch(arg, "roll", 4)) {
+      /* Roll (shift with wrap-around) by offset. */
+      if (++argn >= argc)       /* advance to next argument */
+        usage();
+      select_transform(JXFORM_ROLL);
+      if (!jtransform_parse_crop_spec(&transformoption, argv[argn]) ||
+          transformoption.crop_width_set != JCROP_UNSET ||
+          transformoption.crop_height_set != JCROP_UNSET) {
+        fprintf(stderr, "%s: invalid roll specification '%s'\n",
+                progname, argv[argn]);
+        exit(EXIT_FAILURE);
       }
 
     } else if (keymatch(arg, "rotate", 2)) {

--- a/src/transupp.h
+++ b/src/transupp.h
@@ -5,6 +5,7 @@
  * Copyright (C) 1997-2019, Thomas G. Lane, Guido Vollbeding.
  * libjpeg-turbo Modifications:
  * Copyright (C) 2017, 2021, D. R. Commander.
+ * Copyright (C) 2026, Ricardo M. Ferreira.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -105,7 +106,8 @@ typedef enum {
   JXFORM_ROT_180,         /* 180-degree rotation */
   JXFORM_ROT_270,         /* 270-degree clockwise (or 90 ccw) */
   JXFORM_WIPE,            /* wipe */
-  JXFORM_DROP             /* drop */
+  JXFORM_DROP,            /* drop */
+  JXFORM_ROLL             /* roll (shift with wrap-around) */
 } JXFORM_CODE;
 
 /*

--- a/test/tjtrantest.in
+++ b/test/tjtrantest.in
@@ -143,21 +143,30 @@ for precision in 8 12; do
 													continue
 												fi
 											fi
-											runme $TJTRAN $ariarg $copyarg $croparg $xformarg \
-												$grayarg $optarg $progarg $restartarg $trimarg \
-												$OUTDIR/${basename}-$subsamp.jpg \
-												$OUTDIR/${basename}-tjtran.jpg
-											runme $EXEDIR/jpegtran $ariarg $copyarg $croparg \
-												$xformarg $grayarg $optarg $progarg $restartarg \
-												$trimarg -outf $OUTDIR/${basename}-jpegtran.jpg \
-												$OUTDIR/${basename}-$subsamp.jpg
-											$EXEDIR/test/md5sum $OUTDIR/${basename}-tjtran.jpg \
-												$OUTDIR/${basename}-jpegtran.jpg |
-												sed "s@$OUTDIR@\$OUTDIR@g"
-											cmp $OUTDIR/${basename}-tjtran.jpg \
-												$OUTDIR/${basename}-jpegtran.jpg
-											rm $OUTDIR/${basename}-tjtran.jpg \
-												$OUTDIR/${basename}-jpegtran.jpg
+											# Skip tjtran for -roll (not implemented in TurboJPEG API)
+											if [[ "$xformarg" =~ ^"-roll" ]]; then
+												runme $EXEDIR/jpegtran $ariarg $copyarg $croparg \
+													$xformarg $grayarg $optarg $progarg $restartarg \
+													$trimarg -outf $OUTDIR/${basename}-jpegtran.jpg \
+													$OUTDIR/${basename}-$subsamp.jpg
+												rm $OUTDIR/${basename}-jpegtran.jpg
+											else
+												runme $TJTRAN $ariarg $copyarg $croparg $xformarg \
+													$grayarg $optarg $progarg $restartarg $trimarg \
+													$OUTDIR/${basename}-$subsamp.jpg \
+													$OUTDIR/${basename}-tjtran.jpg
+												runme $EXEDIR/jpegtran $ariarg $copyarg $croparg \
+													$xformarg $grayarg $optarg $progarg $restartarg \
+													$trimarg -outf $OUTDIR/${basename}-jpegtran.jpg \
+													$OUTDIR/${basename}-$subsamp.jpg
+												$EXEDIR/test/md5sum $OUTDIR/${basename}-tjtran.jpg \
+													$OUTDIR/${basename}-jpegtran.jpg |
+													sed "s@$OUTDIR@\$OUTDIR@g"
+												cmp $OUTDIR/${basename}-tjtran.jpg \
+													$OUTDIR/${basename}-jpegtran.jpg
+												rm $OUTDIR/${basename}-tjtran.jpg \
+													$OUTDIR/${basename}-jpegtran.jpg
+											fi
 											echo
 										done
 									done


### PR DESCRIPTION
Add in `jpegtran` support for the `-roll` transformation. It shifts with wrap-around the image horizontally by X pixels and vertically by Y pixels. For a perfect transformation, the absolute values of X and Y should be multiples of the iMCU width and height. When  used  with `-perfect`, the transformation will fail if the absolute value of X or Y is not a multiple of the corresponding iMCU dimension.

Closes #870